### PR TITLE
Fix: Add urdf_parser dependency to support thruster_matrix (v0.8.4-dev)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt update && apt install -y \
     ros-humble-joint-state-publisher-gui \
     ros-humble-actuator-msgs \
     ros-humble-rosbridge-server \
+    ros-humble-urdf-parser-plugin \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependency: CasADi

--- a/space_station_gnc/CMakeLists.txt
+++ b/space_station_gnc/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rosidl_default_runtime REQUIRED)
 find_package(action_msgs REQUIRED)
+find_package(urdf REQUIRED)
 
 # Generate interfaces
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -59,7 +60,7 @@ ament_target_dependencies(control_torque rclcpp std_msgs tf2 tf2_ros nav_msgs tf
 rosidl_get_typesupport_target(cpp_typesupport_target
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 target_link_libraries(control_torque ${cpp_typesupport_target})
-target_link_libraries(physics_motion ${cpp_typesupport_target})
+target_link_libraries(physics_motion ${cpp_typesupport_target} urdf::urdf)
 
 # Link OpenCV libraries
 target_link_libraries(demo1a_nauka_incident_estimate ${OpenCV_LIBRARIES} ${SDL2_LIBRARIES})

--- a/space_station_gnc/package.xml
+++ b/space_station_gnc/package.xml
@@ -4,22 +4,24 @@
   <name>space_station_gnc</name>
   <version>0.0.0</version>
   <description>TODO: Package description</description>
-  <maintainer email="yuyuqq@todo.todo">yuyuqq</maintainer>
+  <maintainer email="yuyuqq@gmail.com">yuyuqq</maintainer>
   <license>Apache-2.0</license>
 
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>urdf</build_depend>
   <!--buildtool_depend>ament_python</buildtool_depend-->
   
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
-
+  <exec_depend>urdf</exec_depend>
   
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <depend> builtin_interfaces</depend>
+  
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
This PR adds the missing `urdf_parser` dependency to the `space_station_gnc` package to support ThrusterMatrix functionality.

Changes:
- Added `urdf` to `package.xml`
- Linked `urdf::urdf` in `CMakeLists.txt`
- Installed `ros-humble-urdf-parser-plugin` in Dockerfile

This PR correctly targets the `v0.8.4-dev` branch, fixing the earlier mistake in PR #104 which was merged into `main`.

This setup enables proper CI testing and review for PR #88.
