### PR TITLE
[PR3] Add GitHub Actions Docker CI (Closes #74, Related to #81)

### DIFF
--- a/.github/workflows/ros2_humble_ci.yml
+++ b/.github/workflows/ros2_humble_ci.yml
@@ -8,18 +8,13 @@ on:
   workflow_dispatch:        
 
 jobs:
-  
-
-
   docker-publish:
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/ros2_humble_ci.yml
+++ b/.github/workflows/ros2_humble_ci.yml
@@ -8,13 +8,18 @@ on:
   workflow_dispatch:        
 
 jobs:
+  
+
+
   docker-publish:
     runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/ros2_humble_ci.yml
+++ b/.github/workflows/ros2_humble_ci.yml
@@ -8,13 +8,39 @@ on:
   workflow_dispatch:        
 
 jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    container:
+      image: ros:humble
+      options: --user root
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Install colcon and dependencies
+        run: |
+          apt update
+          apt install -y python3-colcon-common-extensions python3-pip git
+          apt install -y build-essential
+          apt install -y build-essential libopencv-dev
+          rosdep update
+          rosdep install --from-paths . --ignore-src -r -y
+
+      - name: Build the workspace
+        run: |
+          bash -c "source /opt/ros/humble/setup.bash && colcon build --event-handlers console_direct+"
+
+
+
   docker-publish:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
### Summary

This PR introduces the first GitHub Actions-based Docker CI pipeline to the `space_station_os` monorepo.  
The setup enables automatic build and deployment of Docker images to GitHub Container Registry (GHCR) upon every push or PR to `main`.

This CI enhancement improves reproducibility, accelerates onboarding, and reduces host-environment dependency issues.

---

### Changes

- Created `.github/workflows/ros2_humble_ci.yml`
  - CI triggers on `push`, `pull_request`, and `workflow_dispatch`
  - Builds ROS 2 Humble-based container image
  - Pushes to `ghcr.io/space-station-os/space_station_os:latest`
- Modified Dockerfile accordingly
- Verified build passes from GH Actions
- Confirmed that the image runs ROS 2 CLI tools as intended
- Documented image usage in `README.md`

---

### Limitations

- GUI-based features (e.g. `image_view`, OpenCV windows) are currently **not supported** inside the container.  
  → See tracking issue: [#81](https://github.com/space-station-os/space_station_os/issues/81)

---

### Related Discussions

- Initial reasoning and pros/cons: [Issue #74](https://github.com/space-station-os/space_station_os/issues/74)
- GUI limitations and user-facing concerns: [Issue #81](https://github.com/space-station-os/space_station_os/issues/81)

---

### Closing

Closes #74  
Related to #81
