### PR TITLE
[modify]add orbit_dynamics install in CMakeLists.

### DIFF
--- a/space_station_gnc/CMakeLists.txt
+++ b/space_station_gnc/CMakeLists.txt
@@ -110,6 +110,7 @@ install(TARGETS
   torque_collector
   physics_motion
   physics_sensor
+  orbit_dynamics
   sense_estimate
   control_torque
   thruster_matrix


### PR DESCRIPTION
orbit_dynamics install was not in CMakeList.txt, so I added a line.
#57 