### PR TITLE
[v0.8.6][Integration] GNC: robust logic for automated thruster triggering & actuator switching (#158)

### DIFF
--- a/.github/workflows/docker-img-ci.yml
+++ b/.github/workflows/docker-img-ci.yml
@@ -25,6 +25,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+
+      - name: Add OSRF apt repo (Gazebo)
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y wget lsb-release gnupg
+          sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list'
+          wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+          sudo apt-get update -y
+          # meta package for Gazebo Harmonic
+          sudo apt-get install -y gz-harmonic
+
+      - name: Install system deps (fallback)
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libeigen3-dev
+
       - name: Sanitize tag name
         id: vars
         run: |

--- a/space_station_gnc/CMakeLists.txt
+++ b/space_station_gnc/CMakeLists.txt
@@ -109,6 +109,8 @@ ament_export_include_directories(
   $<INSTALL_INTERFACE:include>
 )
 
+ament_export_dependencies(Eigen3)
+
 target_link_libraries(control_torque ${cpp_typesupport_target})
 target_link_libraries(physics_motion ${cpp_typesupport_target})
 target_link_libraries(orbit_dynamics ${cpp_typesupport_target})

--- a/space_station_gnc/CMakeLists.txt
+++ b/space_station_gnc/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(action_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(urdf REQUIRED)        # provides target urdf::urdf
 find_package(yaml-cpp REQUIRED)    # YAML tables support
+find_package(ament_index_cpp REQUIRED)
 
 # Generate interfaces
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -67,7 +68,7 @@ ament_target_dependencies(physics_motion rclcpp std_msgs tf2 tf2_ros tf2_geometr
 ament_target_dependencies(orbit_dynamics rclcpp std_msgs nav_msgs tf2 tf2_ros tf2_geometry_msgs visualization_msgs)
 ament_target_dependencies(physics_sensor rclcpp std_msgs tf2 tf2_ros tf2_geometry_msgs visualization_msgs)
 ament_target_dependencies(sense_estimate rclcpp std_msgs tf2 tf2_ros nav_msgs tf2_geometry_msgs visualization_msgs)
-ament_target_dependencies(control_torque rclcpp std_msgs tf2 tf2_ros nav_msgs tf2_geometry_msgs visualization_msgs)
+ament_target_dependencies(control_torque rclcpp std_msgs tf2 tf2_ros nav_msgs tf2_geometry_msgs visualization_msgs ament_index_cpp)
 ament_target_dependencies(thruster_matrix rclcpp)
 
 

--- a/space_station_gnc/config/eagle_thruster_properties.yaml
+++ b/space_station_gnc/config/eagle_thruster_properties.yaml
@@ -1,0 +1,17 @@
+# Per-thruster physical properties (limits / performance).
+# Keys MUST match URDF child link names.
+thrusters:
+  thruster_xp1: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_xp2: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_xn1: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_xn2: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+
+  thruster_yp1: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_yp2: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_yn1: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_yn2: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+
+  thruster_zp1: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_zp2: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_zn1: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }
+  thruster_zn2: { max_force: 100.0, isp: 60.0, efficiency: 0.90 }

--- a/space_station_gnc/config/eagle_thruster_table.yaml
+++ b/space_station_gnc/config/eagle_thruster_table.yaml
@@ -1,0 +1,50 @@
+# Thruster table with explicit force/torque directions.
+# Conventions:
+#   - Body axes: +X forward (or starboard), +Y left, +Z up  
+#   - Force  = [Fx, Fy, Fz]
+#   - Torque = [Tx, Ty, Tz] = [Roll, Pitch, Yaw]
+#
+
+tables:
+  sixdof_phys:
+    # ---- X nozzles ----
+    thruster_xp1:
+      force:  [ +9.0,  0.0,  0.0 ]
+      torque: [  0.0,  0.0, +1.0 ]   # +Yaw
+    thruster_xp2:
+      force:  [ +9.0,  0.0,  0.0 ]
+      torque: [  0.0,  0.0, -1.0 ]   # -Yaw
+    thruster_xn1:
+      force:  [ -9.0,  0.0,  0.0 ]
+      torque: [  0.0,  0.0, -1.0 ]   # -Yaw
+    thruster_xn2:
+      force:  [ -9.0,  0.0,  0.0 ]
+      torque: [  0.0,  0.0, +1.0 ]   # +Yaw
+
+    # ---- Y nozzles  ----
+    thruster_yp1:
+      force:  [  0.0, +9.0,  0.0 ]
+      torque: [  0.0, +1.0,  0.0 ]   # +Pitch
+    thruster_yp2:
+      force:  [  0.0, +9.0,  0.0 ]
+      torque: [  0.0, -1.0,  0.0 ]   # -Pitch
+    thruster_yn1:
+      force:  [  0.0, -9.0,  0.0 ]
+      torque: [  0.0, -1.0,  0.0 ]   # -Pitch
+    thruster_yn2:
+      force:  [  0.0, -9.0,  0.0 ]
+      torque: [  0.0, +1.0,  0.0 ]   # +Pitch
+
+    # ---- Z nozzles  ----
+    thruster_zp1:
+      force:  [  0.0,  0.0, +9.0 ]
+      torque: [ +1.0,  0.0,  0.0 ]   # +Roll
+    thruster_zp2:
+      force:  [  0.0,  0.0, +9.0 ]
+      torque: [ -1.0,  0.0,  0.0 ]   # -Roll
+    thruster_zn1:
+      force:  [  0.0,  0.0, -9.0 ]
+      torque: [ -1.0,  0.0,  0.0 ]   # -Roll
+    thruster_zn2:
+      force:  [  0.0,  0.0, -9.0 ]
+      torque: [ +1.0,  0.0,  0.0 ]   # +Roll

--- a/space_station_gnc/config/ros_config.yaml
+++ b/space_station_gnc/config/ros_config.yaml
@@ -13,9 +13,9 @@ physics_motion:
   ros__parameters:
     dynamics:
       J:
-        xx: 280e6
-        yy: 140e6
-        zz: 420e6
+        xx: 4.2e6
+        yy: 4.2e6
+        zz: 6.7e6
       mu: 3.986e14
       r_orbit:  7e6
 

--- a/space_station_gnc/include/space_station_gnc/thruster_matrix.hpp
+++ b/space_station_gnc/include/space_station_gnc/thruster_matrix.hpp
@@ -15,153 +15,169 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <urdf_parser/urdf_parser.h>
-#include <urdf_model/model.h>
-#include <urdf_model/link.h>
-#include <yaml-cpp/yaml.h>
 #include <Eigen/StdVector>
+#include <urdf_model/link.h>
+#include <urdf_model/model.h>
+#include <urdf_parser/urdf_parser.h>
+#include <yaml-cpp/yaml.h>
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
-#include <limits>
-#include <vector>
 #include <utility>
-
-
+#include <vector>
 
 /// @brief Utilities for extracting thruster-related information from URDF.
-class URDFUtils
-{
+class URDFUtils {
 public:
   URDFUtils();
 
-  bool isThruster(const std::string & name) const;
- 
+  bool isThruster(const std::string &name) const;
+
   /// @brief Count all thrusters (based on child link name rule)
-  std::size_t getNumAct(const urdf::ModelInterfaceSharedPtr & model) const;
+  std::size_t getNumAct(const urdf::ModelInterfaceSharedPtr &model) const;
 
   /// @brief Thruster positions in the current base frame (3xN)
-  Eigen::Matrix<double, 3,
-    Eigen::Dynamic> getThrPos(const urdf::ModelInterfaceSharedPtr & model) const;
+  Eigen::Matrix<double, 3, Eigen::Dynamic>
+  getThrPos(const urdf::ModelInterfaceSharedPtr &model) const;
 
   /// @brief Thruster directions in the current base frame (3xN), normalized
-  Eigen::Matrix<double, 3,
-    Eigen::Dynamic> getThrOrient(const urdf::ModelInterfaceSharedPtr & model) const;
+  Eigen::Matrix<double, 3, Eigen::Dynamic>
+  getThrOrient(const urdf::ModelInterfaceSharedPtr &model) const;
 
-
-  void printLinks(const std::map<std::string, std::shared_ptr<urdf::Link>> & links) const;
+  void printLinks(
+      const std::map<std::string, std::shared_ptr<urdf::Link>> &links) const;
 };
 
-/// @brief Thruster unified configuration after merging URDF, properties.yaml, and table.yaml
+/// @brief Thruster unified configuration after merging URDF, properties.yaml,
+/// and table.yaml
 
-struct ThrusterConfig
-{
-    std::string name;
-    Eigen::Vector3d position;   ///< URDF: position in body frame
-    Eigen::Vector3d direction;  ///< URDF: direction vector
-    double max_force = 100.0;     ///< properties.yaml: [N]
-    double isp = 0.0;           ///< properties.yaml: [s]
-    double efficiency = 1.0;    ///< properties.yaml: [-]
-    bool active = false;        ///< table.yaml: mode-dependent activation
+struct ThrusterConfig {
+  std::string name;
+  Eigen::Vector3d position;  ///< URDF: position in body frame
+  Eigen::Vector3d direction; ///< URDF: direction vector
+  double max_force = 100.0;  ///< properties.yaml: [N]
+  double isp = 0.0;          ///< properties.yaml: [s]
+  double efficiency = 1.0;   ///< properties.yaml: [-]
+  bool active = false;       ///< table.yaml: mode-dependent activation
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 // Forward declarations
-using ThrusterConfigVec = std::vector<
-    ThrusterConfig,
-    Eigen::aligned_allocator<ThrusterConfig>>;
+using ThrusterConfigVec =
+    std::vector<ThrusterConfig, Eigen::aligned_allocator<ThrusterConfig>>;
 
 using PinvMat = Eigen::Matrix<double, Eigen::Dynamic, 6>;
-using PinvCacheMap = std::map<
-    std::string,
-    PinvMat,
-    std::less<>,
-    Eigen::aligned_allocator<std::pair<const std::string, PinvMat>>>;
+using PinvCacheMap =
+    std::map<std::string, PinvMat, std::less<>,
+             Eigen::aligned_allocator<std::pair<const std::string, PinvMat>>>;
 
 using ThrusterCfgMap = std::map<
-    std::string,
-    ThrusterConfig,
-    std::less<>,
+    std::string, ThrusterConfig, std::less<>,
     Eigen::aligned_allocator<std::pair<const std::string, ThrusterConfig>>>;
 
-
 /**
- * @brief YAML-defined per-thruster weights selecting contribution to wrench axes.
- * torque_weight corresponds to [Tx, Ty, Tz], force_weight to [Fx, Fy, Fz].
+ * @brief YAML-defined per-thruster weights selecting contribution to wrench
+ * axes. torque_weight corresponds to [Tx, Ty, Tz], force_weight to [Fx, Fy,
+ * Fz].
  */
-struct ThrusterWeight
-{
-  Eigen::Vector3d torque_weight = Eigen::Vector3d::Zero();   // [Tx, Ty, Tz]
-  Eigen::Vector3d force_weight  = Eigen::Vector3d::Zero();   // [Fx, Fy, Fz]
+struct ThrusterWeight {
+  Eigen::Vector3d torque_weight = Eigen::Vector3d::Zero(); // [Tx, Ty, Tz]
+  Eigen::Vector3d force_weight = Eigen::Vector3d::Zero();  // [Fx, Fy, Fz]
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 using ThrusterTable = std::map<
-    std::string,
-    ThrusterWeight,
-    std::less<>,
-    Eigen::aligned_allocator<std::pair<const std::string, ThrusterWeight>>
->;
+    std::string, ThrusterWeight, std::less<>,
+    Eigen::aligned_allocator<std::pair<const std::string, ThrusterWeight>>>;
 
-//using ThrusterTable = std::map<std::string, ThrusterWeight>;     // map<thruster_name, weights> for one mode
-using ThrusterTableSet = std::map<std::string, ThrusterTable>;   // map<mode_name, table>
+// using ThrusterTable = std::map<std::string, ThrusterWeight>;     //
+// map<thruster_name, weights> for one mode
+using ThrusterTableSet =
+    std::map<std::string, ThrusterTable>; // map<mode_name, table>
 
 /**
  * @brief Allocation helper combining URDF geometry and optional YAML tables.
  *
  *  - Legacy path:
- *      bodyToThruster / thrusterToBody use URDF-only allocation (3xN torque mapping).
+ *      bodyToThruster / thrusterToBody use URDF-only allocation (3xN torque
+ * mapping).
  *  - Table path:
- *      loadProperties() + loadTable() + setThrusterTable() + generateCommandFromTable()
- *      enables mode-dependent selection/weighting over the same URDF geometry.
+ *      loadProperties() + loadTable() + setThrusterTable() +
+ * generateCommandFromTable() enables mode-dependent selection/weighting over
+ * the same URDF geometry.
  *
  * Design contracts decided in this project:
  *  - URDF: geometry only (pose/direction/existence).
  *  - properties.yaml: ratings (max_force, isp, efficiency) per thruster.
  *  - table.yaml: operational modes (per-mode active set and optional weights).
  *  - The single source of truth in runtime is the merged ThrusterConfig set.
-*/
-class ThrusterMatrix
-{
+ */
+class ThrusterMatrix {
 public:
-    ThrusterMatrix();
+  ThrusterMatrix();
 
-    /// @brief Initialize merged thruster configuration
-    ///        Combine URDF, properties.yaml, and table.yaml
-    void initialize(const std::string& urdf_xml);
+  /// @brief Initialize merged thruster configuration
+  ///        Combine URDF, properties.yaml, and table.yaml
+  void initialize(const std::string &urdf_xml);
 
-    /// @brief Load URDF-defined thruster geometry
-    void loadURDF(const urdf::ModelInterfaceSharedPtr& model);
+  /// @brief Load URDF-defined thruster geometry
+  void loadURDF(const urdf::ModelInterfaceSharedPtr &model);
 
-    /// @brief Load thruster properties from properties.yaml
-    void loadProperties(const std::string& yaml_file);
+  /// @brief Load thruster properties from properties.yaml
+  void loadProperties(const std::string &yaml_file);
 
-    /// @brief Load thruster table (modes) from table.yaml
-    void loadTable(const std::string& yaml_file);
+  /// @brief Load thruster table (modes) from table.yaml
+  void loadTable(const std::string &yaml_file);
 
-    /// @brief Select current mode (table) by name. Throws if not found.
-    void setThrusterTable(const std::string & table_name);
+  /// @brief Select current mode (table) by name. Throws if not found.
+  void setThrusterTable(const std::string &table_name);
 
-    /// @brief Change base link frame and rebuild geometry and caches.
-    /// @note Changing base invalidates geometry-dependent caches (e.g., pinv(W)).
-    void setBaseLink(const std::string & link_name);
+  /// @brief Change base link frame and rebuild geometry and caches.
+  /// @note Changing base invalidates geometry-dependent caches (e.g., pinv(W)).
+  void setBaseLink(const std::string &link_name);
 
-    /// @brief Current base link name (empty means URDF root)
-    std::string base_link_name_{};
+  /// @brief Current base link name (empty means URDF root)
+  std::string base_link_name_{};
 
+  /// @brief Get full thruster list (URDF-defined, regardless of active state)
+  std::vector<std::string> getAllThrusterNames() const;
 
-     /// @brief Get full thruster list (URDF-defined, regardless of active state)
-    std::vector<std::string> getAllThrusterNames() const;
+  /// @brief Get active thruster configs (for current mode)
+  // std::vector<ThrusterConfig> getActiveThrusters() const;
+  ThrusterConfigVec getActiveThrusters() const;
 
-    /// @brief Get active thruster configs (for current mode)
-    //std::vector<ThrusterConfig> getActiveThrusters() const;
-    ThrusterConfigVec getActiveThrusters() const;
+  std::size_t getNumThr();
 
-    std::size_t getNumThr();
+  bool isReady();
 
-    bool isReady();
+public:
+  void buildDirectMapForMode();
+
+  bool generateCommandDirectTorqueOnly(const Eigen::Vector3d &,
+                                       Eigen::VectorXd &, double) const;
+
+  bool generateCommandPreferDirect(const Eigen::VectorXd &desired_wrench,
+                                   Eigen::VectorXd &thruster_output,
+                                   double tol) const;
+
+  // --- Direct allocation (torque-only) support ------------------------
+  struct AxisPair {
+    int i1{-1};
+    int i2{-1};
+    double gain{0.0}; // |A(k,i1)| + |A(k,i2)|
+    bool valid() const { return (i1 >= 0 && i2 >= 0 && gain > 0.0); }
+  };
+
+  struct DirectMap {
+    AxisPair x_pos, x_neg;
+    AxisPair y_pos, y_neg;
+    AxisPair z_pos, z_neg;
+    bool ready{false};
+    void clear() { *this = DirectMap(); }
+  };
 
   // --------------------------------------------------------------------------
   // Table path (6xN W * u = desired_wrench)
@@ -174,80 +190,84 @@ public:
    * @param thruster_output output size N (resized inside)
    *
    * Policy (documented/decided):
-   *  - If W becomes all zeros for the active mode, throw (no actuators effectively).
-   *  - If the unconstrained solution contains negatives, apply one-shot active-set
-   *    refinement and clamp to non-negative (NNLS-lite). See .cpp for details.
+   *  - If W becomes all zeros for the active mode, throw (no actuators
+   * effectively).
+   *  - If the unconstrained solution contains negatives, apply one-shot
+   * active-set refinement and clamp to non-negative (NNLS-lite). See .cpp
+   * for details.
    */
-  void generateCommandFromTable(
-    const Eigen::VectorXd & desired_wrench,
-    Eigen::VectorXd & thruster_output) const;
+  void generateCommandFromTable(const Eigen::VectorXd &desired_wrench,
+                                Eigen::VectorXd &thruster_output) const;
 
-   // --------------------------------------------------------------------------
+  // --------------------------------------------------------------------------
   // Legacy path (URDF-only 3xN moment allocation)
   // --------------------------------------------------------------------------
 
-  /// @brief Map body moment (3x1) to thruster forces (Nx1) using inverse_allocation_mat.
-  void bodyToThruster(
-    const Eigen::Vector3d & body_wrench_moment,
-    Eigen::VectorXd & thruster_force) const;
+  /// @brief Map body moment (3x1) to thruster forces (Nx1) using
+  /// inverse_allocation_mat.
+  void bodyToThruster(const Eigen::Vector3d &body_wrench_moment,
+                      Eigen::VectorXd &thruster_force) const;
 
-  /// @brief Map thruster forces (Nx1) back to body moment (3x1) using allocation_mat.
-  void thrusterToBody(
-    const Eigen::VectorXd & recv_thruster_force,
-    Eigen::Vector3d & body_force) const;
+  /// @brief Map thruster forces (Nx1) back to body moment (3x1) using
+  /// allocation_mat.
+  void thrusterToBody(const Eigen::VectorXd &recv_thruster_force,
+                      Eigen::Vector3d &body_force) const;
 
   // --------------------------------------------------------------------------
   // Back-compat adapter (deprecated)
   // --------------------------------------------------------------------------
 
   /// @deprecated Use loadTable() instead. Kept for backward compatibility.
-  void loadThrusterTableFromYaml(const std::string & yaml_path);
-
-
+  void loadThrusterTableFromYaml(const std::string &yaml_path);
 
 private:
-/*
-  template<typename _Matrix_Type_1_, typename _Matrix_Type_2_>
-  _Matrix_Type_2_ pseudoInverse(
-    const _Matrix_Type_1_ & a,
-    double epsilon = std::numeric_limits<double>::epsilon()) const
-  {
-    Eigen::JacobiSVD<_Matrix_Type_1_> svd(a, Eigen::ComputeThinU | Eigen::ComputeThinV);
- 
-    const auto & s = svd.singularValues(); 
-    const double s_max = (s.size() > 0) ? s.maxCoeff() : 0.0; 
-    const double tol = epsilon * std::max(a.cols(), a.rows()) * s_max; 
-    //double tol = epsilon * std::max(a.cols(), a.rows()) * svd.singularValues().array().abs()(0); 
-    //Eigen::ArrayXd inv = svd.singularValues().array();
-    Eigen::ArrayXd inv = s.array();
+  /*
+    template<typename _Matrix_Type_1_, typename _Matrix_Type_2_>
+    _Matrix_Type_2_ pseudoInverse(
+      const _Matrix_Type_1_ & a,
+      double epsilon = std::numeric_limits<double>::epsilon()) const
+    {
+      Eigen::JacobiSVD<_Matrix_Type_1_> svd(a, Eigen::ComputeThinU |
+    Eigen::ComputeThinV);
 
-    for (int i = 0; i < inv.size(); ++i) {
-      inv(i) = (std::abs(inv(i)) > tol) ? 1.0 / inv(i) : 0.0;
+      const auto & s = svd.singularValues();
+      const double s_max = (s.size() > 0) ? s.maxCoeff() : 0.0;
+      const double tol = epsilon * std::max(a.cols(), a.rows()) * s_max;
+      //double tol = epsilon * std::max(a.cols(), a.rows()) *
+    svd.singularValues().array().abs()(0);
+      //Eigen::ArrayXd inv = svd.singularValues().array();
+      Eigen::ArrayXd inv = s.array();
+
+      for (int i = 0; i < inv.size(); ++i) {
+        inv(i) = (std::abs(inv(i)) > tol) ? 1.0 / inv(i) : 0.0;
+      }
+      return svd.matrixV() * inv.matrix().asDiagonal() *
+    svd.matrixU().adjoint();
     }
-    return svd.matrixV() * inv.matrix().asDiagonal() * svd.matrixU().adjoint();
-  }
-*/
-  template<typename MatA, typename MatPinv>
-  MatPinv pseudoInverse(const MatA& a,
-                      double epsilon = std::numeric_limits<double>::epsilon()) const
-  {
+  */
+  template <typename MatA, typename MatPinv>
+  MatPinv
+  pseudoInverse(const MatA &a,
+                double epsilon = std::numeric_limits<double>::epsilon()) const {
     using Index = Eigen::Index;
 
     // 0) Empty-guard
     if (a.rows() == 0 || a.cols() == 0) {
-      MatPinv z(a.cols(), a.rows());  // pinv has shape (cols x rows)
+      MatPinv z(a.cols(), a.rows()); // pinv has shape (cols x rows)
       z.setZero();
       return z;
     }
 
     // 1) SVD
-    Eigen::MatrixXd A = a;  // 
-    Eigen::JacobiSVD<Eigen::MatrixXd> svd(
-      A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::MatrixXd A = a; //
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeThinU |
+                                                 Eigen::ComputeThinV);
 
-    const auto& s = svd.singularValues();
+    const auto &s = svd.singularValues();
     const double smax = (s.size() ? s.array().abs().maxCoeff() : 0.0);
-    const double tol  = epsilon * static_cast<double>(std::max<Index>(a.rows(), a.cols())) * smax;
+    const double tol =
+        epsilon * static_cast<double>(std::max<Index>(a.rows(), a.cols())) *
+        smax;
 
     // 2) Build Σ^+ with tolerance
     Eigen::VectorXd sinv = s;
@@ -255,7 +275,8 @@ private:
       sinv(i) = (std::abs(s(i)) > tol) ? 1.0 / s(i) : 0.0;
     }
 
-    // 3) Use only the first r columns where r = rank (== s.size() with Thin SVD)
+    // 3) Use only the first r columns where r = rank (== s.size() with Thin
+    // SVD)
     const Index r = sinv.size();
     if (r == 0) {
       MatPinv z(a.cols(), a.rows());
@@ -271,24 +292,23 @@ private:
     return V_r * sinv.asDiagonal() * U_r.adjoint();
   }
 
-
   // URDF-based structure
   URDFUtils urdfUtils;
   urdf::ModelInterfaceSharedPtr model_urdf_;
- 
+
   // Stable column order for all matrices (derived from URDF traversal)
   std::vector<std::string> thruster_order_;
 
   // Geometry + merged attributes per thruster (key = thruster name)
-  //std::map<std::string, ThrusterConfig> urdf_thrusters_;
+  // std::map<std::string, ThrusterConfig> urdf_thrusters_;
   ThrusterCfgMap urdf_thrusters_;
 
   // Properties.yaml (ratings) by name
-  //std::map<std::string, ThrusterProperties> properties_map_;
+  // std::map<std::string, ThrusterProperties> properties_map_;
 
   // YAML-based table
   ThrusterTableSet table_map_;
-  //ThrusterTable current_table_;
+  // ThrusterTable current_table_;
   std::string current_mode_;
   bool table_loaded_ = false;
 
@@ -300,15 +320,20 @@ private:
   double rating_thruster_force{100.0};
   Eigen::Matrix<double, 3, Eigen::Dynamic> allocation_mat;
   Eigen::Matrix<double, Eigen::Dynamic, 3> inverse_allocation_mat;
-  //Eigen::Matrix<double, 3, 1> moment;
-
+  // Eigen::Matrix<double, 3, 1> moment;
 
   // Cache: mode_name -> pinv(W_mode) where W_mode is 6xN for that mode
-  //mutable std::map<std::string, Eigen::Matrix<double, Eigen::Dynamic, 6>> pinv_cache_;
+  // mutable std::map<std::string, Eigen::Matrix<double, Eigen::Dynamic, 6>>
+  // pinv_cache_;
   mutable PinvCacheMap pinv_cache_;
 
-  // Helper: build 6xN W for a given mode, following the same joint/column order.
-  Eigen::Matrix<double, 6, Eigen::Dynamic> buildWForMode(const std::string & mode_name) const;
+public:
+  // Helper: build 6xN W for a given mode, following the same joint/column
+  // order.
+  Eigen::Matrix<double, 6, Eigen::Dynamic>
+  buildWForMode(const std::string &mode_name) const;
+
+  DirectMap direct_map_;
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/space_station_gnc/launch/gnc_thruster_cmg_switch.launch.py
+++ b/space_station_gnc/launch/gnc_thruster_cmg_switch.launch.py
@@ -1,0 +1,152 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, Command, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.parameter_descriptions import ParameterValue
+
+def generate_launch_description():
+    # ------------------------------------------------------------------
+    # Paths
+    # ------------------------------------------------------------------
+    pkg_share = get_package_share_directory('space_station_gnc')
+
+    # NOTE: Adjust this if your model is a .xacro or has a different name.
+    # For xacro: replace Command(['cat ', urdf_path]) with Command(['xacro ', urdf_path])
+    urdf_path = PathJoinSubstitution([
+        FindPackageShare('space_station_gnc'),
+        'urdf',
+        'space_station_eagle.xacro'
+    ])
+
+    # ------------------------------------------------------------------
+    # Arguments
+    # ------------------------------------------------------------------
+    table_mode_arg = DeclareLaunchArgument(
+        'table_mode',
+        default_value='sixdof_phys',
+        description='Thruster table mode to use inside ThrusterMatrix'
+    )
+
+    # ------------------------------------------------------------------
+    # Parameters (GNC / controller)
+    # ------------------------------------------------------------------
+    thruster_params = {
+        # PD gains
+        'kp_thruster': 1_000_000.0,
+        'kd_thruster': 1_000_000.0,
+
+        # LPF for feedback signals (control_torque.cpp)
+        'thruster_omega_lpf_tau': 1.0,
+        'thruster_angle_lpf_tau': 0.0,
+        'lpf_dt': 0.1,
+
+        # Thruster tables & properties
+        'thruster_tables_yaml':     'package://space_station_gnc/config/eagle_thruster_table.yaml',
+        'thruster_properties_yaml': 'package://space_station_gnc/config/eagle_thruster_properties.yaml',
+        'table_mode': LaunchConfiguration('table_mode'),
+    }
+
+    # ------------------------------------------------------------------
+    # Parameters (plant / physics)
+    # ------------------------------------------------------------------
+    phys_params = {
+        # Loop periods
+        'timing.torque_dt': 0.1,       # dynamics step
+        'timing.pub_dt':    0.1,       # publish step
+        'timing.publish_every': 10,    # reduce logging frequency
+
+        # Inertia and orbit
+        'dynamics.J.xx': 4.2e6,
+        'dynamics.J.yy': 4.2e6,
+        'dynamics.J.zz': 6.7e6,
+        'dynamics.mu':   3.986e14,
+        'dynamics.r_orbit': 7.0e6,
+
+        # Optional initial states (uncomment if needed)
+        # 'initial.attitude': [0.0, 0.0, 0.0, 1.0],
+        # 'initial.angvel':  [0.0, 0.0, 0.0],
+        # 'initial.angacc':  [0.0, 0.0, 0.0],
+    }
+
+    # ------------------------------------------------------------------
+    # Nodes
+    # ------------------------------------------------------------------
+    robot_state_pub = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        name='robot_state_publisher',
+        parameters=[{
+            # If your model is a .xacro, use: Command(['xacro ', urdf_path])
+            'robot_description': ParameterValue(
+                Command(['xacro', ' ', urdf_path]),  #
+                value_type=str
+            ),
+        }],
+
+        output='screen'
+    )
+
+    #torque_collector = Node(
+    #    package='space_station_gnc',
+    #    executable='torque_collector',
+    #    name='torque_collector',
+    #    arguments=['--ros-args',
+    #            '--log-level', 'warn',
+    #            '--log-level', 'torque_collector:=warn'],
+    #    output='screen'
+    #)
+
+    control_torque = Node(
+        package='space_station_gnc',
+        executable='control_torque',
+        name='control_torque',
+        parameters=[thruster_params],
+        arguments=['--ros-args',
+                '--log-level', 'info',
+                '--log-level', 'control_torque:=info'],
+        output='screen'
+    )
+
+    physics_motion = Node(
+        package='space_station_gnc',
+        executable='physics_motion',
+        name='physics_motion',
+        parameters=[phys_params],
+        arguments=['--ros-args',
+               '--log-level', 'warn',
+               '--log-level', 'physics_motion:=warn'],
+        output='screen'
+    )
+
+    physics_sensor = Node(
+        package='space_station_gnc',
+        executable='physics_sensor',
+        name='physics_sensor',
+        arguments=['--ros-args',
+               '--log-level', 'warn',
+               '--log-level', 'physics_sensor:=warn'],
+        output='screen'
+    )
+
+    sense_estimate = Node(
+        package='space_station_gnc',
+        executable='sense_estimate',
+        name='sense_estimate',
+        arguments=['--ros-args',
+                '--log-level', 'warn',
+                '--log-level', 'sense_estimate:=warn'],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        table_mode_arg,
+        robot_state_pub,
+        #torque_collector,
+        control_torque,
+        physics_motion,
+        physics_sensor,
+        sense_estimate,
+    ])
+

--- a/space_station_gnc/package.xml
+++ b/space_station_gnc/package.xml
@@ -11,6 +11,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <!--buildtool_depend>ament_python</buildtool_depend-->
   
+  <build_depend>ament_index_cpp</build_depend>
+  <exec_depend>ament_index_cpp</exec_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/space_station_gnc/package.xml
+++ b/space_station_gnc/package.xml
@@ -45,7 +45,12 @@
   <!-- Eigen is found via CMake's Eigen3 package; declare the helper module if available -->
   <!-- Some distros export this as eigen3_cmake_module. Safe to add as a build dependency. -->
   <build_depend>eigen3_cmake_module</build_depend>
+  <build_export_depend>eigen3_cmake_module</build_export_depend>
   <exec_depend>eigen3_cmake_module</exec_depend>
+
+  <build_depend>eigen3</build_depend>
+  <build_export_depend>eigen3</build_export_depend>
+  <exec_depend>eigen3</exec_depend>
 
   <!-- Testing -->
   <test_depend>ament_lint_auto</test_depend>

--- a/space_station_gnc/src/control_torque.cpp
+++ b/space_station_gnc/src/control_torque.cpp
@@ -12,119 +12,239 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rclcpp/rclcpp.hpp>
-#include <rclcpp_action/rclcpp_action.hpp>
+#include "space_station_gnc/action/unloading.hpp"
+#include "space_station_gnc/thruster_matrix.hpp"
+#include <Eigen/Dense>
+#include <algorithm>
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <filesystem> // C++17
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/multi_array_dimension.hpp>
 #include <std_msgs/msg/multi_array_layout.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <Eigen/Dense>
-#include <algorithm>
-#include "space_station_gnc/action/unloading.hpp"
-#include "space_station_gnc/thruster_matrix.hpp"
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
 
-class ControlTorque : public rclcpp::Node
-{
+static std::string resolve_package_url_to_path(const std::string &uri) {
+  const std::string prefix = "package://";
+  if (uri.rfind(prefix, 0) == 0) {
+    const std::string rest = uri.substr(prefix.size()); // "pkg/path/.."
+    const auto slash = rest.find('/');
+    if (slash == std::string::npos) {
+      throw std::runtime_error("Invalid package URI (no slash): " + uri);
+    }
+    const std::string pkg = rest.substr(0, slash);
+    const std::string rel = rest.substr(slash + 1);
+    const std::string share = ament_index_cpp::get_package_share_directory(pkg);
+    return share + "/" + rel;
+  }
+  return uri; // already a filesystem path
+}
+
+class ControlTorque : public rclcpp::Node {
 public:
   using unloading = space_station_gnc::action::Unloading;
   using GoalHandleUnloading = rclcpp_action::ServerGoalHandle<unloading>;
-  ControlTorque()
-  : Node("control_torque")
-  {
+  ControlTorque() : Node("control_torque") {
 
     // Declare parameters for PD gains
     this->declare_parameter("kp_cmg", 300000.0);
     this->declare_parameter("kd_cmg", 300000.0);
     this->declare_parameter("k_unload", 10.0);
-    this->declare_parameter("kp_thruster", 10000.0);
-    this->declare_parameter("kd_thruster", 8000.0);
+    // this->declare_parameter("kp_thruster", 500.0);
+    // this->declare_parameter("kd_thruster", 100.0);
+    this->declare_parameter("kp_thruster", 1000000.0);
+    this->declare_parameter("kd_thruster", 1000000.0);
+
+    this->declare_parameter("thruster_omega_lpf_tau", 1.0); //
+    this->declare_parameter("thruster_angle_lpf_tau", 0.0); //
+    this->declare_parameter("lpf_dt", 0.1);                 //
+
+    angvel_filter_timeconst =
+        this->get_parameter("thruster_omega_lpf_tau").as_double();
+    angpos_filter_timeconst =
+        this->get_parameter("thruster_angle_lpf_tau").as_double();
+    lpf_dt = this->get_parameter("lpf_dt").as_double();
+
+    auto calc_alpha = [&](double tau) -> double {
+      if (tau <= 0.0)
+        return 0.0;
+      double dt = std::clamp(lpf_dt, 1e-4, 0.2);
+      return std::clamp(std::exp(-dt / tau), 0.0, 0.9999);
+    };
+    angvel_filter_alpha = calc_alpha(angvel_filter_timeconst);
+    angpos_filter_alpha = calc_alpha(angpos_filter_timeconst);
+    angvel_filter_state.setZero();
+    angpos_filter_state.setZero();
 
     // Subscribers
     pose_ref_sub_ = this->create_subscription<geometry_msgs::msg::Quaternion>(
-      "/gnc/pose_ref", rclcpp::QoS(10),
-      std::bind(&ControlTorque::callback_pose_ref, this, std::placeholders::_1));
+        "/gnc/pose_ref", rclcpp::QoS(10),
+        std::bind(&ControlTorque::callback_pose_ref, this,
+                  std::placeholders::_1));
 
     pose_est_sub_ = this->create_subscription<geometry_msgs::msg::Quaternion>(
-      "/gnc/pose_est", rclcpp::QoS(10),
-      std::bind(&ControlTorque::callback_pose_est, this, std::placeholders::_1));
+        "/gnc/pose_est", rclcpp::QoS(10),
+        std::bind(&ControlTorque::callback_pose_est, this,
+                  std::placeholders::_1));
 
     angvel_est_sub_ = this->create_subscription<geometry_msgs::msg::Vector3>(
-      "/gnc/angvel_est", rclcpp::QoS(10),
-      std::bind(&ControlTorque::callback_angvel_est, this, std::placeholders::_1));
+        "/gnc/angvel_est", rclcpp::QoS(10),
+        std::bind(&ControlTorque::callback_angvel_est, this,
+                  std::placeholders::_1));
 
     cmg_h_sub_ = this->create_subscription<geometry_msgs::msg::Vector3>(
-      "/gnc/cmg_h", rclcpp::QoS(10),
-      std::bind(&ControlTorque::callback_cmg_h, this, std::placeholders::_1));
+        "/gnc/cmg_h", rclcpp::QoS(10),
+        std::bind(&ControlTorque::callback_cmg_h, this, std::placeholders::_1));
 
     control_mode_sub_ = this->create_subscription<std_msgs::msg::String>(
-      "/gnc/mode_gnc_control", 10,
-      [this](const std_msgs::msg::String::SharedPtr msg) {
-        const std::string & mode = msg->data;
-        if (mode == "cmg" || mode == "thruster") {
-          mode_gnc_control_ = mode;
-          RCLCPP_INFO(this->get_logger(), "Control mode set to: %s", mode_gnc_control_.c_str());
-        } else {
-          RCLCPP_WARN(
-            this->get_logger(), "Received invalid control mode: '%s'. Keeping current mode: %s",
-            mode.c_str(), mode_gnc_control_.c_str());
-        }
-      });
+        "/gnc/mode_gnc_control", 10,
+        [this](const std_msgs::msg::String::SharedPtr msg) {
+          const std::string &mode = msg->data;
+          if (mode == "cmg" || mode == "thruster") {
+            mode_gnc_control_ = mode;
+            RCLCPP_WARN(this->get_logger(), "Control mode set to: %s",
+                        mode_gnc_control_.c_str());
+          } else {
+            RCLCPP_WARN(
+                this->get_logger(),
+                "Received invalid control mode: '%s'. Keeping current mode: %s",
+                mode.c_str(), mode_gnc_control_.c_str());
+          }
+        });
 
     urdf_sub_ = this->create_subscription<std_msgs::msg::String>(
-      "/robot_description", 10,
-      [this](const std_msgs::msg::String::SharedPtr msg)
-      {
-        if (!received_) {
+        "/robot_description",
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
+        [this](const std_msgs::msg::String::SharedPtr msg) {
+          if (received_)
+            return;
           received_ = true;
+
+          // 1) URDF → Thruster geometry
           thrusterMat.initialize(msg->data);
-          RCLCPP_INFO(this->get_logger(), "Received robot description and initialised thrusters!!");
+          thrusterMat.setBaseLink("Root");
+
+          // 2) Table YAML param
+          const auto tables_yaml_param = this->declare_parameter<std::string>(
+              "thruster_tables_yaml",
+              "package://space_station_gnc/config/eagle_thruster_table.yaml");
+
+          const std::string tables_yaml_file =
+              resolve_package_url_to_path(tables_yaml_param);
+          if (!std::filesystem::exists(tables_yaml_file)) {
+            RCLCPP_FATAL(this->get_logger(),
+                         "Thruster table file not found: %s",
+                         tables_yaml_file.c_str());
+            throw std::runtime_error("Thruster table YAML not found");
+          }
+
+          // 3) Load & select mode
+          thrusterMat.loadThrusterTableFromYaml(tables_yaml_file);
+
+          const auto table_mode =
+              this->declare_parameter<std::string>("table_mode", "sixdof_phys");
+          thrusterMat.setThrusterTable(table_mode);
+
+          // 4) Load per-thruster properties (limits etc.)
+          const auto props_yaml_param = this->declare_parameter<std::string>(
+              "thruster_properties_yaml", "package://space_station_gnc/config/"
+                                          "eagle_thruster_properties.yaml");
+          const std::string props_yaml_file =
+              resolve_package_url_to_path(props_yaml_param);
+          thrusterMat.loadProperties(props_yaml_file);
+
+          RCLCPP_INFO(this->get_logger(), "Thruster properties loaded: %s",
+                      props_yaml_file.c_str());
+
+          // Sanity log
+          Eigen::Matrix<double, 6, Eigen::Dynamic> W =
+              thrusterMat.buildWForMode(table_mode);
+          Eigen::FullPivLU<Eigen::MatrixXd> lu(W);
+          int rank = lu.rank();
+          double colsum = 0.0;
+          for (int i = 0; i < W.cols(); ++i)
+            colsum += W.col(i).norm();
+          RCLCPP_INFO(this->get_logger(),
+                      "Thruster table loaded: %s, path=%s, W: 6x%ld, rank=%d, "
+                      "sum|col|=%.3f",
+                      table_mode.c_str(), tables_yaml_file.c_str(),
+                      static_cast<long>(W.cols()), rank, colsum);
+
+          RCLCPP_INFO(this->get_logger(),
+                      "Received robot description and initialised thrusters!!");
 
           urdf_sub_.reset();
-
-        }
-
-      });
+        });
 
     pose_ref_.x = 0.0;
     pose_ref_.y = 0.0;
     pose_ref_.z = 0.0;
     pose_ref_.w = 1.0;
 
-
     // Publisher
-    torque_pub_ = this->create_publisher<geometry_msgs::msg::Vector3>("/gnc/cmg_torque_cmd", 10);
-    torque_thr_pub_ =
-      this->create_publisher<geometry_msgs::msg::Vector3>("/gnc/bias_torque_cmd", 10);
-    ind_thr_pub_ = this->create_publisher<std_msgs::msg::Float32MultiArray>(
-      "/gnc/bias_thruster_cmd", 10);
+    torque_cmg_pub_ = this->create_publisher<geometry_msgs::msg::Vector3>(
+        "/gnc/torque_cmg_cmd", 10);
+    torque_thr_pub_ = this->create_publisher<geometry_msgs::msg::Vector3>(
+        "/gnc/torque_thr_cmd", 10);
+    thr_duty_pub_ = this->create_publisher<std_msgs::msg::Float32MultiArray>(
+        "/gnc/thr_duty_cmd", 10);
+    thr_force_pub_ = this->create_publisher<std_msgs::msg::Float32MultiArray>(
+        "/gnc/thr_force_cmd", 10);
 
     // Action server for unloading
     unloading_server_ = rclcpp_action::create_server<unloading>(
-      this,
-      "gnc/unloading",
-      std::bind(&ControlTorque::handle_goal, this, std::placeholders::_1, std::placeholders::_2),
-      std::bind(&ControlTorque::handle_cancel, this, std::placeholders::_1),
-      std::bind(&ControlTorque::handle_accepted, this, std::placeholders::_1));
+        this, "gnc/unloading",
+        std::bind(&ControlTorque::handle_goal, this, std::placeholders::_1,
+                  std::placeholders::_2),
+        std::bind(&ControlTorque::handle_cancel, this, std::placeholders::_1),
+        std::bind(&ControlTorque::handle_accepted, this,
+                  std::placeholders::_1));
 
     RCLCPP_INFO(this->get_logger(), "Control Torque Node Initialized");
   }
 
 private:
-  void callback_pose_ref(const geometry_msgs::msg::Quaternion::SharedPtr msg)
-  {
-    pose_ref_ = *msg;
+  // Publish a 3D zero torque on /gnc/cmg_torque_cmd
+  void publish_zero_cmg_torque() {
+    geometry_msgs::msg::Vector3 zero;
+    zero.x = zero.y = zero.z = 0.0;
+    torque_cmg_pub_->publish(zero);
   }
 
-  void callback_pose_est(const geometry_msgs::msg::Quaternion::SharedPtr msg)
-  {
+  // Publish a zero-thrust vector of length N on /gnc/thr_duty_cmd
+  void publish_zero_thr_torque() {
+    geometry_msgs::msg::Vector3 z;
+    z.x = z.y = z.z = 0.0;
+    torque_thr_pub_->publish(z);
+  }
+
+  void publish_zero_thr_duty(std::size_t n) {
+    std_msgs::msg::Float32MultiArray zeros;
+    zeros.data.assign(n, 0.0f);
+    thr_duty_pub_->publish(zeros);
+  }
+
+  void callback_pose_ref(const geometry_msgs::msg::Quaternion::SharedPtr msg) {
+    pose_ref_ = *msg;
+    RCLCPP_INFO(this->get_logger(),
+                "Received new pose_ref: [w=%.4f x=%.4f y=%.4f z=%.4f]",
+                pose_ref_.w, pose_ref_.x, pose_ref_.y, pose_ref_.z);
+  }
+
+  void callback_pose_est(const geometry_msgs::msg::Quaternion::SharedPtr msg) {
     pose_est_ = *msg;
 
-    Eigen::Quaterniond q_ref_LVLH = Eigen::Quaterniond::Identity();
-    Eigen::Quaterniond q_act_LVLH(pose_est_.w, pose_est_.x, pose_est_.y, pose_est_.z);
+    // Eigen::Quaterniond q_ref_LVLH = Eigen::Quaterniond::Identity();
+    Eigen::Quaterniond q_ref_LVLH =
+        Eigen::Quaterniond(pose_ref_.w, pose_ref_.x, pose_ref_.y, pose_ref_.z);
+    q_ref_LVLH.normalize();
+    Eigen::Quaterniond q_act_LVLH(pose_est_.w, pose_est_.x, pose_est_.y,
+                                  pose_est_.z);
     q_act_LVLH.normalize();
 
     Eigen::Quaterniond q_error = q_act_LVLH.conjugate() * q_ref_LVLH;
@@ -149,30 +269,42 @@ private:
     error_vector = theta * error_axis_norm;
     error_angvel = Eigen::Vector3d(angvel_est_.x, angvel_est_.y, angvel_est_.z);
 
+    // --- attitude diagnostics (small-angle vector already computed upstream)
+    // ---
+    const double err_ang = error_vector.norm(); // [rad]
+    Eigen::Vector3d err_axis = Eigen::Vector3d::Zero();
+    if (err_ang > 1e-12)
+      err_axis = error_vector / err_ang;
+
+    const double w_norm = error_angvel.norm(); // [rad/s]
+    RCLCPP_INFO(this->get_logger(),
+                "[att] |err_angle|=%+5.3f deg, axis=[%+.2f %+.2f %+.2f], "
+                "omega=%.3f  [%+.3f %+.3f %+.3f] deg/s",
+                err_ang * 180.0 / M_PI, err_axis.x(), err_axis.y(),
+                err_axis.z(), w_norm * 180.0 / M_PI,
+                angvel_est_.x * 180.0 / M_PI, angvel_est_.y * 180.0 / M_PI,
+                angvel_est_.z * 180.0 / M_PI);
 
     if (mode_gnc_control_ == "cmg") {
       compute_cmg_control();
     } else if (mode_gnc_control_ == "thruster") {
       compute_thruster_control();
     } else {
-      RCLCPP_WARN(this->get_logger(), "Unknown control mode: %s", mode_gnc_control_.c_str());
+      RCLCPP_WARN(this->get_logger(), "Unknown control mode: %s",
+                  mode_gnc_control_.c_str());
     }
   }
 
-  void callback_angvel_est(const geometry_msgs::msg::Vector3::SharedPtr msg)
-  {
+  void callback_angvel_est(const geometry_msgs::msg::Vector3::SharedPtr msg) {
     angvel_est_ = *msg;
   }
-  void callback_cmg_h(const geometry_msgs::msg::Vector3::SharedPtr msg)
-  {
+  void callback_cmg_h(const geometry_msgs::msg::Vector3::SharedPtr msg) {
     cmg_pos_ = Eigen::Vector3d(msg->x, msg->y, msg->z);
   }
 
-  void compute_cmg_control()
-  {
+  void compute_cmg_control() {
     double kp = this->get_parameter("kp_cmg").as_double();
     double kd = this->get_parameter("kd_cmg").as_double();
-
 
     this->torque_cmd = kp * error_vector + kd * (-error_angvel);
     Eigen::Vector3d torque_thr_cmd = Eigen::Vector3d::Zero();
@@ -196,43 +328,332 @@ private:
       }
     }
 
-    torque_msg.x = torque_cmd.x();
-    torque_msg.y = torque_cmd.y();
-    torque_msg.z = torque_cmd.z();
-    torque_pub_->publish(torque_msg);
+    torque_cmg_msg.x = torque_cmd.x();
+    torque_cmg_msg.y = torque_cmd.y();
+    torque_cmg_msg.z = torque_cmd.z();
+    torque_cmg_pub_->publish(torque_cmg_msg);
+
+    // Inactive thruster branch: always zero
+    const std::size_t n_thr = static_cast<std::size_t>(thrusterMat.getNumThr());
+    publish_zero_thr_duty(n_thr);
+    publish_zero_thr_torque();
   }
 
-  void compute_thruster_control()
-  {
-    double kp = this->get_parameter("kp_thruster").as_double();
-    double kd = this->get_parameter("kd_thruster").as_double();
+  void compute_thruster_control() {
+    // Gains
+    const double kp = this->get_parameter("kp_thruster").as_double();
+    const double kd = this->get_parameter("kd_thruster").as_double();
 
-    this->torque_cmd = kp * error_vector + kd * (-error_angvel);
+    // angpos_filter: e_filt[k] = α*e_filt[k-1] + (1-α)*e_raw[k]
+    const Eigen::Vector3d e_raw(error_vector.x(), error_vector.y(),
+                                error_vector.z());
+    if (angpos_filter_alpha > 0.0) {
+      angpos_filter_state = angpos_filter_alpha * angpos_filter_state +
+                            (1.0 - angpos_filter_alpha) * e_raw;
+    } else {
+      angpos_filter_state = e_raw;
+    }
+    const Eigen::Vector3d w_raw(error_angvel.x(), error_angvel.y(),
+                                error_angvel.z());
+    if (angvel_filter_alpha > 0.0) {
+      angvel_filter_state = angvel_filter_alpha * angvel_filter_state +
+                            (1.0 - angvel_filter_alpha) * w_raw;
+    } else {
+      angvel_filter_state = w_raw;
+    }
 
+    // --- Dead-zone with hysteresis using angle AND angular rate ---
+    // Units: angle [deg], rate [deg/s]
+    static bool dz_active = false;
+
+    // Tunable thresholds (you can move these to ROS parameters if desired)
+    const double ang_on_deg =
+        0.150; // leave zero region when error grows (upper)
+    const double ang_off_deg =
+        0.1; // enter zero region when already small (lower)
+    const double rate_on_dps =
+        0.25; // leave zero when angular rate grows (upper)
+    const double rate_off_dps =
+        0.15; // enter zero when rate already small (lower)
+
+    // Current values
+    const double err_ang_deg = error_vector.norm() * 180.0 / M_PI; // [deg]
+    const double rate_dps = error_angvel.norm() * 180.0 / M_PI;    // [deg/s]
+
+    // Enter: BOTH angle <= off AND rate <= off  → quiet enough
+    if (!dz_active && (err_ang_deg <= ang_off_deg) &&
+        (rate_dps <= rate_off_dps)) {
+      dz_active = true;
+    } else if (dz_active &&
+               (err_ang_deg >= ang_on_deg || rate_dps >= rate_on_dps)) {
+      // Leave: EITHER angle >= on OR rate >= on   → motion sizable
+      dz_active = false;
+    }
+
+    // Build P (or PD) torque command
+    Eigen::Vector3d tau_cmd_vec =
+        kp * angpos_filter_state + kd * (-angvel_filter_state);
+
+    // Apply dead-zone
+    if (dz_active) {
+      tau_cmd_vec.setZero();
+    }
+
+    // Optional: tiny command clamp even when dz_active==false (avoids micro
+    // pulses)
+    const double tau_min = 1e-3; // [N·m], tune as needed
+    if (tau_cmd_vec.norm() < tau_min) {
+      tau_cmd_vec.setZero();
+    }
+
+    this->torque_cmd = tau_cmd_vec;
+
+    // Always zero the inactive branch (CMG)
+    publish_zero_cmg_torque();
+
+    // Geometry/table readiness
     if (!thrusterMat.isReady()) {
+      publish_zero_thr_duty(0);
+      publish_zero_thr_torque();
       return;
     }
 
-    thrusterMat.bodyToThruster(torque_cmd, thruster_force);
-    ind_thr_msg.data.resize(thrusterMat.getNumThr());
-    size_t idx = 0;
-    for (auto & val : ind_thr_msg.data) {
-      val = thruster_force(idx);
-      if ((unsigned int)idx != (unsigned int)thruster_force.size()) {
-        idx++;
+    // --- Attitude diagnostics (angle/axis and angular-rate) ---
+    const double err_ang = error_vector.norm(); // [rad]
+    Eigen::Vector3d err_axis = Eigen::Vector3d::Zero();
+    if (err_ang > 1e-12)
+      err_axis = error_vector / err_ang;
+    const double w_norm = error_angvel.norm(); // [rad/s]
+    // TODO
+
+    // --- 6DOF table path: build wrench [Tx Ty Tz Fx Fy Fz]^T ---
+    Eigen::VectorXd wrench6(6);
+    wrench6.setZero();
+    wrench6(0) = torque_cmd.x();
+    wrench6(1) = torque_cmd.y();
+    wrench6(2) = torque_cmd.z();
+    // Fx, Fy, Fz are zero for now (translation not commanded here)
+
+    // Solve table allocation: u_thr (force commands per thruster) [N]
+    Eigen::VectorXd u_thr;
+    const double tol = std::max(1e-8, 1e-6 * torque_cmd.norm());
+    try {
+      // thrusterMat.generateCommandFromTable(wrench6, u_thr);
+      if (!thrusterMat.generateCommandPreferDirect(wrench6, u_thr, tol)) {
+        // Safety: if both direct and table failed, zero out
+        u_thr = Eigen::VectorXd::Zero(thrusterMat.getNumThr());
+      }
+
+    } catch (const std::exception &e) {
+      RCLCPP_ERROR(this->get_logger(),
+                   "[diag] generateCommandFromTable exception: %s", e.what());
+      publish_zero_thr_duty(0);
+      publish_zero_thr_torque();
+      return;
+    }
+
+    // --- Diagnostics on u_thr before clipping ---
+    {
+      const double u_norm = (u_thr.size() > 0) ? u_thr.norm() : 0.0;
+      int neg_cnt = 0, pos_cnt = 0, zero_cnt = 0;
+      for (int i = 0; i < u_thr.size(); ++i) {
+        if (u_thr(i) > 1e-12)
+          ++pos_cnt;
+        else if (u_thr(i) < -1e-12)
+          ++neg_cnt;
+        else
+          ++zero_cnt;
+      }
+      RCLCPP_DEBUG(
+          this->get_logger(),
+          "[diag] u_thr.size=%d |u_thr|=%.6f (pos=%d, neg=%d, zero=%d)",
+          (int)u_thr.size(), u_norm, pos_cnt, neg_cnt, zero_cnt);
+    }
+
+    // --- Load per-thruster limits (already loaded into ThrusterMatrix via
+    // loadProperties) --- Convert u_thr -> clamped force vector in [0,
+    // max_force] and duty in [0, 1]
+    auto active =
+        thrusterMat.getActiveThrusters(); // aligned with thruster_order_
+    const std::size_t M = std::min<std::size_t>(
+        active.size(), static_cast<std::size_t>(u_thr.size()));
+
+    thr_duty_msg.data.resize(static_cast<std::size_t>(u_thr.size()));
+    Eigen::VectorXd force =
+        Eigen::VectorXd::Zero(u_thr.size()); // [N] used for tau reconstruction
+
+    for (std::size_t i = 0; i < M; ++i) {
+      const double fmax = std::max(0.0, active[i].max_force);
+      // clamp to [0, fmax] (non-negativity is already applied in table solver)
+      const double fi = (fmax > 0.0)
+                            ? std::clamp(u_thr(static_cast<int>(i)), 0.0, fmax)
+                            : 0.0;
+      force(static_cast<int>(i)) = fi;
+      const double duty =
+          (fmax > 0.0) ? (fi / fmax) : 0.0; // normalized duty [0..1]
+      thr_duty_msg.data[i] = static_cast<float>(duty);
+    }
+    // zero the remainder if any
+    for (std::size_t i = M; i < static_cast<std::size_t>(u_thr.size()); ++i)
+      thr_duty_msg.data[i] = 0.0f;
+
+    // Publish duty (future PWM layer will quantize if needed)
+    thr_duty_pub_->publish(thr_duty_msg);
+
+    // Reconstruct effective torque using *force* (not duty)
+    Eigen::Vector3d tau_eff(0.0, 0.0, 0.0);
+    try {
+      thrusterMat.thrusterToBody(force, tau_eff); // A * force
+    } catch (const std::exception &e) {
+      RCLCPP_ERROR(this->get_logger(), "[diag] thrusterToBody exception: %s",
+                   e.what());
+      publish_zero_thr_torque();
+      return;
+    }
+
+    // Residuals: table-residual ||W*u_thr - wrench|| and geometric-residual
+    // ||A*u_thr - tau_cmd||
+    try {
+      const std::string mode = this->get_parameter("table_mode").as_string();
+      Eigen::Matrix<double, 6, Eigen::Dynamic> W =
+          thrusterMat.buildWForMode(mode);
+      Eigen::VectorXd wrench_eff = W * u_thr;
+      const double resW = (wrench_eff - wrench6).norm();
+      const double resA = (tau_eff - torque_cmd).norm();
+      RCLCPP_DEBUG(
+          this->get_logger(),
+          "[diag] residuals: ||W*u_thr - w||=%.6e, ||A*u_thr - tau_cmd||=%.6e",
+          resW, resA);
+    } catch (...) {
+      // ignore diag errors
+    }
+
+    // -----------------------------
+    // DIAG 1: u_thr (table output)
+    // -----------------------------
+    {
+      // Get names in the same order as allocation columns.
+      // Using getActiveThrusters() preserves orderedThrusterNames().size() and
+      // order for the active set.
+      auto active = thrusterMat.getActiveThrusters();
+      const int N = static_cast<int>(u_thr.size());
+      RCLCPP_DEBUG(this->get_logger(), "[thr] u_thr (table output) N=%d:", N);
+      for (int i = 0; i < N && i < (int)active.size(); ++i) {
+        RCLCPP_DEBUG(this->get_logger(), "  %2d  %-16s  u_thr=%.6f", i,
+                     active[i].name.c_str(), u_thr(i));
+      }
+
+      // Per-column torque contribution from u_thr (using A column i only)
+      RCLCPP_DEBUG(this->get_logger(),
+                   "[thr] torque contribution from u_thr (A*e_i*u_i):");
+      for (int i = 0; i < N; ++i) {
+        Eigen::VectorXd ei = Eigen::VectorXd::Zero(N);
+        // ei(i) = u_thr(i);
+        ei(i) = force(i);
+        Eigen::Vector3d tau_i;
+        thrusterMat.thrusterToBody(ei, tau_i);
+        const char *nm =
+            (i < (int)active.size() ? active[i].name.c_str() : "(n/a)");
+        RCLCPP_DEBUG(this->get_logger(),
+                     "  %2d  %-16s  tau_i=[%.3f %.3f %.3f]  |tau_i|=%.3f", i,
+                     nm, tau_i.x(), tau_i.y(), tau_i.z(), tau_i.norm());
       }
     }
-    ind_thr_pub_->publish(ind_thr_msg);
+
+    auto print_mat_rowwise = [&](const char *tag,
+                                 const Eigen::Ref<const Eigen::MatrixXd> &M,
+                                 const std::array<const char *, 3> &rname) {
+      for (int r = 0; r < M.rows(); ++r) {
+        std::stringstream ss;
+        ss.setf(std::ios::fixed);
+        ss << std::setprecision(5);
+        ss << tag << " " << rname[r] << " [";
+        for (int c = 0; c < M.cols(); ++c) {
+          ss << std::setw(8) << M(r, c);
+          if (c + 1 < M.cols())
+            ss << " ";
+        }
+        ss << "]";
+        RCLCPP_INFO(this->get_logger(), "%s", ss.str().c_str());
+      }
+    };
+
+    //    RCLCPP_INFO(
+    //        this->get_logger(),
+    //        "[diag] tau_from_thr = [%6.1f %6.1f %6.1f] |tau_from_thr|=%6.1f  "
+    //        "(|tau_cmd|=%6.1f, |force|=%6.1f)",
+    //        tau_eff.x(), tau_eff.y(), tau_eff.z(), tau_eff.norm(),
+    //        torque_cmd.norm(), force.norm());
+
+    RCLCPP_INFO(this->get_logger(),
+                "[diag] |force|=%6.1f,  |tau_cmd|=%7.1f, "
+                " |tau_from_thr|=%7.1f | tau_from_thr = [%7.1f %7.1f %7.1f] ",
+                force.norm(), torque_cmd.norm(), tau_eff.norm(), tau_eff.x(),
+                tau_eff.y(), tau_eff.z());
+
+    auto print_vec_pair = [&](const char *tag,
+                              const Eigen::Ref<const Eigen::Vector3d> &a,
+                              const Eigen::Ref<const Eigen::Vector3d> &b) {
+      RCLCPP_INFO(this->get_logger(),
+                  "%s cmd=[%+6.1f %+6.1f %+6.1f]  thr=[%+6.1f %+6.1f %+6.1f]",
+                  tag, a.x(), a.y(), a.z(), b.x(), b.y(), b.z());
+    };
+
+    // ===== concise diagnostics =====
+    {
+      const int N = static_cast<int>(u_thr.size());
+
+      // 3xN: per-thruster torque matrix
+      Eigen::MatrixXd Tau(3, N);
+      Tau.setZero();
+      for (int i = 0; i < N; ++i) {
+        Eigen::VectorXd ei = Eigen::VectorXd::Zero(N);
+        ei(i) = u_thr(i);
+        Eigen::Vector3d tau_i;
+        thrusterMat.thrusterToBody(ei, tau_i); // A * (e_i * u_i)
+        Tau.col(i) = tau_i;
+      }
+
+      // tau_cmd と tau_from_thr
+      const Eigen::Vector3d tau_cmd_vec = torque_cmd;
+      const Eigen::Vector3d tau_thr_vec = tau_eff;
+
+      // 姿勢行列（Body←測定姿勢）
+      Eigen::Quaterniond q_act(pose_est_.w, pose_est_.x, pose_est_.y,
+                               pose_est_.z);
+      q_act.normalize();
+      const Eigen::Matrix3d R = q_act.toRotationMatrix();
+
+      // (i) per-thruster torque matrix（3行で出力）
+      print_mat_rowwise("[thr/Tau]", Tau, {"Tx:", "Ty:", "Tz:"});
+
+      // (ii) tau_cmd vs tau_from_thr（1行）
+      print_vec_pair("[tau]", tau_cmd_vec, tau_thr_vec);
+
+      // (iii) attitude rotation matrix（3行で出力）
+      print_mat_rowwise("[att/R]", R, {"r1:", "r2:", "r3:"});
+    }
+
+    // Publish torque to the plant
+    torque_thr_msg.x = tau_eff.x();
+    torque_thr_msg.y = tau_eff.y();
+    torque_thr_msg.z = tau_eff.z();
+    torque_thr_pub_->publish(torque_thr_msg);
+
+    // (Optional) Per-thruster dump for deeper analysis:
+    // auto names = thrusterMat.getAllThrusterNames();
+    // for (int i = 0; i < u_thr.size() && i < (int)names.size(); ++i) {
+    //   RCLCPP_DEBUG(this->get_logger(), "  %2d  %-16s  u_thr=%.6f", i,
+    //   names[i].c_str(), u_thr(i));
+    // }
   }
 
-
-  void handleUnloading(const std::shared_ptr<GoalHandleUnloading> goal_handle)
-  {
+  void handleUnloading(const std::shared_ptr<GoalHandleUnloading> goal_handle) {
     RCLCPP_INFO(this->get_logger(), "Handling unloading request");
     rclcpp::Rate rate(1);
     const auto goal = goal_handle->get_goal();
     auto feedback = std::make_shared<unloading::Feedback>();
-    auto & status = feedback->rem;
+    auto &status = feedback->rem;
     auto result = std::make_shared<unloading::Result>();
     unload = goal->unload;
 
@@ -243,7 +664,7 @@ private:
         RCLCPP_INFO(this->get_logger(), "Unloading stopped");
         return;
       }
-      status = t_bias.norm();       // TODO: Needs better feedback
+      status = t_bias.norm(); // TODO: Needs better feedback
       goal_handle->publish_feedback(feedback);
       rate.sleep();
     }
@@ -256,7 +677,7 @@ private:
   }
 
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr control_mode_sub_;
-  std::string mode_gnc_control_ = "cmg";   // default
+  std::string mode_gnc_control_ = "cmg"; // default
 
   rclcpp::Subscription<geometry_msgs::msg::Quaternion>::SharedPtr pose_ref_sub_;
   rclcpp::Subscription<geometry_msgs::msg::Quaternion>::SharedPtr pose_est_sub_;
@@ -264,32 +685,32 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr cmg_h_sub_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr urdf_sub_;
   bool received_ = false;
-  rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr torque_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr torque_cmg_pub_;
   rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr torque_thr_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr ind_thr_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr thr_duty_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr thr_force_pub_;
   rclcpp_action::Server<unloading>::SharedPtr unloading_server_;
 
-  rclcpp_action::GoalResponse handle_goal(
-    const rclcpp_action::GoalUUID & uuid,
-    std::shared_ptr<const unloading::Goal> goal)
-  {
-    RCLCPP_INFO(this->get_logger(), "Received unloading request, unload: %i", goal->unload);
+  rclcpp_action::GoalResponse
+  handle_goal(const rclcpp_action::GoalUUID &uuid,
+              std::shared_ptr<const unloading::Goal> goal) {
+    RCLCPP_INFO(this->get_logger(), "Received unloading request, unload: %i",
+                goal->unload);
     (void)uuid;
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
   }
 
-  rclcpp_action::CancelResponse handle_cancel(
-    const std::shared_ptr<GoalHandleUnloading> goal_handle)
-  {
+  rclcpp_action::CancelResponse
+  handle_cancel(const std::shared_ptr<GoalHandleUnloading> goal_handle) {
     RCLCPP_INFO(this->get_logger(), "Received cancel request");
     (void)goal_handle;
     return rclcpp_action::CancelResponse::ACCEPT;
   }
-  void handle_accepted(const std::shared_ptr<GoalHandleUnloading> goal_handle)
-  {
+  void handle_accepted(const std::shared_ptr<GoalHandleUnloading> goal_handle) {
     std::thread(
-      std::bind(&ControlTorque::handleUnloading, this, std::placeholders::_1),
-      goal_handle).detach();
+        std::bind(&ControlTorque::handleUnloading, this, std::placeholders::_1),
+        goal_handle)
+        .detach();
   }
 
   geometry_msgs::msg::Quaternion pose_ref_;
@@ -299,12 +720,12 @@ private:
 
   Eigen::VectorXd thruster_force;
 
-  geometry_msgs::msg::Vector3 torque_msg;
+  geometry_msgs::msg::Vector3 torque_cmg_msg;
   geometry_msgs::msg::Vector3 torque_thr_msg;
-  std_msgs::msg::Float32MultiArray ind_thr_msg;
+  std_msgs::msg::Float32MultiArray thr_duty_msg;
 
   double kp_, kd_, k;
-  Eigen::Vector3d k_;   // Bias factor for unloading CMG
+  Eigen::Vector3d k_; // Bias factor for unloading CMG
   Eigen::Vector3d t_bias, t_bias_norm, t_att;
   Eigen::Matrix<double, 3, 3> N;
 
@@ -312,13 +733,21 @@ private:
   Eigen::Vector3d error_angvel;
   Eigen::Vector3d torque_cmd;
 
-  std::atomic<bool> unload = false;   // Flag to indicate if unloading is required
+  // --- LPF states & params (persistent) ---
+  Eigen::Vector3d angvel_filter_state{Eigen::Vector3d::Zero()};
+  double angvel_filter_timeconst{0.15}; // [s]
+  double angvel_filter_alpha{0.0};
+  Eigen::Vector3d angpos_filter_state{Eigen::Vector3d::Zero()};
+  double angpos_filter_timeconst{0.0}; // [s] 0で無効
+  double angpos_filter_alpha{0.0};
+  double lpf_dt{0.1}; // [s]
+
+  std::atomic<bool> unload = false; // Flag to indicate if unloading is required
 
   ThrusterMatrix thrusterMat;
 };
 
-int main(int argc, char ** argv)
-{
+int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
   rclcpp::spin(std::make_shared<ControlTorque>());
   rclcpp::shutdown();

--- a/space_station_gnc/src/physics_motion.cpp
+++ b/space_station_gnc/src/physics_motion.cpp
@@ -12,57 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rclcpp/rclcpp.hpp>
+#include "L_p_func.cpp"
 #include "rclcpp_action/rclcpp_action.hpp"
-#include <iostream>
-#include <string>
+#include "space_station_gnc/action/unloading.hpp"
+#include "space_station_gnc/thruster_matrix.hpp"
+#include <Eigen/Dense>
+#include <chrono>
 #include <cmath>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <geometry_msgs/msg/vector3.hpp>
-#include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <visualization_msgs/msg/marker.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <iostream>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
-#include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/multi_array_dimension.hpp>
 #include <std_msgs/msg/multi_array_layout.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <chrono>
+#include <string>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2_ros/transform_broadcaster.h>
 #include <thread>
-#include <Eigen/Dense>
 #include <vector>
-#include "L_p_func.cpp"
-#include "space_station_gnc/action/unloading.hpp"
-#include "space_station_gnc/thruster_matrix.hpp"
-//std::string mode_demo;
+#include <visualization_msgs/msg/marker.hpp>
+// std::string mode_demo;
 
-class AttitudeDynamicsNode : public rclcpp::Node
-{
+class AttitudeDynamicsNode : public rclcpp::Node {
 public:
   using unloading = space_station_gnc::action::Unloading;
   using GoalHandleUnloading = rclcpp_action::ClientGoalHandle<unloading>;
-  AttitudeDynamicsNode(const rclcpp::NodeOptions & options)
-  : Node("physics_motion", options)
-  {
-    // // dynamics parameters
-    // this->declare_parameter<double>("dynamics.J.xx", 280e6);
-    // this->declare_parameter<double>("dynamics.J.yy", 140e6);
-    // this->declare_parameter<double>("dynamics.J.zz", 420e6);
-    // this->declare_parameter<double>("dynamics.mu", 3.986e14);
-    // this->declare_parameter<double>("dynamics.r_orbit", 7e6);
+  AttitudeDynamicsNode(const rclcpp::NodeOptions &options)
+      : Node("physics_motion", options) {
+    // Timing
+    if (!this->has_parameter("timing.torque_dt")) {
+      this->declare_parameter<double>("timing.torque_dt", 0.1);
+    }
+    if (!this->has_parameter("timing.pub_dt")) {
+      this->declare_parameter<double>("timing.pub_dt", 0.1);
+    }
+    if (!this->has_parameter("timing.publish_every")) {
+      this->declare_parameter<int>("timing.publish_every", 10);
+    }
 
-    // // timing parameters
-    // this->declare_parameter<double>("timing.torque_dt", 0.1);
-    // this->declare_parameter<double>("timing.pub_dt", 0.1);
-    // this->declare_parameter<int>   ("timing.publish_every", 10);
+    // Dynamics
+    if (!this->has_parameter("dynamics.J.xx")) {
+      // this->declare_parameter<double>("dynamics.J.xx", 2.8e8);
+      this->declare_parameter<double>("dynamics.J.xx", 4.2e6);
+    }
+    if (!this->has_parameter("dynamics.J.yy")) {
+      // this->declare_parameter<double>("dynamics.J.yy", 1.4e8);
+      this->declare_parameter<double>("dynamics.J.yy", 4.2e6);
+    }
+    if (!this->has_parameter("dynamics.J.zz")) {
+      // this->declare_parameter<double>("dynamics.J.zz", 4.2e8);
+      this->declare_parameter<double>("dynamics.J.zz", 6.7e6);
+    }
+    if (!this->has_parameter("dynamics.mu")) {
+      this->declare_parameter<double>("dynamics.mu", 3.986e14);
+    }
+    if (!this->has_parameter("dynamics.r_orbit")) {
+      this->declare_parameter<double>("dynamics.r_orbit", 7.0e6);
+    }
 
-    // // initial state parameters
-    // this->declare_parameter<std::vector<double>>("initial.attitude", {0,0,0,1});
-    // this->declare_parameter<std::vector<double>>("initial.angvel", {0,0,0});
-    // this->declare_parameter<std::vector<double>>("initial.angacc", {0,0,0});
+    // Initial state
+    if (!this->has_parameter("initial.attitude")) {
+      this->declare_parameter<std::vector<double>>(
+          "initial.attitude", std::vector<double>{0.0, 0.0, 0.0, 1.0});
+    }
+    if (!this->has_parameter("initial.angvel")) {
+      this->declare_parameter<std::vector<double>>(
+          "initial.angvel", std::vector<double>{0.0, 0.0, 0.0});
+    }
+    if (!this->has_parameter("initial.angacc")) {
+      this->declare_parameter<std::vector<double>>(
+          "initial.angacc", std::vector<double>{0.0, 0.0, 0.0});
+    }
 
     Ttorque_ = this->get_parameter("timing.torque_dt").as_double();
     Tpubatt_ = this->get_parameter("timing.pub_dt").as_double();
@@ -80,40 +106,43 @@ public:
     H_th << 0.3, 0.3, 0.3;
 
     pub_attitude_LVLH = this->create_publisher<geometry_msgs::msg::Quaternion>(
-      "gnc/attitude_LVLH",
-      10);
-    pub_angvel_body = this->create_publisher<geometry_msgs::msg::Vector3>("gnc/angvel_body", 10);
-    pub_cmg_del = this->create_publisher<std_msgs::msg::Float64MultiArray>("gnc/cmg_del", 1);
-    pub_pose_all = this->create_publisher<geometry_msgs::msg::PoseStamped>("gnc/pose_all", 10);
-    pub_cmg_h = this->create_publisher<geometry_msgs::msg::Vector3>("gnc/cmg_h", 1);
+        "gnc/attitude_LVLH", 10);
+    pub_angvel_body = this->create_publisher<geometry_msgs::msg::Vector3>(
+        "gnc/angvel_body", 10);
+    pub_cmg_del = this->create_publisher<std_msgs::msg::Float64MultiArray>(
+        "gnc/cmg_del", 1);
+    pub_pose_all = this->create_publisher<geometry_msgs::msg::PoseStamped>(
+        "gnc/pose_all", 10);
+    pub_cmg_h =
+        this->create_publisher<geometry_msgs::msg::Vector3>("gnc/cmg_h", 1);
 
-    pub_ang_acc = this->create_publisher<geometry_msgs::msg::Vector3>("gnc/ang_acc", 10);
-    //pub_pose_marker = this->create_publisher<visualization_msgs::msg::Marker>("pose_marker", 10);
+    pub_ang_acc =
+        this->create_publisher<geometry_msgs::msg::Vector3>("gnc/ang_acc", 10);
+    // pub_pose_marker =
+    // this->create_publisher<visualization_msgs::msg::Marker>("pose_marker",
+    // 10);
     broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
 
-
-    i2disp = 0;     //publish rate: Npublish * Ttorque
+    i2disp = 0; // publish rate: Npublish * Ttorque
     should_pub_att = false;
 
-    //omebcur.setValue(0.0,+0.22 / 180.0 * M_PI,0.0);
+    // omebcur.setValue(0.0,+0.22 / 180.0 * M_PI,0.0);
     omebprv = omebcur;
-    //omedotbcur.setValue(0.0,+0.0003 / 180.0 * M_PI,0.0);
+    // omedotbcur.setValue(0.0,+0.0003 / 180.0 * M_PI,0.0);
     omedotbcur.setValue(0.0, +0.0000780, 0.0);
     omedotbprv = omedotbcur;
     publish_attitude(attcur);
     printq(attcur);
 
-    //attcur.setRPY(0.0,1.72/180.0*M_PI,0.0);
-    //attcur.setRPY(0.0,11.97/180.0*M_PI,0.0);
+    // attcur.setRPY(0.0,1.72/180.0*M_PI,0.0);
+    // attcur.setRPY(0.0,11.97/180.0*M_PI,0.0);
     attprv = attcur;
 
-    //TODO: handled by parameter surver?
+    // TODO: handled by parameter surver?
     double J11 = this->get_parameter("dynamics.J.xx").as_double();
     double J22 = this->get_parameter("dynamics.J.yy").as_double();
     double J33 = this->get_parameter("dynamics.J.zz").as_double();
-    J123 << J11, 0.0, 0.0,
-      0.0, J22, 0.0,
-      0.0, 0.0, J33;
+    J123 << J11, 0.0, 0.0, 0.0, J22, 0.0, 0.0, 0.0, J33;
     J123inv = J123.inverse();
     mu = this->get_parameter("dynamics.mu").as_double();
     rOrbit = this->get_parameter("dynamics.r_orbit").as_double();
@@ -121,60 +150,79 @@ public:
     deltacur << 0.0, 0.0, 0.0, 0.0;
 
     sub_t_fwd_sim = this->create_subscription<std_msgs::msg::Float64>(
-      "gnc/t_fwd_sim", 1,
-      std::bind(&AttitudeDynamicsNode::callback_t_fwd_sim, this, std::placeholders::_1));
+        "gnc/t_fwd_sim", 1,
+        std::bind(&AttitudeDynamicsNode::callback_t_fwd_sim, this,
+                  std::placeholders::_1));
 
-    sub_attitude_overwrite = this->create_subscription<geometry_msgs::msg::Quaternion>(
-      "gnc/attitude_overwrite", 1,
-      std::bind(&AttitudeDynamicsNode::callback_attitude_overwrite, this, std::placeholders::_1));
+    sub_attitude_overwrite =
+        this->create_subscription<geometry_msgs::msg::Quaternion>(
+            "gnc/attitude_overwrite", 1,
+            std::bind(&AttitudeDynamicsNode::callback_attitude_overwrite, this,
+                      std::placeholders::_1));
 
-    sub_angvel_overwrite = this->create_subscription<geometry_msgs::msg::Vector3>(
-      "gnc/angvel_overwrite", 1,
-      std::bind(&AttitudeDynamicsNode::callback_angvel_overwrite, this, std::placeholders::_1));
+    sub_angvel_overwrite =
+        this->create_subscription<geometry_msgs::msg::Vector3>(
+            "gnc/angvel_overwrite", 1,
+            std::bind(&AttitudeDynamicsNode::callback_angvel_overwrite, this,
+                      std::placeholders::_1));
 
-    sub_torque_control = this->create_subscription<geometry_msgs::msg::Vector3>(
-      "gnc/thr_torque_cmd", 1,
-      std::bind(&AttitudeDynamicsNode::callback_attitude_dynamics, this, std::placeholders::_1));
+    attitude_timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(100), // 10Hz = 100ms interval
+        std::bind(&AttitudeDynamicsNode::timer_callback_attitude_dynamics,
+                  this));
 
-    sub_cmg_torque_control = this->create_subscription<geometry_msgs::msg::Vector3>(
-      "gnc/cmg_torque_cmd", 1,
-      std::bind(&AttitudeDynamicsNode::callback_cmg_inp, this, std::placeholders::_1));
+    sub_thruster_torque_inp =
+        this->create_subscription<geometry_msgs::msg::Vector3>(
+            "gnc/torque_thr_cmd", 1,
+            std::bind(&AttitudeDynamicsNode::callback_thruster_torque_inp, this,
+                      std::placeholders::_1));
 
-    sub_bias_torque_control = this->create_subscription<geometry_msgs::msg::Vector3>(
-      "gnc/bias_torque_cmd", 1,
-      std::bind(&AttitudeDynamicsNode::callback_bias_inp, this, std::placeholders::_1));
+    sub_cmg_torque_inp = this->create_subscription<geometry_msgs::msg::Vector3>(
+        "gnc/torque_cmg_cmd", 1,
+        std::bind(&AttitudeDynamicsNode::callback_cmg_torque_inp, this,
+                  std::placeholders::_1));
 
-    sub_bias_thruster_control = this->create_subscription<std_msgs::msg::Float32MultiArray>(
-      "gnc/bias_thruster_cmd", 1,
-      std::bind(&AttitudeDynamicsNode::callback_bias_thruster_inp, this, std::placeholders::_1));
+    sub_bias_torque_control =
+        this->create_subscription<geometry_msgs::msg::Vector3>(
+            "gnc/bias_torque_cmd", 1,
+            std::bind(&AttitudeDynamicsNode::callback_bias_inp, this,
+                      std::placeholders::_1));
+
+    sub_bias_thruster_control =
+        this->create_subscription<std_msgs::msg::Float32MultiArray>(
+            ///"gnc/thr_duty_cmd", 1,
+            "gnc/thr_thruster_cmd", 1,
+            std::bind(&AttitudeDynamicsNode::callback_bias_thruster_inp, this,
+                      std::placeholders::_1));
 
     urdf_sub_ = this->create_subscription<std_msgs::msg::String>(
-      "/robot_description", 10,
-      [this](const std_msgs::msg::String::SharedPtr msg)
-      {
-        if (!received_) {
-          received_ = true;
-          thrusterMat.initialize(msg->data);
-          RCLCPP_INFO(this->get_logger(), "Received robot description and initialised thrusters!!");
-
-          urdf_sub_.reset();
-        }
-      });
+        "/robot_description",
+        rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable(),
+        [this](const std_msgs::msg::String::SharedPtr msg) {
+          if (!received_) {
+            received_ = true;
+            thrusterMat.initialize(msg->data);
+            RCLCPP_INFO(
+                this->get_logger(),
+                "Received robot description and initialised thrusters!!");
+            urdf_sub_.reset();
+          }
+        });
 
     timer_ = this->create_wall_timer(
-      std::chrono::milliseconds((int)(Tpubatt_ * 1000.0)),
-      std::bind(&AttitudeDynamicsNode::callback_timer_pub_att, this));
+        std::chrono::milliseconds((int)(Tpubatt_ * 1000.0)),
+        std::bind(&AttitudeDynamicsNode::callback_timer_pub_att, this));
 
     timer_acc_ = this->create_wall_timer(
-      std::chrono::milliseconds((int)(Tpubatt_ * 1000.0)),
-      std::bind(&AttitudeDynamicsNode::callback_timer_pub_acc, this));
+        std::chrono::milliseconds((int)(Tpubatt_ * 1000.0)),
+        std::bind(&AttitudeDynamicsNode::callback_timer_pub_acc, this));
 
     timer_unload_ = this->create_wall_timer(
-      std::chrono::milliseconds((int)(Tpubatt_ * 1000.0)),
-      std::bind(&AttitudeDynamicsNode::callback_timer_pub_unload, this));
+        std::chrono::milliseconds((int)(Tpubatt_ * 1000.0)),
+        std::bind(&AttitudeDynamicsNode::callback_timer_pub_unload, this));
 
-    unloading_client_ = rclcpp_action::create_client<unloading>(
-      this, "gnc/unloading");
+    unloading_client_ =
+        rclcpp_action::create_client<unloading>(this, "gnc/unloading");
 
     if (!unloading_client_->wait_for_action_server(std::chrono::seconds(5))) {
       RCLCPP_ERROR(this->get_logger(), "Unloading action server not available");
@@ -182,35 +230,45 @@ public:
     }
 
     goal_msg.unload = false;
-    send_goal_options.goal_response_callback = std::bind(
-      &AttitudeDynamicsNode::goal_response_callback, this, std::placeholders::_1);
-    send_goal_options.feedback_callback = std::bind(
-      &AttitudeDynamicsNode::feedback_callback, this,
-      std::placeholders::_1, std::placeholders::_2);
+    send_goal_options.goal_response_callback =
+        std::bind(&AttitudeDynamicsNode::goal_response_callback, this,
+                  std::placeholders::_1);
+    send_goal_options.feedback_callback =
+        std::bind(&AttitudeDynamicsNode::feedback_callback, this,
+                  std::placeholders::_1, std::placeholders::_2);
     send_goal_options.result_callback = std::bind(
-      &AttitudeDynamicsNode::result_callback, this,
-      std::placeholders::_1);
+        &AttitudeDynamicsNode::result_callback, this, std::placeholders::_1);
   }
 
 private:
-  //ros2 stuff
-  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sub_torque_control;
-  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sub_cmg_torque_control;
-  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sub_bias_torque_control;
-  rclcpp::Subscription<std_msgs::msg::Float32MultiArray>::SharedPtr sub_bias_thruster_control;
+  // ros2 stuff
+  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr
+      sub_thruster_torque_inp;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr
+      sub_cmg_torque_inp;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr
+      sub_bias_torque_control;
+  rclcpp::Subscription<std_msgs::msg::Float32MultiArray>::SharedPtr
+      sub_bias_thruster_control;
   rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr sub_t_fwd_sim;
-  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr sub_angvel_overwrite;
-  rclcpp::Subscription<geometry_msgs::msg::Quaternion>::SharedPtr sub_attitude_overwrite;
+  rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr
+      sub_angvel_overwrite;
+  rclcpp::Subscription<geometry_msgs::msg::Quaternion>::SharedPtr
+      sub_attitude_overwrite;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr urdf_sub_;
   bool received_ = false;
 
-  rclcpp::Publisher<geometry_msgs::msg::Quaternion>::SharedPtr pub_attitude_LVLH;
+  rclcpp::TimerBase::SharedPtr attitude_timer_;
+
+  rclcpp::Publisher<geometry_msgs::msg::Quaternion>::SharedPtr
+      pub_attitude_LVLH;
   rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr pub_angvel_body;
   rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr pub_cmg_del;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_pose_all;
   rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr pub_cmg_h;
   rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr pub_ang_acc;
-  // rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr pub_pose_marker;
+  // rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr
+  // pub_pose_marker;
   geometry_msgs::msg::Quaternion attitude_LVLH;
   geometry_msgs::msg::Vector3 angvel_body;
   geometry_msgs::msg::Vector3 ang_acc;
@@ -222,22 +280,21 @@ private:
   rclcpp::TimerBase::SharedPtr timer_unload_;
   rclcpp_action::Client<unloading>::SharedPtr unloading_client_;
 
-  //define parameters for dynamics
-  //TODO: Jall, dynamic change of J,
-  // as well as CoG offset issue is a big TODO
+  // define parameters for dynamics
+  // TODO: Jall, dynamic change of J,
+  //  as well as CoG offset issue is a big TODO
   Eigen::Matrix3d J123;
   Eigen::Matrix3d J123inv;
-  double mu;                 ///< Gravitational parameter (m^3/s^2)
-  double rOrbit;             ///< Nominal orbit radius (m)
+  double mu;     ///< Gravitational parameter (m^3/s^2)
+  double rOrbit; ///< Nominal orbit radius (m)
 
-
-  Eigen::Quaterniond attcur;   // pose
-  Eigen::Quaterniond attprv;   // pose
-  tf2::Vector3 omebcur;   //rad/sec, angular velocity of body frame
-  tf2::Vector3 omebprv;   //rad/sec, angular velocity of body frame
-  tf2::Vector3 omedotbcur;   //rad/sec^2 angular acc of body frame
-  tf2::Vector3 omedotbprv;   //rad/sec^2 angular acc of body frame
-  Eigen::Vector4d deltacur;   //rad, each CMG angle around torque axis
+  Eigen::Quaterniond attcur; // pose
+  Eigen::Quaterniond attprv; // pose
+  tf2::Vector3 omebcur;      // rad/sec, angular velocity of body frame
+  tf2::Vector3 omebprv;      // rad/sec, angular velocity of body frame
+  tf2::Vector3 omedotbcur;   // rad/sec^2 angular acc of body frame
+  tf2::Vector3 omedotbprv;   // rad/sec^2 angular acc of body frame
+  Eigen::Vector4d deltacur;  // rad, each CMG angle around torque axis
   Eigen::VectorXd bias_thruster_input;
 
   tf2::Vector3 tau_ctlcmgcur;
@@ -246,14 +303,13 @@ private:
   tf2::Vector3 tau_allcur;
   tf2::Vector3 tau_ctlbiascur;
 
+  // define parameters for simulation
+  double Tstep_rk; // in seconds
+  double Ttorque_; // same as T_callback
+  // int Nstep; // number of steps for simulation, Ttorque_/Tstep_
 
-  //define parameters for simulation
-  double Tstep_rk;   // in seconds
-  double Ttorque_;   //same as T_callback
-  //int Nstep; // number of steps for simulation, Ttorque_/Tstep_
-
-  int N2disp;   // publish rate: Npublish * Ttorque
-  int i2disp;   // index for i2disp
+  int N2disp; // publish rate: Npublish * Ttorque
+  int i2disp; // index for i2disp
   double Tpubatt_;
   Eigen::Vector3d H_th;
   rclcpp_action::ClientGoalHandle<unloading>::SharedPtr goal_handle;
@@ -261,54 +317,50 @@ private:
   rclcpp_action::Client<unloading>::SendGoalOptions send_goal_options;
   // rclcpp_action::Client<unloading>::CancelGoalOptions cancel_goal_options;
 
-  bool should_pub_att;   // true then publish attitude for display purpose
+  bool should_pub_att; // true then publish attitude for display purpose
 
-  std::atomic<bool> unload = false;   // Flag to indicate if unloading is required
+  std::atomic<bool> unload = false; // Flag to indicate if unloading is required
   std::atomic<bool> prevUnload = false;
 
   ThrusterMatrix thrusterMat;
 
-  void goal_response_callback(
-    const GoalHandleUnloading::SharedPtr & future)
-  {
+  void goal_response_callback(const GoalHandleUnloading::SharedPtr &future) {
     goal_handle = future;
     if (!goal_handle) {
-      RCLCPP_ERROR(this->get_logger(), "Goal was rejected by the unloading server");
+      RCLCPP_ERROR(this->get_logger(),
+                   "Goal was rejected by the unloading server");
     } else {
       RCLCPP_INFO(this->get_logger(), "Goal accepted by the unloading server");
     }
   }
 
-  void feedback_callback(
-    GoalHandleUnloading::SharedPtr,
-    const std::shared_ptr<const unloading::Feedback> feedback)
-  {
+  void
+  feedback_callback(GoalHandleUnloading::SharedPtr,
+                    const std::shared_ptr<const unloading::Feedback> feedback) {
     RCLCPP_INFO(this->get_logger(), "Feedback received: %f", feedback->rem);
   }
 
-  void result_callback(const GoalHandleUnloading::WrappedResult & result)
-  {
+  void result_callback(const GoalHandleUnloading::WrappedResult &result) {
     switch (result.code) {
-      case rclcpp_action::ResultCode::SUCCEEDED:
-        RCLCPP_INFO(this->get_logger(), "Successfully Unloaded");
-        break;
-      case rclcpp_action::ResultCode::ABORTED:
-        RCLCPP_ERROR(this->get_logger(), "Unloading action aborted");
-        break;
-      case rclcpp_action::ResultCode::CANCELED:
-        RCLCPP_WARN(this->get_logger(), "Action canceled");
-        break;
-      default:
-        RCLCPP_ERROR(this->get_logger(), "Unknown action result code");
-        break;
+    case rclcpp_action::ResultCode::SUCCEEDED:
+      RCLCPP_INFO(this->get_logger(), "Successfully Unloaded");
+      break;
+    case rclcpp_action::ResultCode::ABORTED:
+      RCLCPP_ERROR(this->get_logger(), "Unloading action aborted");
+      break;
+    case rclcpp_action::ResultCode::CANCELED:
+      RCLCPP_WARN(this->get_logger(), "Action canceled");
+      break;
+    default:
+      RCLCPP_ERROR(this->get_logger(), "Unknown action result code");
+      break;
     }
   }
 
-
-  //utility function
-  void printq(const Eigen::Quaterniond & q)
-  {
-    Eigen::Matrix<double, 3, 3> m = q.toRotationMatrix();   //r11,r21,r31 show where original x axis points
+  // utility function
+  void printq(const Eigen::Quaterniond &q) {
+    Eigen::Matrix<double, 3, 3> m =
+        q.toRotationMatrix(); // r11,r21,r31 show where original x axis points
     double r11 = m(0, 0), r12 = m(0, 1), r13 = m(0, 2);
     double r21 = m(1, 0), r22 = m(1, 1), r23 = m(1, 2);
     double r31 = m(2, 0), r32 = m(2, 1), r33 = m(2, 2);
@@ -317,14 +369,15 @@ private:
     RCLCPP_INFO(this->get_logger(), "  [%+.4f, %+.4f, %+.4f]", r31, r32, r33);
   }
 
-  //utility function
-  void publish_attitude(Eigen::Quaterniond att)
-  {
+  // utility function
+  void publish_attitude(Eigen::Quaterniond att) {
     attitude_LVLH.x = att.x();
     attitude_LVLH.y = att.y();
     attitude_LVLH.z = att.z();
     attitude_LVLH.w = att.w();
-    pub_attitude_LVLH->publish(attitude_LVLH);       //rclcpp::Publisher<geometry_msgs::msg::Quaternion>::SharedPtr pub_attitude_LVLH;
+    pub_attitude_LVLH->publish(
+        attitude_LVLH); // rclcpp::Publisher<geometry_msgs::msg::Quaternion>::SharedPtr
+                        // pub_attitude_LVLH;
 
     auto message = geometry_msgs::msg::PoseStamped();
     message.header.stamp = this->get_clock()->now();
@@ -333,12 +386,14 @@ private:
     message.pose.orientation.y = att.y();
     message.pose.orientation.z = att.z();
     message.pose.orientation.w = att.w();
-    pub_pose_all->publish(message);        //rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_pose_all;
+    pub_pose_all->publish(
+        message); // rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr
+                  // pub_pose_all;
 
     geometry_msgs::msg::TransformStamped transform_stamped;
     transform_stamped.header.stamp = this->get_clock()->now();
     transform_stamped.header.frame_id = "world";
-    //transform_stamped.child_frame_id = "pose_marker";
+    // transform_stamped.child_frame_id = "pose_marker";
     transform_stamped.child_frame_id = "base_link";
 
     transform_stamped.transform.translation.x = 0.0;
@@ -353,13 +408,12 @@ private:
   }
 
   // utility function to calculate total angular momentum
-  Eigen::Vector3d compute_h(const Eigen::Vector4d & delta)
-  {
+  Eigen::Vector3d compute_h(const Eigen::Vector4d &delta) {
     Eigen::Vector3d h;
-    const casadi_real * deltaI[4] = {&delta(0), &delta(1), &delta(2), &delta(3)};
+    const casadi_real *deltaI[4] = {&delta(0), &delta(1), &delta(2), &delta(3)};
 
     std::vector<casadi_real> h_out(3, 0.0);
-    casadi_real * resH[1] = {h_out.data()};
+    casadi_real *resH[1] = {h_out.data()};
 
     casadi_int iwH[70] = {0};
     casadi_real wH[70] = {0};
@@ -367,19 +421,18 @@ private:
 
     hFunc(deltaI, resH, iwH, wH, mem);
 
-    casadi_real * hArr = &h_out[0];
+    casadi_real *hArr = &h_out[0];
     h = Eigen::Map<Eigen::Vector3d>(hArr);
     return h;
   }
 
-  //utility function to calculate pseudo-inverse matrix
-  Eigen::Matrix<double, 4, 3> pseudoinverse(Eigen::Vector4d delta)
-  {
+  // utility function to calculate pseudo-inverse matrix
+  Eigen::Matrix<double, 4, 3> pseudoinverse(Eigen::Vector4d delta) {
     Eigen::Matrix<double, 4, 3> pseudoinv;
-    const casadi_real * deltaI[4] = {&delta(0), &delta(1), &delta(2), &delta(3)};
+    const casadi_real *deltaI[4] = {&delta(0), &delta(1), &delta(2), &delta(3)};
 
     std::vector<casadi_real> Inv(12, 0.0);
-    casadi_real * resInv[1] = {Inv.data()};
+    casadi_real *resInv[1] = {Inv.data()};
 
     casadi_int iwInv[70] = {0};
     casadi_real wInv[70] = {0};
@@ -387,14 +440,13 @@ private:
 
     pseudoInvFunc(deltaI, resInv, iwInv, wInv, mem);
 
-    casadi_real * invArr = &Inv[0];
+    casadi_real *invArr = &Inv[0];
     pseudoinv = Eigen::Map<Eigen::Matrix<double, 4, 3>>(invArr);
 
     return pseudoinv;
   }
 
-  void callback_timer_pub_att()
-  {
+  void callback_timer_pub_att() {
     if (!should_pub_att) {
       return;
     }
@@ -408,15 +460,14 @@ private:
 
     cmg_del.data = {deltacur(0), deltacur(1), deltacur(2), deltacur(3)};
     pub_cmg_del->publish(cmg_del);
-
   }
 
-  void callback_timer_pub_acc()
-  {
+  void callback_timer_pub_acc() {
     // Calculate angular acceleration in body frame
     Eigen::Vector3d tau_allcure(tau_allcur.x(), tau_allcur.y(), tau_allcur.z());
     // for current
-    Eigen::Vector3d tau_inp(tau_ctlcmgcur.x(), tau_ctlcmgcur.y(), tau_ctlcmgcur.z());
+    Eigen::Vector3d tau_inp(tau_ctlcmgcur.x(), tau_ctlcmgcur.y(),
+                            tau_ctlcmgcur.z());
     Eigen::Vector3d omega_inp(omebcur.x(), omebcur.y(), omebcur.z());
 
     Eigen::Vector3d rhs1 = J123 * omega_inp;
@@ -430,8 +481,7 @@ private:
     pub_ang_acc->publish(ang_acc);
   }
 
-  void callback_timer_pub_unload()
-  {
+  void callback_timer_pub_unload() {
     Eigen::Vector3d h = compute_h(deltacur);
     cmg_h.x = h.x();
     cmg_h.y = h.y();
@@ -440,7 +490,8 @@ private:
 
     unload = checkCMGThresh(h);
     if (unload && !prevUnload) {
-      RCLCPP_INFO(this->get_logger(), "CMG threshold exceeded, unloading initiated.");
+      RCLCPP_INFO(this->get_logger(),
+                  "CMG threshold exceeded, unloading initiated.");
       goal_msg.unload = unload;
       unloading_client_->async_send_goal(goal_msg, send_goal_options);
     } else if (!unload && prevUnload) {
@@ -450,22 +501,22 @@ private:
     prevUnload = unload.load();
   }
 
-  //forcing the simulation forward
-  void callback_t_fwd_sim(const std_msgs::msg::Float64::SharedPtr msg)
-  {
+  // forcing the simulation forward
+  void callback_t_fwd_sim(const std_msgs::msg::Float64::SharedPtr msg) {
     double t_sim2forward = msg->data;
     RCLCPP_INFO(this->get_logger(), "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
     RCLCPP_INFO(this->get_logger(), "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
     RCLCPP_INFO(this->get_logger(), "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-    RCLCPP_INFO(this->get_logger(), "forwarding for %f mins!!!!", t_sim2forward / 60.0);
+    RCLCPP_INFO(this->get_logger(), "forwarding for %f mins!!!!",
+                t_sim2forward / 60.0);
     RCLCPP_INFO(this->get_logger(), "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
     RCLCPP_INFO(this->get_logger(), "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
     RCLCPP_INFO(this->get_logger(), "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
-    //int divide = 64;
+    // int divide = 64;
     int divide = (int)(t_sim2forward / Ttorque_);
     for (int ii = 0; ii < divide; ii++) {
-      //forward_attitude_dynamics(t_sim/(double)(divide));
+      // forward_attitude_dynamics(t_sim/(double)(divide));
       forward_attitude_dynamics(Ttorque_);
       if (ii % 60 == 1) {
         publish_attitude(attcur);
@@ -476,12 +527,9 @@ private:
     RCLCPP_INFO(this->get_logger(), "forwarded");
   }
 
-
-  //utility function
-  tf2::Quaternion stepupdate_attitude(
-    const tf2::Quaternion & qi, const tf2::Vector3 & omeb,
-    double dt)
-  {
+  // utility function
+  tf2::Quaternion stepupdate_attitude(const tf2::Quaternion &qi,
+                                      const tf2::Vector3 &omeb, double dt) {
     // Step 1: Calculate rotation angle
     double thetab = omeb.length() * dt;
     if (thetab == 0.0) {
@@ -494,12 +542,8 @@ private:
     // Step 3: Calculate rotation quaternion in the body frame
     double half_thetab = thetab / 2.0;
     double sin_half_thetab = std::sin(half_thetab);
-    tf2::Quaternion q_omegab(
-      u.x() * sin_half_thetab,
-      u.y() * sin_half_thetab,
-      u.z() * sin_half_thetab,
-      std::cos(half_thetab)
-    );
+    tf2::Quaternion q_omegab(u.x() * sin_half_thetab, u.y() * sin_half_thetab,
+                             u.z() * sin_half_thetab, std::cos(half_thetab));
     q_omegab = q_omegab.normalize();
 
     // Step 4: Transform q_omegab to world frame
@@ -511,17 +555,15 @@ private:
     return qf;
   }
 
-  bool checkCMGThresh(const Eigen::Vector3d & hState)
-  {
+  bool checkCMGThresh(const Eigen::Vector3d &hState) {
     bool exceed = (std::abs(hState.x()) > H_th.x()) ||
-      (std::abs(hState.y()) > H_th.y()) ||
-      (std::abs(hState.z()) > H_th.z());
+                  (std::abs(hState.y()) > H_th.y()) ||
+                  (std::abs(hState.z()) > H_th.z());
 
     return exceed;
   }
 
-  void forward_attitude_dynamics(double Tfwd_sec)
-  {
+  void forward_attitude_dynamics(double Tfwd_sec) {
     double thetab = omebcur.length();
     if (0.5 < thetab) {
       Tstep_rk = 0.001;
@@ -539,7 +581,8 @@ private:
 
     for (int istep = 0; istep < Nstep; istep++) {
       // for current
-      Eigen::Vector3d tau_inp(tau_ctlcmgcur.x(), tau_ctlcmgcur.y(), tau_ctlcmgcur.z());
+      Eigen::Vector3d tau_inp(tau_ctlcmgcur.x(), tau_ctlcmgcur.y(),
+                              tau_ctlcmgcur.z());
       Eigen::Vector3d omega_k1(omebcur.x(), omebcur.y(), omebcur.z());
       Eigen::Quaterniond att_k1 = attcur;
       Eigen::Vector4d delta_k1 = deltacur;
@@ -550,8 +593,10 @@ private:
       Eigen::Vector3d omega_dot_k1 = J123inv * tau_eff;
       Eigen::Matrix<double, 4, 3> pseudoInv1 = pseudoinverse(delta_k1);
       Eigen::Vector3d h1 = compute_h(delta_k1);
-      Eigen::Vector4d delta_dot_k1 = pseudoInv1 * (-(tau_inp + omega_k1.cross(h1)));
-      Eigen::Quaterniond omega_quat_k1(0, omega_k1.x(), omega_k1.y(), omega_k1.z());
+      Eigen::Vector4d delta_dot_k1 =
+          pseudoInv1 * (-(tau_inp + omega_k1.cross(h1)));
+      Eigen::Quaterniond omega_quat_k1(0, omega_k1.x(), omega_k1.y(),
+                                       omega_k1.z());
       Eigen::Quaterniond att_dot_k1;
       att_dot_k1.coeffs() = (omega_quat_k1 * att_k1).coeffs() * 0.5;
 
@@ -560,12 +605,15 @@ private:
       Eigen::Quaterniond att_k2 = att_k1;
       att_k2.coeffs() += 0.5 * Tstep_rk * att_dot_k1.coeffs();
       Eigen::Vector3d rhs2 = J123 * omega_k2;
-      Eigen::Vector3d omega_dot_k2 = J123inv * (tau_allcure - omega_k2.cross(rhs2));
+      Eigen::Vector3d omega_dot_k2 =
+          J123inv * (tau_allcure - omega_k2.cross(rhs2));
       Eigen::Vector4d delta_k2 = delta_k1 + 0.5 * Tstep_rk * delta_dot_k1;
       Eigen::Matrix<double, 4, 3> pseudoInv2 = pseudoinverse(delta_k2);
       Eigen::Vector3d h2 = compute_h(delta_k2);
-      Eigen::Vector4d delta_dot_k2 = pseudoInv2 * (-(tau_inp + omega_k2.cross(h2)));
-      Eigen::Quaterniond omega_quat_k2(0, omega_k2.x(), omega_k2.y(), omega_k2.z());
+      Eigen::Vector4d delta_dot_k2 =
+          pseudoInv2 * (-(tau_inp + omega_k2.cross(h2)));
+      Eigen::Quaterniond omega_quat_k2(0, omega_k2.x(), omega_k2.y(),
+                                       omega_k2.z());
       Eigen::Quaterniond att_dot_k2;
       att_dot_k2.coeffs() = (omega_quat_k2 * att_k2).coeffs() * 0.5;
 
@@ -574,12 +622,15 @@ private:
       Eigen::Quaterniond att_k3 = att_k1;
       att_k3.coeffs() += 0.5 * Tstep_rk * att_dot_k2.coeffs();
       Eigen::Vector3d rhs3 = J123 * omega_k3;
-      Eigen::Vector3d omega_dot_k3 = J123inv * (tau_allcure - omega_k3.cross(rhs3));
+      Eigen::Vector3d omega_dot_k3 =
+          J123inv * (tau_allcure - omega_k3.cross(rhs3));
       Eigen::Vector4d delta_k3 = delta_k1 + 0.5 * Tstep_rk * delta_dot_k2;
       Eigen::Matrix<double, 4, 3> pseudoInv3 = pseudoinverse(delta_k3);
       Eigen::Vector3d h3 = compute_h(delta_k3);
-      Eigen::Vector4d delta_dot_k3 = pseudoInv3 * (-(tau_inp + omega_k3.cross(h3)));
-      Eigen::Quaterniond omega_quat_k3(0, omega_k3.x(), omega_k3.y(), omega_k3.z());
+      Eigen::Vector4d delta_dot_k3 =
+          pseudoInv3 * (-(tau_inp + omega_k3.cross(h3)));
+      Eigen::Quaterniond omega_quat_k3(0, omega_k3.x(), omega_k3.y(),
+                                       omega_k3.z());
       Eigen::Quaterniond att_dot_k3;
       att_dot_k3.coeffs() = (omega_quat_k3 * att_k3).coeffs() * 0.5;
 
@@ -588,57 +639,58 @@ private:
       Eigen::Quaterniond att_k4 = att_k1;
       att_k4.coeffs() += Tstep_rk * att_dot_k3.coeffs();
       Eigen::Vector3d rhs4 = J123 * omega_k4;
-      Eigen::Vector3d omega_dot_k4 = J123inv * (tau_allcure - omega_k4.cross(rhs4));
+      Eigen::Vector3d omega_dot_k4 =
+          J123inv * (tau_allcure - omega_k4.cross(rhs4));
       Eigen::Vector4d delta_k4 = delta_k1 + Tstep_rk * delta_dot_k3;
       Eigen::Matrix<double, 4, 3> pseudoInv4 = pseudoinverse(delta_k4);
       Eigen::Vector3d h4 = compute_h(delta_k4);
-      Eigen::Vector4d delta_dot_k4 = pseudoInv4 * (-(tau_inp + omega_k4.cross(h4)));
-      Eigen::Quaterniond omega_quat_k4(0, omega_k4.x(), omega_k4.y(), omega_k4.z());
+      Eigen::Vector4d delta_dot_k4 =
+          pseudoInv4 * (-(tau_inp + omega_k4.cross(h4)));
+      Eigen::Quaterniond omega_quat_k4(0, omega_k4.x(), omega_k4.y(),
+                                       omega_k4.z());
       Eigen::Quaterniond att_dot_k4;
       att_dot_k4.coeffs() = (omega_quat_k4 * att_k4).coeffs() * 0.5;
 
       // RK4
-      omega_k1 += (Tstep_rk / 6.0) *
-        (omega_dot_k1 + 2 * omega_dot_k2 + 2 * omega_dot_k3 + omega_dot_k4);
-      delta_k1 += (Tstep_rk / 6.0) *
-        (delta_dot_k1 + 2 * delta_dot_k2 + 2 * delta_dot_k3 + delta_dot_k4);
-      att_k1.coeffs() += (Tstep_rk / 6.0) *
-        (att_dot_k1.coeffs() + 2 * att_dot_k2.coeffs() + 2 * att_dot_k3.coeffs() +
-        att_dot_k4.coeffs());
+      omega_k1 += (Tstep_rk / 6.0) * (omega_dot_k1 + 2 * omega_dot_k2 +
+                                      2 * omega_dot_k3 + omega_dot_k4);
+      delta_k1 += (Tstep_rk / 6.0) * (delta_dot_k1 + 2 * delta_dot_k2 +
+                                      2 * delta_dot_k3 + delta_dot_k4);
+      att_k1.coeffs() +=
+          (Tstep_rk / 6.0) * (att_dot_k1.coeffs() + 2 * att_dot_k2.coeffs() +
+                              2 * att_dot_k3.coeffs() + att_dot_k4.coeffs());
       att_k1.normalize();
 
       omebcur.setValue(omega_k1.x(), omega_k1.y(), omega_k1.z());
       deltacur = delta_k1;
       attcur = att_k1;
-
     }
   }
 
-
-  void callback_attitude_overwrite(const geometry_msgs::msg::Quaternion::SharedPtr msg)
-  {
-    //tf2::Quaternion attcur;
+  void callback_attitude_overwrite(
+      const geometry_msgs::msg::Quaternion::SharedPtr msg) {
+    // tf2::Quaternion attcur;
     attcur = Eigen::Quaterniond(msg->w, msg->x, msg->y, msg->z);
   }
 
-  void callback_angvel_overwrite(const geometry_msgs::msg::Vector3::SharedPtr msg)
-  {
+  void
+  callback_angvel_overwrite(const geometry_msgs::msg::Vector3::SharedPtr msg) {
     omebcur.setValue(msg->x, msg->y, msg->z);
   }
 
   /**
    * @brief Computes the gravity gradient torque.
    *
-  * This function calculates the gravity gradient torque acting on the spacecraft
-  * based on its attitude state and inertia properties.
-  *
-  * @param x The current attitude state.
-  * @param par The spacecraft parameters including inertia and gravitational parameters.
-  * @return Eigen::Vector3d The gravity gradient torque vector.
-  */
-  tf2::Vector3 gravityGradT()
-  {
-    //compute phi(roll) and theta(pitch) from attcur
+   * This function calculates the gravity gradient torque acting on the
+   * spacecraft based on its attitude state and inertia properties.
+   *
+   * @param x The current attitude state.
+   * @param par The spacecraft parameters including inertia and gravitational
+   * parameters.
+   * @return Eigen::Vector3d The gravity gradient torque vector.
+   */
+  tf2::Vector3 gravityGradT() {
+    // compute phi(roll) and theta(pitch) from attcur
     double roll, pitch, yaw;
 
     Eigen::Vector3d angles = attcur.toRotationMatrix().eulerAngles(2, 1, 0);
@@ -662,92 +714,93 @@ private:
     return 3.0 * n * n * tf2::Vector3(T1, T2, T3);
   }
 
-
-  //receiving control torque input
-  void callback_cmg_inp(const geometry_msgs::msg::Vector3::SharedPtr msg)
-  {
+  // receiving control torque input
+  void
+  callback_cmg_torque_inp(const geometry_msgs::msg::Vector3::SharedPtr msg) {
     tau_ctlcmgcur.setValue(msg->x, msg->y, msg->z);
-
   }
 
-  void callback_bias_inp(const geometry_msgs::msg::Vector3::SharedPtr msg)
-  {
+  void callback_thruster_torque_inp(
+      const geometry_msgs::msg::Vector3::SharedPtr msg) {
+    tau_ctlthrcur.setValue(msg->x, msg->y, msg->z);
+  }
+
+  void callback_bias_inp(const geometry_msgs::msg::Vector3::SharedPtr msg) {
     tau_ctlbiascur.setValue(msg->x, msg->y, msg->z);
   }
 
-  void callback_bias_thruster_inp(const std_msgs::msg::Float32MultiArray::SharedPtr msg)
-  {
-    // if(msg->data.size() != 12){
-    //     RCLCPP_ERROR(this->get_logger(), "Bias thruster input must have 12 values, received %zu", msg->data.size());
-    //     return;
-    // }
+  void callback_bias_thruster_inp(
+      const std_msgs::msg::Float32MultiArray::SharedPtr msg) {
+
     size_t idx = 0;
     bias_thruster_input.resize(msg->data.size());
-    for (auto & value : msg->data) {
+    for (auto &value : msg->data) {
       if (std::isnan(value)) {
-        RCLCPP_ERROR(this->get_logger(), "Received NaN value in bias thruster input");
+        RCLCPP_ERROR(this->get_logger(),
+                     "Received NaN value in bias thruster input");
         return;
       }
       bias_thruster_input(idx) = value;
       ++idx;
     }
-
   }
 
-  void callback_attitude_dynamics(const geometry_msgs::msg::Vector3::SharedPtr msg)
-  {
+  void timer_callback_attitude_dynamics() {
     should_pub_att = true;
-    tau_ctlthrcur.setValue(msg->x, msg->y, msg->z);
+    // tau_ctlthrcur.setValue(msg->x, msg->y, msg->z);
 
-    //TODO: Currently we assume only gravity gradient torque
+    // TODO: Currently we assume only gravity gradient torque
     tau_extgracur = gravityGradT();
 
+    /*
     Eigen::Vector3d tau_ctlbiascur_eigen;
     if (thrusterMat.isReady()) {
       thrusterMat.thrusterToBody(bias_thruster_input, tau_ctlbiascur_eigen);
     } else {
       tau_ctlbiascur_eigen = Eigen::Vector3d::Zero();
     }
-
-    tau_ctlbiascur.setValue(
+       tau_ctlbiascur.setValue(
       tau_ctlbiascur_eigen.x(),
       tau_ctlbiascur_eigen.y(), tau_ctlbiascur_eigen.z());
 
     tau_allcur = tau_ctlcmgcur + tau_ctlthrcur + tau_extgracur + tau_ctlbiascur;
+    RCLCPP_WARN(this->get_logger(),
+      "tau_ctlbiascur: %f %f
+    %f\n",tau_ctlbiascur_eigen.x(),tau_ctlbiascur_eigen.y(),tau_ctlbiascur_eigen.z());
 
-    //compute attitude update
-    forward_attitude_dynamics(Ttorque_);     //Ttorque_ is simulation time period
+    */
+
+    tau_allcur = tau_ctlcmgcur + tau_ctlthrcur + tau_extgracur;
+
+    // compute attitude update
+    forward_attitude_dynamics(Ttorque_); // Ttorque_ is simulation time period
 
     //
     i2disp++;
     if (N2disp <= i2disp) {
       i2disp = 0;
-      RCLCPP_INFO(
-        this->get_logger(), "Received input: %f %f %f",
-        msg->x, msg->y, msg->z);
-      RCLCPP_INFO(
-        this->get_logger(), " Angular velocity: %f %f %f (deg/sec)",
-        omebcur.x() / M_PI * 180.0, omebcur.y() / M_PI * 180.0, omebcur.z() / M_PI * 180.0);
+      RCLCPP_INFO(this->get_logger(), "Received cmg input: %f %f %f",
+                  tau_ctlcmgcur.x(), tau_ctlcmgcur.y(), tau_ctlcmgcur.z());
+      RCLCPP_INFO(this->get_logger(), "Received thr input: %f %f %f",
+                  tau_ctlthrcur.x(), tau_ctlthrcur.y(), tau_ctlthrcur.z());
+      RCLCPP_INFO(this->get_logger(), " Angular velocity: %f %f %f (deg/sec)",
+                  omebcur.x() / M_PI * 180.0, omebcur.y() / M_PI * 180.0,
+                  omebcur.z() / M_PI * 180.0);
       printq(attcur);
-      RCLCPP_INFO(
-        this->get_logger(), " CMG angles: %f %f %f %f(raads)",
-        deltacur(0), deltacur(1), deltacur(2), deltacur(3));
-
+      RCLCPP_INFO(this->get_logger(), " CMG angles: %f %f %f %f(raads)",
+                  deltacur(0), deltacur(1), deltacur(2), deltacur(3));
     }
   }
-
 };
 
-double get_time_double(rclcpp::Node::SharedPtr node)
-{
+double get_time_double(rclcpp::Node::SharedPtr node) {
   rclcpp::Clock::SharedPtr clock = node->get_clock();
   rclcpp::Time tclock = clock->now();
-  return (double)(tclock.seconds()) + (double)(tclock.nanoseconds()) * 0.001 * 0.001 * 0.001;
+  return (double)(tclock.seconds()) +
+         (double)(tclock.nanoseconds()) * 0.001 * 0.001 * 0.001;
 }
 
-
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions options;
   options.automatically_declare_parameters_from_overrides(true);
@@ -755,7 +808,6 @@ int main(int argc, char * argv[])
   rclcpp::spin(node);
 
   rclcpp::shutdown();
-
 
   return 0;
 }

--- a/space_station_gnc/src/thruster_matrix.cpp
+++ b/space_station_gnc/src/thruster_matrix.cpp
@@ -13,22 +13,28 @@
 // limitations under the License.
 
 #include "space_station_gnc/thruster_matrix.hpp"
+#include <algorithm>
 #include <iostream>
-#include <stdexcept>
-#include <algorithm> 
-#include <unordered_set>
+#include <rclcpp/rclcpp.hpp>
 #include <sstream>
+#include <stdexcept>
+#include <unordered_set>
 
 // ===========================
 // Helpers (file-local)
 // ===========================
 
-namespace
-{
+namespace {
+
+// Put this at file scope (top of thruster_matrix.cpp), outside any namespace or
+// inside anonymous namespace
+static inline Eigen::Vector3d nozzle_local_axis() {
+  // By convention: child link +X is the nozzle axis.
+  return Eigen::Vector3d::UnitX();
+}
 
 // Convert URDF pose (RPY + translation) to Eigen Isometry
-inline Eigen::Isometry3d poseToIso(const urdf::Pose & p)
-{
+inline Eigen::Isometry3d poseToIso(const urdf::Pose &p) {
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   T.translation() = Eigen::Vector3d(p.position.x, p.position.y, p.position.z);
   double roll = 0.0, pitch = 0.0, yaw = 0.0;
@@ -42,25 +48,26 @@ inline Eigen::Isometry3d poseToIso(const urdf::Pose & p)
 
 // DFS over the URDF tree to compute base->link and base->joint transforms.
 // Base is the URDF root link frame. Joint transform is at the joint origin.
-void buildTransformsDFS(
-  const urdf::ModelInterfaceSharedPtr & model,
-  const urdf::LinkConstSharedPtr & link,
-  const Eigen::Isometry3d & T_parent,
-  std::map<std::string, Eigen::Isometry3d> & T_map_link,
-  std::map<std::string, Eigen::Isometry3d> & T_map_joint)
-{
+void buildTransformsDFS(const urdf::ModelInterfaceSharedPtr &model,
+                        const urdf::LinkConstSharedPtr &link,
+                        const Eigen::Isometry3d &T_parent,
+                        std::map<std::string, Eigen::Isometry3d> &T_map_link,
+                        std::map<std::string, Eigen::Isometry3d> &T_map_joint) {
   T_map_link[link->name] = T_parent;
 
-  for (const auto & j : link->child_joints) {
-    if (!j) continue;
-    const Eigen::Isometry3d T_pj = poseToIso(j->parent_to_joint_origin_transform);
+  for (const auto &j : link->child_joints) {
+    if (!j)
+      continue;
+    const Eigen::Isometry3d T_pj =
+        poseToIso(j->parent_to_joint_origin_transform);
     const Eigen::Isometry3d T_base_joint = T_parent * T_pj;
     T_map_joint[j->name] = T_base_joint;
 
     urdf::LinkConstSharedPtr child_link = model->getLink(j->child_link_name);
 
     if (child_link) {
-      buildTransformsDFS(model, child_link, T_base_joint, T_map_link, T_map_joint);
+      buildTransformsDFS(model, child_link, T_base_joint, T_map_link,
+                         T_map_joint);
     }
   }
 }
@@ -68,13 +75,14 @@ void buildTransformsDFS(
 // Build the ordered list of thruster names by scanning joints_ in map order.
 // Column ordering in all matrices follows this vector.
 inline std::vector<std::string>
-orderedThrusterNames(const urdf::ModelInterfaceSharedPtr & model, const URDFUtils & utils)
-{
+orderedThrusterNames(const urdf::ModelInterfaceSharedPtr &model,
+                     const URDFUtils &utils) {
   std::vector<std::string> names;
-  if (!model) return names;
+  if (!model)
+    return names;
   names.reserve(model->joints_.size());
-  for (const auto & kv : model->joints_) {
-    const auto & j = kv.second;
+  for (const auto &kv : model->joints_) {
+    const auto &j = kv.second;
     if (j && utils.isThruster(j->child_link_name)) {
       names.push_back(j->child_link_name);
     }
@@ -84,69 +92,77 @@ orderedThrusterNames(const urdf::ModelInterfaceSharedPtr & model, const URDFUtil
 
 } // namespace
 
-
 //
 // URDFUtils
 //
 
 URDFUtils::URDFUtils() = default;
 
-bool URDFUtils::isThruster(const std::string & name) const
-{
-  if (name.rfind("thruster_", 0) == 0) return true;
-  if (name.rfind("thr_", 0) == 0)      return true;
-  if (name.rfind("th_", 0) == 0)       return true;
+bool URDFUtils::isThruster(const std::string &name) const {
+  if (name.rfind("thruster_", 0) == 0)
+    return true;
+  if (name.rfind("thr_", 0) == 0)
+    return true;
+  if (name.rfind("th_", 0) == 0)
+    return true;
   return false;
 }
 
-std::size_t URDFUtils::getNumAct(const urdf::ModelInterfaceSharedPtr & model) const
-{
+std::size_t
+URDFUtils::getNumAct(const urdf::ModelInterfaceSharedPtr &model) const {
   std::size_t count = 0;
-  for (const auto & kv : model->joints_) {
-    if (isThruster(kv.second->child_link_name)) ++count;
+  for (const auto &kv : model->joints_) {
+    if (isThruster(kv.second->child_link_name))
+      ++count;
   }
-  std::cout <<
-    "=========================================================================================" <<
-    std::endl;
+  std::cout << "==============================================================="
+               "=========================="
+            << std::endl;
   std::cout << "getNumAct: Number of thrusters: " << count << std::endl;
   return count;
 }
 
 Eigen::Matrix<double, 3, Eigen::Dynamic>
-URDFUtils::getThrPos(const urdf::ModelInterfaceSharedPtr & model) const
-{
+URDFUtils::getThrPos(const urdf::ModelInterfaceSharedPtr &model) const {
   std::cout << "URDFUtils::getThrPos called" << std::endl;
-  //std::size_t n = getNumAct(model);
+  // std::size_t n = getNumAct(model);
 
   // 1) count thrusters without calling resize on any fixed-size vector
   std::size_t n = 0;
-  for (const auto & kv : model->joints_) {
-    const auto & j = kv.second;
-    if (j && isThruster(j->child_link_name)) ++n;
+  for (const auto &kv : model->joints_) {
+    const auto &j = kv.second;
+    if (j && isThruster(j->child_link_name))
+      ++n;
   }
 
-
   Eigen::Matrix<double, 3, Eigen::Dynamic> pos(3, n);
-  if (n == 0) {return pos;}
+  if (n == 0) {
+    return pos;
+  }
 
   // Build transforms from URDF root
   std::map<std::string, Eigen::Isometry3d> T_map_link;
   std::map<std::string, Eigen::Isometry3d> T_map_joint;
   const urdf::LinkConstSharedPtr root = model->getRoot();
-  if (!root) {throw std::runtime_error("URDFUtils::getThrPos: URDF root link is null.");}
-  buildTransformsDFS(model, root, Eigen::Isometry3d::Identity(), T_map_link, T_map_joint);
+  if (!root) {
+    throw std::runtime_error("URDFUtils::getThrPos: URDF root link is null.");
+  }
+  buildTransformsDFS(model, root, Eigen::Isometry3d::Identity(), T_map_link,
+                     T_map_joint);
   // Fill in thruster positions following the same joint traversal order
   std::size_t idx = 0;
-  for (const auto & kv : model->joints_) {
+  for (const auto &kv : model->joints_) {
     auto j = kv.second;
-    if (!isThruster(j->child_link_name)) continue;
+    if (!isThruster(j->child_link_name))
+      continue;
 
     auto jt = T_map_joint.find(j->name);
     if (jt == T_map_joint.end()) {
-      // Fallback: use parent_to_joint_origin in parent frame if base transform is missing
+      // Fallback: use parent_to_joint_origin in parent frame if base transform
+      // is missing
       pos.col(idx) << j->parent_to_joint_origin_transform.position.x,
-        j->parent_to_joint_origin_transform.position.y,
-        j->parent_to_joint_origin_transform.position.z;
+          j->parent_to_joint_origin_transform.position.y,
+          j->parent_to_joint_origin_transform.position.z;
     } else {
       pos.col(idx) = jt->second.translation();
     }
@@ -156,41 +172,43 @@ URDFUtils::getThrPos(const urdf::ModelInterfaceSharedPtr & model) const
 }
 
 Eigen::Matrix<double, 3, Eigen::Dynamic>
-URDFUtils::getThrOrient(const urdf::ModelInterfaceSharedPtr & model) const
-{
-std::cout << "URDFUtils::getThrOrient called" << std::endl;
-
-  //std::size_t n = getNumAct(model);
-  // 1) count thrusters without calling resize on any fixed-size vector
+URDFUtils::getThrOrient(const urdf::ModelInterfaceSharedPtr &model) const {
   std::size_t n = 0;
-  for (const auto & kv : model->joints_) {
-    const auto & j = kv.second;
-    if (j && isThruster(j->child_link_name)) ++n;
+  for (const auto &kv : model->joints_) {
+    const auto &j = kv.second;
+    if (j && isThruster(j->child_link_name))
+      ++n;
   }
-
   Eigen::Matrix<double, 3, Eigen::Dynamic> orient(3, n);
-  if (n == 0) return orient;
+  if (n == 0)
+    return orient;
+
+  // Build base->joint transforms
   std::map<std::string, Eigen::Isometry3d> T_map_link;
   std::map<std::string, Eigen::Isometry3d> T_map_joint;
-  urdf::LinkConstSharedPtr root = model->getRoot();
-  if (!root) {throw std::runtime_error("URDFUtils::getThrOrient: URDF root link is null.");}
-  buildTransformsDFS(model, root, Eigen::Isometry3d::Identity(), T_map_link, T_map_joint);
+  const urdf::LinkConstSharedPtr root = model->getRoot();
+  if (!root)
+    throw std::runtime_error(
+        "URDFUtils::getThrOrient: URDF root link is null.");
+  buildTransformsDFS(model, root, Eigen::Isometry3d::Identity(), T_map_link,
+                     T_map_joint);
 
+  // For each thruster joint: orientation = R_base_joint * (+X)
   std::size_t idx = 0;
-  for (const auto & kv : model->joints_) {
-    auto j = kv.second;
-    if (!isThruster(j->child_link_name)) continue;
+  for (const auto &kv : model->joints_) {
+    const auto &j = kv.second;
+    if (!j || !isThruster(j->child_link_name))
+      continue;
 
-    Eigen::Vector3d axis(j->axis.x, j->axis.y, j->axis.z);
-    axis.normalize();
-
-    auto jt = T_map_joint.find(j->name);
-    if (jt == T_map_joint.end()) {
-      // Fallback: rotate only by the joint origin in parent frame
-      const Eigen::Isometry3d Tpj = poseToIso(j->parent_to_joint_origin_transform);
-      orient.col(idx) = (Tpj.linear() * axis).normalized();
+    const auto it = T_map_joint.find(j->name);
+    if (it != T_map_joint.end()) {
+      orient.col(idx) =
+          (it->second.linear() * nozzle_local_axis()).normalized();
     } else {
-      orient.col(idx) = (jt->second.linear() * axis).normalized();
+      // Fallback: use parent_to_joint origin if DFS map missing
+      const Eigen::Isometry3d Tpj =
+          poseToIso(j->parent_to_joint_origin_transform);
+      orient.col(idx) = (Tpj.linear() * nozzle_local_axis()).normalized();
     }
     ++idx;
   }
@@ -198,9 +216,8 @@ std::cout << "URDFUtils::getThrOrient called" << std::endl;
 }
 
 void URDFUtils::printLinks(
-  const std::map<std::string, std::shared_ptr<urdf::Link>> & links) const
-{
-  for (const auto & kv : links) {
+    const std::map<std::string, std::shared_ptr<urdf::Link>> &links) const {
+  for (const auto &kv : links) {
     std::cout << "Link name: " << kv.first << "\n";
   }
 }
@@ -211,34 +228,34 @@ void URDFUtils::printLinks(
 
 ThrusterMatrix::ThrusterMatrix() = default;
 
-void ThrusterMatrix::initialize(const std::string & urdf_xml)
-{
+void ThrusterMatrix::initialize(const std::string &urdf_xml) {
   model_urdf_ = urdf::parseURDF(urdf_xml);
-  if (!model_urdf_) throw std::runtime_error("Failed to parse URDF XML");
+  if (!model_urdf_)
+    throw std::runtime_error("Failed to parse URDF XML");
   loadURDF(model_urdf_);
-
 }
 
-void ThrusterMatrix::loadURDF(const urdf::ModelInterfaceSharedPtr & mdl)
-{
+void ThrusterMatrix::loadURDF(const urdf::ModelInterfaceSharedPtr &mdl) {
   std::cout << "ThrusterMatrix::loadURDF called" << std::endl;
-  if (!mdl) throw std::runtime_error("loadURDF: null model.");
+  if (!mdl)
+    throw std::runtime_error("loadURDF: null model.");
   model_urdf_ = mdl;
   urdf::ModelInterfaceSharedPtr model = model_urdf_;
 
-  // Discover thrusters and derive geometry (column order is orderedThrusterNames)
+  // Discover thrusters and derive geometry (column order is
+  // orderedThrusterNames)
   const auto names = orderedThrusterNames(model, urdfUtils);
   n_thruster = names.size();
 
   thruster_order_.clear();
   thruster_order_.reserve(n_thruster);
-  for (const auto& nm : names) {
+  for (const auto &nm : names) {
     thruster_order_.push_back(nm);
   }
 
   // Derive geometry
-  thruster_position   = urdfUtils.getThrPos(model);      // 3xN
-  thruster_orientation= urdfUtils.getThrOrient(model);   // 3xN
+  thruster_position = urdfUtils.getThrPos(model);       // 3xN
+  thruster_orientation = urdfUtils.getThrOrient(model); // 3xN
   allocation_mat.resize(3, n_thruster);
   inverse_allocation_mat.resize(n_thruster, 3);
 
@@ -251,19 +268,19 @@ void ThrusterMatrix::loadURDF(const urdf::ModelInterfaceSharedPtr & mdl)
     const Eigen::Vector3d f = -thruster_orientation.col(i);
     allocation_mat.col(i) = r.cross(f);
   }
-  inverse_allocation_mat = pseudoInverse<
-      Eigen::Matrix<double, 3, Eigen::Dynamic>,
-      Eigen::Matrix<double, Eigen::Dynamic, 3>>(allocation_mat);
+  inverse_allocation_mat =
+      pseudoInverse<Eigen::Matrix<double, 3, Eigen::Dynamic>,
+                    Eigen::Matrix<double, Eigen::Dynamic, 3>>(allocation_mat);
 
- // Build urdf_thrusters_ map (geometry only at this point)
+  // Build urdf_thrusters_ map (geometry only at this point)
   urdf_thrusters_.clear();
   for (std::size_t i = 0; i < n_thruster; ++i) {
     ThrusterConfig tc;
-    tc.name      = names[i];
-    tc.position  = thruster_position.col(i);
+    tc.name = names[i];
+    tc.position = thruster_position.col(i);
     tc.direction = thruster_orientation.col(i);
     // ratings are default; properties.yaml may override later
-    tc.active    = false;
+    tc.active = false;
     urdf_thrusters_[tc.name] = tc;
   }
 
@@ -271,18 +288,32 @@ void ThrusterMatrix::loadURDF(const urdf::ModelInterfaceSharedPtr & mdl)
   pinv_cache_.clear();
   table_map_.clear();
   table_loaded_ = false;
-  //current_table_.clear();
+  // current_table_.clear();
   current_mode_.clear();
 
   if (n_thruster == 0) {
     std::cerr << "[ThrusterMatrix] Warning: no thrusters found in URDF.\n";
+  } else {
+    double sum_norm = 0.0;
+    for (std::size_t i = 0; i < n_thruster; ++i) {
+      const double n_r = thruster_position.col(i).norm();
+      const double n_f = thruster_orientation.col(i).norm();
+      const double n_rf = allocation_mat.col(i).norm();
+      sum_norm += n_rf;
+      std::cout << "[A-diag] i=" << i << " |r|=" << n_r << " |f|=" << n_f
+                << " |r×f|=" << n_rf << " r=["
+                << thruster_position.col(i).transpose() << "] f=["
+                << thruster_orientation.col(i).transpose() << "]\n";
+    }
+    std::cout << "[A-diag] ||A||_sum=" << sum_norm
+              << " invA=" << inverse_allocation_mat.rows() << "x"
+              << inverse_allocation_mat.cols() << std::endl;
   }
 }
 
-
-void ThrusterMatrix::loadProperties(const std::string & yaml_file)
-{
-  if (!model_urdf_) throw std::runtime_error("loadProperties: URDF must be loaded first.");
+void ThrusterMatrix::loadProperties(const std::string &yaml_file) {
+  if (!model_urdf_)
+    throw std::runtime_error("loadProperties: URDF must be loaded first.");
   YAML::Node root = YAML::LoadFile(yaml_file);
   if (!root || !root["thrusters"]) {
     throw std::runtime_error("loadProperties: Missing 'thrusters' at root.");
@@ -301,15 +332,18 @@ void ThrusterMatrix::loadProperties(const std::string & yaml_file)
       continue;
     }
 
-    if (entry["max_force"])  it_cfg->second.max_force  = entry["max_force"].as<double>();
-    if (entry["isp"])        it_cfg->second.isp        = entry["isp"].as<double>();
-    if (entry["efficiency"]) it_cfg->second.efficiency = entry["efficiency"].as<double>();
+    if (entry["max_force"])
+      it_cfg->second.max_force = entry["max_force"].as<double>();
+    if (entry["isp"])
+      it_cfg->second.isp = entry["isp"].as<double>();
+    if (entry["efficiency"])
+      it_cfg->second.efficiency = entry["efficiency"].as<double>();
   }
 }
 
-void ThrusterMatrix::loadTable(const std::string & yaml_file)
-{
-  if (!model_urdf_) throw std::runtime_error("loadTable: URDF must be loaded first.");
+void ThrusterMatrix::loadTable(const std::string &yaml_file) {
+  if (!model_urdf_)
+    throw std::runtime_error("loadTable: URDF must be loaded first.");
   YAML::Node root = YAML::LoadFile(yaml_file);
   if (!root || !root["tables"]) {
     throw std::runtime_error("loadTable: Missing 'tables' at root.");
@@ -318,7 +352,7 @@ void ThrusterMatrix::loadTable(const std::string & yaml_file)
   // Set of URDF-registered names for validation
   std::unordered_set<std::string> registered;
   registered.reserve(urdf_thrusters_.size());
-  for (const auto & kv : urdf_thrusters_) {
+  for (const auto &kv : urdf_thrusters_) {
     registered.insert(kv.first);
   }
   table_map_.clear();
@@ -326,7 +360,7 @@ void ThrusterMatrix::loadTable(const std::string & yaml_file)
   const YAML::Node tables = root["tables"];
   for (auto it = tables.begin(); it != tables.end(); ++it) {
     const std::string mode_name = it->first.as<std::string>();
-    const YAML::Node  tableNode = it->second;
+    const YAML::Node tableNode = it->second;
 
     ThrusterTable table;
     std::vector<std::string> unknown_in_yaml;
@@ -341,16 +375,18 @@ void ThrusterMatrix::loadTable(const std::string & yaml_file)
       const YAML::Node entry = jt->second;
       ThrusterWeight w;
       w.torque_weight = Eigen::Vector3d::Zero();
-      w.force_weight  = Eigen::Vector3d::Zero();
-      if (entry["torque"] && entry["torque"].IsSequence() && entry["torque"].size() == 3) {
+      w.force_weight = Eigen::Vector3d::Zero();
+      if (entry["torque"] && entry["torque"].IsSequence() &&
+          entry["torque"].size() == 3) {
         w.torque_weight = Eigen::Vector3d(entry["torque"][0].as<double>(),
                                           entry["torque"][1].as<double>(),
                                           entry["torque"][2].as<double>());
       }
-      if (entry["force"] && entry["force"].IsSequence() && entry["force"].size() == 3) {
-        w.force_weight  = Eigen::Vector3d(entry["force"][0].as<double>(),
-                                          entry["force"][1].as<double>(),
-                                          entry["force"][2].as<double>());
+      if (entry["force"] && entry["force"].IsSequence() &&
+          entry["force"].size() == 3) {
+        w.force_weight = Eigen::Vector3d(entry["force"][0].as<double>(),
+                                         entry["force"][1].as<double>(),
+                                         entry["force"][2].as<double>());
       }
       table.emplace(thr_name, w);
     }
@@ -360,7 +396,8 @@ void ThrusterMatrix::loadTable(const std::string & yaml_file)
       oss << "loadTable: mode '" << mode_name
           << "' contains thruster names not in URDF: ";
       for (size_t i = 0; i < unknown_in_yaml.size(); ++i) {
-        if (i) oss << ", ";
+        if (i)
+          oss << ", ";
         oss << unknown_in_yaml[i];
       }
       throw std::runtime_error(oss.str());
@@ -396,14 +433,14 @@ void ThrusterMatrix::loadTable(const std::string & yaml_file)
 #endif
 }
 
-void ThrusterMatrix::setThrusterTable(const std::string & table_name)
-{
+void ThrusterMatrix::setThrusterTable(const std::string &table_name) {
   if (!table_loaded_) {
     throw std::runtime_error("setThrusterTable: No table loaded.");
   }
   auto it = table_map_.find(table_name);
   if (it == table_map_.end()) {
-    throw std::out_of_range("setThrusterTable: Table '" + table_name + "' not found.");
+    throw std::out_of_range("setThrusterTable: Table '" + table_name +
+                            "' not found.");
   }
   current_mode_ = table_name;
 
@@ -415,123 +452,179 @@ void ThrusterMatrix::setThrusterTable(const std::string & table_name)
                 << "' has zero W. Commands will fail.\n";
     } else {
       pinv_cache_[current_mode_] =
-        pseudoInverse<Eigen::Matrix<double, 6, Eigen::Dynamic>,
-                      Eigen::Matrix<double, Eigen::Dynamic, 6>>(W);
+          pseudoInverse<Eigen::Matrix<double, 6, Eigen::Dynamic>,
+                        Eigen::Matrix<double, Eigen::Dynamic, 6>>(W);
     }
   }
+
+  // At the end of setThrusterTable(...) and also after allocation_mat is
+  // rebuilt in setBaseLink():
+  buildDirectMapForMode();
 }
 
-void ThrusterMatrix::setBaseLink(const std::string & link_name)
-{
-  if (!model_urdf_) throw std::runtime_error("setBaseLink: URDF model not initialized.");
+void ThrusterMatrix::setBaseLink(const std::string &link_name) {
+  if (!model_urdf_) {
+    throw std::runtime_error("setBaseLink: URDF model not initialized.");
+  }
   urdf::ModelInterfaceSharedPtr model = model_urdf_;
 
   auto it = model->links_.find(link_name);
   if (it == model->links_.end()) {
-    throw std::out_of_range("setBaseLink: link '" + link_name + "' not found in URDF.");
+    throw std::out_of_range("setBaseLink: link '" + link_name +
+                            "' not found in URDF.");
   }
 
   base_link_name_ = link_name;
 
-
-  // Rebuild transforms relative to this link as new base
+  // Build transforms relative to the new base (this link becomes the DFS root).
   std::map<std::string, Eigen::Isometry3d> T_map_link;
   std::map<std::string, Eigen::Isometry3d> T_map_joint;
-  buildTransformsDFS(model, it->second, Eigen::Isometry3d::Identity(), T_map_link, T_map_joint);
+  buildTransformsDFS(model, it->second, Eigen::Isometry3d::Identity(),
+                     T_map_link, T_map_joint);
 
-  // Update thruster positions/orientations following the same ordering
+  // Column ordering stays consistent with orderedThrusterNames()
   const auto names = orderedThrusterNames(model, urdfUtils);
   if (names.size() != n_thruster) {
-    // Should not happen unless URDF changed at runtime
-    std::cerr << "[ThrusterMatrix] Warning: thruster count changed after setBaseLink.\n";
+    RCLCPP_WARN(
+        rclcpp::get_logger("ThrusterMatrix"),
+        "setBaseLink: thruster count changed after base switch (%zu -> %zu). "
+        "This should not happen unless URDF changed at runtime.",
+        static_cast<size_t>(n_thruster), names.size());
   }
-  printf("before thruster_position %zu x %zu\n", thruster_position.rows(),thruster_position.cols());
+
+  RCLCPP_INFO(rclcpp::get_logger("ThrusterMatrix"),
+              "setBaseLink('%s'): resizing thruster matrices (before %ldx%ld).",
+              link_name.c_str(), static_cast<long>(thruster_position.rows()),
+              static_cast<long>(thruster_position.cols()));
 
   thruster_position.resize(3, n_thruster);
   thruster_orientation.resize(3, n_thruster);
-  printf("after thruster_position %zu x %zu\n", thruster_position.rows(),thruster_position.cols());
 
+  RCLCPP_INFO(rclcpp::get_logger("ThrusterMatrix"),
+              "setBaseLink('%s'): resized thruster matrices (after  %ldx%ld).",
+              link_name.c_str(), static_cast<long>(thruster_position.rows()),
+              static_cast<long>(thruster_position.cols()));
+
+  // Fill positions and orientations using the joint transform's rotation
+  // Orientation convention: child link +X is the nozzle axis in the child
+  // frame. We rotate +X by the base->joint rotation to obtain orientation in
+  // the base frame.
   std::size_t idx = 0;
-  for (const auto & kv : model->joints_) {
-    const auto & j = kv.second;
-    if (!urdfUtils.isThruster(j->child_link_name))   continue;
-    
+  for (const auto &kvj : model->joints_) {
+    const auto &j = kvj.second;
+    if (!j)
+      continue;
+    if (!urdfUtils.isThruster(j->child_link_name))
+      continue;
 
     auto jt = T_map_joint.find(j->name);
     if (jt != T_map_joint.end()) {
-      thruster_position.col(idx) = jt->second.translation();
-      thruster_orientation.col(idx) = (jt->second.linear() *
-        Eigen::Vector3d(j->axis.x, j->axis.y, j->axis.z).normalized()).normalized();
+      const Eigen::Isometry3d &Tbj = jt->second;
+      thruster_position.col(idx) = Tbj.translation();
+      thruster_orientation.col(idx) =
+          (Tbj.linear() * nozzle_local_axis()).normalized();
     } else {
-      // Fallback
-      thruster_position.col(idx) << j->parent_to_joint_origin_transform.position.x,
-        j->parent_to_joint_origin_transform.position.y,
-        j->parent_to_joint_origin_transform.position.z;
-      const auto Tpj = poseToIso(j->parent_to_joint_origin_transform);
-      thruster_orientation.col(idx) = (Tpj.linear() *
-        Eigen::Vector3d(j->axis.x, j->axis.y, j->axis.z).normalized()).normalized();
+      // Fallback: parent->joint origin transform if DFS map is missing
+      const Eigen::Isometry3d Tpj =
+          poseToIso(j->parent_to_joint_origin_transform);
+      thruster_position.col(idx)
+          << j->parent_to_joint_origin_transform.position.x,
+          j->parent_to_joint_origin_transform.position.y,
+          j->parent_to_joint_origin_transform.position.z;
+      thruster_orientation.col(idx) =
+          (Tpj.linear() * nozzle_local_axis()).normalized();
     }
-
     ++idx;
+    if (idx >= n_thruster)
+      break;
   }
 
-  // Rebuild allocation_mat and inverse
-  printf("before allocation_mat %zu x %zu\n", allocation_mat.rows(),allocation_mat.cols());
+  // Rebuild allocation matrix A (3xN) and its pseudo-inverse (Nx3)
   allocation_mat.resize(3, n_thruster);
-  printf("after allocation_mat %zu x %zu\n", allocation_mat.rows(),allocation_mat.cols());
   for (std::size_t i = 0; i < n_thruster; ++i) {
     const Eigen::Vector3d r = thruster_position.col(i) - cgPos;
+    // Thrust direction is opposite to the nozzle axis (orientation)
     const Eigen::Vector3d f = -thruster_orientation.col(i);
     allocation_mat.col(i) = r.cross(f);
   }
-  inverse_allocation_mat = pseudoInverse<
-    Eigen::Matrix<double, 3, Eigen::Dynamic>,
-    Eigen::Matrix<double, Eigen::Dynamic, 3>>(allocation_mat);
 
-  // Update urdf_thrusters_ geometry
-  for (std::size_t i = 0; i < std::min(n_thruster, names.size()); ++i) {
+  inverse_allocation_mat =
+      pseudoInverse<Eigen::Matrix<double, 3, Eigen::Dynamic>,
+                    Eigen::Matrix<double, Eigen::Dynamic, 3>>(allocation_mat);
+
+  // Update the cached geometry per thruster name (if present)
+  for (std::size_t i = 0; i < std::min<std::size_t>(n_thruster, names.size());
+       ++i) {
     auto itc = urdf_thrusters_.find(names[i]);
     if (itc != urdf_thrusters_.end()) {
-      itc->second.position  = thruster_position.col(i);
+      itc->second.position = thruster_position.col(i);
       itc->second.direction = thruster_orientation.col(i);
     }
   }
-  pinv_cache_.clear();   // changing base
+
+  // Compact diagnostic: norms of r, orientation, and r×f for each column
+  {
+    double sum_norm = 0.0;
+    for (std::size_t i = 0; i < n_thruster; ++i) {
+      const double n_r = thruster_position.col(i).norm();
+      const double n_f = thruster_orientation.col(i).norm();
+      const double n_rf = allocation_mat.col(i).norm();
+      sum_norm += n_rf;
+      RCLCPP_INFO(rclcpp::get_logger("ThrusterMatrix"),
+                  "[A-diag] i=%zu |r|=%.6f |orientation|=%.6f |r×f|=%.6f  "
+                  "r=[%.6f %.6f %.6f]  ori=[%.6f %.6f %.6f]",
+                  i, n_r, n_f, n_rf, thruster_position(0, i),
+                  thruster_position(1, i), thruster_position(2, i),
+                  thruster_orientation(0, i), thruster_orientation(1, i),
+                  thruster_orientation(2, i));
+    }
+    RCLCPP_INFO(rclcpp::get_logger("ThrusterMatrix"),
+                "[A-diag] ||A||_sum=%.6f  invA=%ldx%ld", sum_norm,
+                static_cast<long>(inverse_allocation_mat.rows()),
+                static_cast<long>(inverse_allocation_mat.cols()));
+  }
+
+  // Invalidate/rebuild cached pinv(W) for table modes (geometry changed)
+  pinv_cache_.clear();
   if (table_loaded_) {
-    for (const auto & kv : table_map_) {
-      const std::string & mode = kv.first;
+    for (const auto &kv : table_map_) {
+      const std::string &mode = kv.first;
       Eigen::Matrix<double, 6, Eigen::Dynamic> W = buildWForMode(mode);
       if (!W.isZero(0)) {
-        pinv_cache_[mode] = pseudoInverse<
-          Eigen::Matrix<double, 6, Eigen::Dynamic>,
-          Eigen::Matrix<double, Eigen::Dynamic, 6>>(W);
+        pinv_cache_[mode] =
+            pseudoInverse<Eigen::Matrix<double, 6, Eigen::Dynamic>,
+                          Eigen::Matrix<double, Eigen::Dynamic, 6>>(W);
+      } else {
+        RCLCPP_WARN(rclcpp::get_logger("ThrusterMatrix"),
+                    "setBaseLink: W is zero for mode '%s' after base switch.",
+                    mode.c_str());
       }
     }
   }
 }
 
-std::vector<std::string> ThrusterMatrix::getAllThrusterNames() const
-{
+std::vector<std::string> ThrusterMatrix::getAllThrusterNames() const {
   std::vector<std::string> names;
   names.reserve(urdf_thrusters_.size());
-  for (const auto & kv : urdf_thrusters_) names.push_back(kv.first);
+  for (const auto &kv : urdf_thrusters_)
+    names.push_back(kv.first);
   std::sort(names.begin(), names.end());
   return names;
 }
 
-
-ThrusterConfigVec ThrusterMatrix::getActiveThrusters() const
-{
+ThrusterConfigVec ThrusterMatrix::getActiveThrusters() const {
   ThrusterConfigVec out;
-  if (current_mode_.empty()) return out;
+  if (current_mode_.empty())
+    return out;
   auto it = table_map_.find(current_mode_);
-  if (it == table_map_.end()) return out;
+  if (it == table_map_.end())
+    return out;
 
-  const auto & tbl = it->second;
+  const auto &tbl = it->second;
   out.reserve(tbl.size());
   // Keep URDF map iteration stable: follow orderedThrusterNames
   const auto names = orderedThrusterNames(model_urdf_, urdfUtils);
-  for (const auto & name : names) {
+  for (const auto &name : names) {
     if (tbl.find(name) != tbl.end()) {
       auto itc = urdf_thrusters_.find(name);
       if (itc != urdf_thrusters_.end()) {
@@ -544,39 +637,41 @@ ThrusterConfigVec ThrusterMatrix::getActiveThrusters() const
   return out;
 }
 
-std::size_t ThrusterMatrix::getNumThr()
-{
-  return this->n_thruster;
-}
+std::size_t ThrusterMatrix::getNumThr() { return this->n_thruster; }
 
-bool ThrusterMatrix::isReady()
-{
+bool ThrusterMatrix::isReady() {
+  // Ready means: allocation matrix is built and non-zero
+  if (allocation_mat.size() == 0)
+    return false;
+  if (allocation_mat.norm() < 1e-12)
+    return false; // guard against all-zero matrix
+
   if (inverse_allocation_mat.rows() > 0 && inverse_allocation_mat.cols() > 0) {
     return true;
   }
   return false;
 }
 
-void ThrusterMatrix::bodyToThruster(
-  const Eigen::Vector3d & body_wrench_moment,
-  Eigen::VectorXd & thruster_force) const
-{
-  // std::cout << "--------------------------------------------------------------------------------------------------------" << std::endl;
-  // std::cout << "inverse_allocation_mat: "
-  //         << inverse_allocation_mat.rows() << "×" << inverse_allocation_mat.cols()
+void ThrusterMatrix::bodyToThruster(const Eigen::Vector3d &body_wrench_moment,
+                                    Eigen::VectorXd &thruster_force) const {
+  // std::cout <<
+  // "--------------------------------------------------------------------------------------------------------"
+  // << std::endl; std::cout << "inverse_allocation_mat: "
+  //         << inverse_allocation_mat.rows() << "×" <<
+  //         inverse_allocation_mat.cols()
   //         << ", body_wrench_moment: "
-  //         << body_wrench_moment.rows()      << "×" << body_wrench_moment.cols()
+  //         << body_wrench_moment.rows()      << "×" <<
+  //         body_wrench_moment.cols()
   //         << std::endl;
 
   thruster_force = inverse_allocation_mat * body_wrench_moment;
 }
 
-void ThrusterMatrix::thrusterToBody(
-  const Eigen::VectorXd & recv_thruster_force,
-  Eigen::Vector3d & body_force) const
-{
+void ThrusterMatrix::thrusterToBody(const Eigen::VectorXd &recv_thruster_force,
+                                    Eigen::Vector3d &body_force) const {
   if (recv_thruster_force.size() != static_cast<int>(n_thruster)) {
-    throw std::runtime_error("thrusterToBody: size mismatch with number of thrusters.");
+    throw std::runtime_error(
+        "thrusterToBody: size mismatch with number of thrusters.");
   }
   body_force = allocation_mat * recv_thruster_force;
 }
@@ -585,25 +680,27 @@ void ThrusterMatrix::thrusterToBody(
 // YAML-based thrust table path
 //
 
-void ThrusterMatrix::loadThrusterTableFromYaml(const std::string & yaml_path)
-{
- if (!model_urdf_) throw std::runtime_error("loadThrusterTableFromYaml: URDF must be initialized first.");
+void ThrusterMatrix::loadThrusterTableFromYaml(const std::string &yaml_path) {
+  if (!model_urdf_)
+    throw std::runtime_error(
+        "loadThrusterTableFromYaml: URDF must be initialized first.");
   loadTable(yaml_path);
 }
-  // Build
+// Build
 
 void ThrusterMatrix::generateCommandFromTable(
-  const Eigen::VectorXd & desired_wrench,
-  Eigen::VectorXd & thruster_output) const
-{
+    const Eigen::VectorXd &desired_wrench,
+    Eigen::VectorXd &thruster_output) const {
   if (!table_loaded_ || current_mode_.empty()) {
-    throw std::runtime_error("generateCommandFromTable: No active table selected.");
+    throw std::runtime_error(
+        "generateCommandFromTable: No active table selected.");
   }
   if (!model_urdf_) {
     throw std::runtime_error("generateCommandFromTable: URDF not initialized.");
   }
   if (desired_wrench.size() != 6) {
-    throw std::runtime_error("generateCommandFromTable: desired_wrench must be 6x1 [Tx Ty Tz Fx Fy Fz].");
+    throw std::runtime_error("generateCommandFromTable: desired_wrench must be "
+                             "6x1 [Tx Ty Tz Fx Fy Fz].");
   }
 
   // Get or build pinv(W) for current mode
@@ -613,17 +710,18 @@ void ThrusterMatrix::generateCommandFromTable(
     if (it != pinv_cache_.end()) {
       pinvW = it->second;
     } else {
-      // Fallback: build once here if YAML load skipped this (e.g. under special flow)
+      // Fallback: build once here if YAML load skipped this (e.g. under special
+      // flow)
       Eigen::Matrix<double, 6, Eigen::Dynamic> W = buildWForMode(current_mode_);
       if (W.isZero(0)) {
-        throw std::runtime_error(
-          "generateCommandFromTable: active table produces zero matrix W (no actuators).");
+        throw std::runtime_error("generateCommandFromTable: active table "
+                                 "produces zero matrix W (no actuators).");
       }
       // Rank-deficient OK
       pinvW = pseudoInverse<Eigen::Matrix<double, 6, Eigen::Dynamic>,
                             Eigen::Matrix<double, Eigen::Dynamic, 6>>(W);
       // cache for next time
-      const_cast<ThrusterMatrix*>(this)->pinv_cache_[current_mode_] = pinvW;
+      const_cast<ThrusterMatrix *>(this)->pinv_cache_[current_mode_] = pinvW;
     }
   }
 
@@ -634,17 +732,25 @@ void ThrusterMatrix::generateCommandFromTable(
   constexpr double kNegTol = 1e-12;
   bool has_neg = false;
   for (Eigen::Index i = 0; i < u.size(); ++i) {
-    if (u(i) < -kNegTol) { has_neg = true; break; }
+    if (u(i) < -kNegTol) {
+      has_neg = true;
+      break;
+    }
   }
   if (!has_neg) {
-    for (Eigen::Index i = 0; i < u.size(); ++i) if (u(i) < 0.0) u(i) = 0.0;
+    for (Eigen::Index i = 0; i < u.size(); ++i)
+      if (u(i) < 0.0)
+        u(i) = 0.0;
     thruster_output = std::move(u);
     return;
   }
 
   // Re-solve with active (non-negative) subset
-  std::vector<int> active_idx; active_idx.reserve(static_cast<size_t>(u.size()));
-  for (int i = 0; i < u.size(); ++i) if (u(i) >= 0.0) active_idx.push_back(i);
+  std::vector<int> active_idx;
+  active_idx.reserve(static_cast<size_t>(u.size()));
+  for (int i = 0; i < u.size(); ++i)
+    if (u(i) >= 0.0)
+      active_idx.push_back(i);
 
   if (active_idx.empty()) {
     thruster_output = Eigen::VectorXd::Zero(u.size()); // safe fallback
@@ -653,13 +759,14 @@ void ThrusterMatrix::generateCommandFromTable(
 
   // Rebuild W and select columns
   Eigen::Matrix<double, 6, Eigen::Dynamic> W = buildWForMode(current_mode_);
-  Eigen::Matrix<double, 6, Eigen::Dynamic> W_active(6, static_cast<int>(active_idx.size()));
+  Eigen::Matrix<double, 6, Eigen::Dynamic> W_active(
+      6, static_cast<int>(active_idx.size()));
   for (int c = 0; c < static_cast<int>(active_idx.size()); ++c) {
     W_active.col(c) = W.col(active_idx[static_cast<size_t>(c)]);
   }
   Eigen::Matrix<double, Eigen::Dynamic, 6> pinvW_active =
-    pseudoInverse<Eigen::Matrix<double, 6, Eigen::Dynamic>,
-                  Eigen::Matrix<double, Eigen::Dynamic, 6>>(W_active);
+      pseudoInverse<Eigen::Matrix<double, 6, Eigen::Dynamic>,
+                    Eigen::Matrix<double, Eigen::Dynamic, 6>>(W_active);
   Eigen::VectorXd u_active = pinvW_active * desired_wrench;
   // Compose final vector with non-negative entries
   Eigen::VectorXd u_nn = Eigen::VectorXd::Zero(u.size());
@@ -669,37 +776,166 @@ void ThrusterMatrix::generateCommandFromTable(
   thruster_output = std::move(u_nn);
 }
 
-
-
 // --------------------------------------------------------------------------
 // Build W for a mode, following thruster_order_
 // --------------------------------------------------------------------------
 
 Eigen::Matrix<double, 6, Eigen::Dynamic>
-ThrusterMatrix::buildWForMode(const std::string & mode_name) const
-{
+ThrusterMatrix::buildWForMode(const std::string &mode_name) const {
   const auto it_mode = table_map_.find(mode_name);
   if (it_mode == table_map_.end()) {
-    throw std::out_of_range("buildWForMode: mode '" + mode_name + "' not found.");
+    throw std::out_of_range("buildWForMode: mode '" + mode_name +
+                            "' not found.");
   }
-  const ThrusterTable & table = it_mode->second;
+  const ThrusterTable &table = it_mode->second;
 
   Eigen::Matrix<double, 6, Eigen::Dynamic> W(6, static_cast<int>(n_thruster));
   W.setZero();
-  if (!model_urdf_ || thruster_order_.empty()) return W;
+  if (!model_urdf_ || thruster_order_.empty())
+    return W;
 
   int col = 0;
-  for (const auto & thr_name : thruster_order_) {
+  for (const auto &thr_name : thruster_order_) {
     auto itw = table.find(thr_name);
     if (itw != table.end()) {
-      const ThrusterWeight & w = itw->second;
-      W.block<3,1>(0, col) = w.torque_weight;
-      W.block<3,1>(3, col) = w.force_weight;
+      const ThrusterWeight &w = itw->second;
+      W.block<3, 1>(0, col) = w.torque_weight;
+      W.block<3, 1>(3, col) = w.force_weight;
     }
     ++col;
-    if (col >= static_cast<int>(n_thruster)) break;
+    if (col >= static_cast<int>(n_thruster))
+      break;
   }
 
   return W;
 }
 
+// Build direct allocation map from the physical allocation matrix A (3xN).
+// We assume torque-only (Fx=Fy=Fz=0) and near-diagonal A columns w.r.t. axes,
+// which is true for designed symmetric layout (X-pair -> Z torque, Y-pair -> X
+// torque, Z-pair -> Y torque).
+void ThrusterMatrix::buildDirectMapForMode() {
+  direct_map_.clear();
+  if (allocation_mat.size() == 0 || allocation_mat.cols() == 0) {
+    direct_map_.ready = false;
+    return;
+  }
+
+  const int N = static_cast<int>(allocation_mat.cols());
+
+  // For each axis k, we pick the top-2 columns with positive A(k, i) and top-2
+  // with negative A(k, i) (largest magnitude), because firing the two that
+  // produce the same sign torque adds up linearly.
+  auto pick_pair = [&](int k, bool positive) -> AxisPair {
+    // Collect (index, value) with desired sign
+    std::vector<std::pair<int, double>> cand;
+    cand.reserve(N);
+    for (int i = 0; i < N; ++i) {
+      const double v = allocation_mat(k, i);
+      if ((positive && v > 0.0) || (!positive && v < 0.0)) {
+        cand.emplace_back(i, std::abs(v));
+      }
+    }
+    if (cand.size() < 2)
+      return AxisPair{};
+    std::sort(cand.begin(), cand.end(),
+              [](auto &a, auto &b) { return a.second > b.second; });
+    AxisPair ap;
+    ap.i1 = cand[0].first;
+    ap.i2 = cand[1].first;
+    ap.gain = cand[0].second + cand[1].second; // sum of magnitudes
+    return ap;
+  };
+
+  // k:0->Tx, 1->Ty, 2->Tz components of A*u
+  direct_map_.x_pos = pick_pair(0, /*positive=*/true);
+  direct_map_.x_neg = pick_pair(0, /*positive=*/false);
+  direct_map_.y_pos = pick_pair(1, /*positive=*/true);
+  direct_map_.y_neg = pick_pair(1, /*positive=*/false);
+  direct_map_.z_pos = pick_pair(2, /*positive=*/true);
+  direct_map_.z_neg = pick_pair(2, /*positive=*/false);
+
+  // Require all six to be valid for torque-only direct coverage.
+  direct_map_.ready = direct_map_.x_pos.valid() && direct_map_.x_neg.valid() &&
+                      direct_map_.y_pos.valid() && direct_map_.y_neg.valid() &&
+                      direct_map_.z_pos.valid() && direct_map_.z_neg.valid();
+}
+
+// Try exact torque-only direct allocation using the per-axis pairs.
+// Returns true and fills u_out (size N) if successful within tolerance;
+// otherwise returns false.
+bool ThrusterMatrix::generateCommandDirectTorqueOnly(
+    const Eigen::Vector3d &tau_cmd, Eigen::VectorXd &u_out, double tol) const {
+  if (!direct_map_.ready || allocation_mat.size() == 0)
+    return false;
+
+  const int N = static_cast<int>(allocation_mat.cols());
+  u_out = Eigen::VectorXd::Zero(N);
+
+  auto apply_axis = [&](double tau_k, const AxisPair &pos,
+                        const AxisPair &neg) -> bool {
+    if (std::abs(tau_k) < tol)
+      return true; // nothing to do
+
+    const bool use_pos = (tau_k > 0.0);
+    const AxisPair &ap = use_pos ? pos : neg;
+    if (!ap.valid())
+      return false;
+
+    // If both thrusters fire equally (same sign), their A(k, i) contributions
+    // add up. torque_k = (|A(k,i1)| + |A(k,i2)|) * u_eq  => u_eq = |tau_k| /
+    // gain
+    const double u_eq = std::abs(tau_k) / ap.gain;
+
+    u_out(ap.i1) += u_eq;
+    u_out(ap.i2) += u_eq;
+    return true;
+  };
+
+  // Solve per-axis independently (torque-only)
+  if (!apply_axis(tau_cmd.x(), direct_map_.x_pos, direct_map_.x_neg))
+    return false;
+  if (!apply_axis(tau_cmd.y(), direct_map_.y_pos, direct_map_.y_neg))
+    return false;
+  if (!apply_axis(tau_cmd.z(), direct_map_.z_pos, direct_map_.z_neg))
+    return false;
+
+  // Check exactness: ||A*u_out - tau_cmd|| <= tol
+  Eigen::Vector3d tau_eff = allocation_mat * u_out;
+  const double res = (tau_eff - tau_cmd).norm();
+  return (res <= tol);
+}
+
+// Preferred entry: try direct torque-only; if not applicable or not exact, fall
+// back to table LS.
+bool ThrusterMatrix::generateCommandPreferDirect(
+    const Eigen::VectorXd &desired_wrench, Eigen::VectorXd &thruster_output,
+    double tol) const {
+  if (!model_urdf_)
+    throw std::runtime_error(
+        "generateCommandPreferDirect: URDF not initialized.");
+  if (desired_wrench.size() != 6)
+    throw std::runtime_error("generateCommandPreferDirect: desired_wrench must "
+                             "be 6x1 [Tx Ty Tz Fx Fy Fz].");
+
+  // 1) If force components are (near) zero, try direct torque-only allocation
+  const Eigen::Vector3d tau_cmd = desired_wrench.head<3>();
+  const Eigen::Vector3d f_cmd = desired_wrench.tail<3>();
+
+  const bool force_is_zero = (f_cmd.norm() <= tol);
+  if (force_is_zero) {
+    Eigen::VectorXd u_direct;
+    if (generateCommandDirectTorqueOnly(tau_cmd, u_direct, tol)) {
+      thruster_output = std::move(u_direct);
+      return true;
+    }
+  }
+
+  // 2) Fallback: use table least-squares (non-negativity handling inside)
+  try {
+    generateCommandFromTable(desired_wrench, thruster_output);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}

--- a/space_station_gnc/urdf/space_station_eagle.xacro
+++ b/space_station_gnc/urdf/space_station_eagle.xacro
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="space_station">
+
+  <!-- Root body (visual/collision/inertial as before) -->
+  <link name="Root">
+    <visual>
+      <!-- Rotate the visual by yaw=pi for your mesh convention -->
+      <origin xyz="0 0 0" rpy="0 0 3.141592653589793"/>
+      <geometry>
+        <mesh filename="package://space_station_gnc/urdf/meshes/SD_SpaceStation_Ver05.dae" scale="100 100 100"/>
+      </geometry>
+    </visual>
+    <collision>
+      <geometry>
+        <mesh filename="package://space_station_gnc/urdf/meshes/SD_SpaceStation_Ver05.dae" scale="100 100 100"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="1.0"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="1.0" iyy="1.0" izz="1.0" ixy="0.0" ixz="0.0" iyz="0.0"/>
+    </inertial>
+  </link>
+
+  <!--
+    Convention:
+      - The child link +X is the nozzle axis (points out of the nozzle).
+      - The physical thrust direction is the opposite of the nozzle axis.
+      - We DO NOT use <axis> on fixed joints. The orientation is fully defined by <origin rpy>.
+      - Users specify an axis (ax ay az). By default it is interpreted as a THRUST direction.
+        We convert to nozzle axis = -axis before computing rpy.
+  -->
+
+  <!-- Low-level macro: create a thruster link and a fixed joint with a given rpy -->
+  <xacro:macro name="add_thruster" params="name parent xyz rpy">
+    <link name="${name}">
+      <inertial>
+        <mass value="0.01"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia ixx="1e-6" iyy="1e-6" izz="1e-6" ixy="0" ixz="0" iyz="0"/>
+      </inertial>
+    </link>
+    <joint name="${name}_joint" type="fixed">
+      <origin xyz="${xyz}" rpy="${rpy}"/>
+      <parent link="${parent}"/>
+      <child link="${name}"/>
+    </joint>
+  </xacro:macro>
+
+  <!-- High-level macro: axis=(ax ay az) => child+X aligned to the nozzle axis.
+       axis_is_thrust=true (default): we treat (ax ay az) as THRUST direction and flip it to NOZZLE axis = -axis.
+       If axis_is_thrust=false, we accept the vector as a nozzle axis directly. -->
+  <xacro:macro name="add_thruster_axis" params="name parent xyz ax ay az axis_is_thrust:=true">
+    <!-- Normalize input vector safely -->
+    <xacro:property name="eps"  value="1e-12"/>
+    <xacro:property name="norm" value="${max(sqrt(ax*ax + ay*ay + az*az), eps)}"/>
+
+    <!-- Decide nozzle axis -->
+    <xacro:if value="${axis_is_thrust}">
+      <!-- thrust axis given -> nozzle axis = -thrust -->
+      <xacro:property name="nx" value="${-ax / norm}"/>
+      <xacro:property name="ny" value="${-ay / norm}"/>
+      <xacro:property name="nz" value="${-az / norm}"/>
+    </xacro:if>
+    <xacro:unless value="${axis_is_thrust}">
+      <!-- nozzle axis given directly -->
+      <xacro:property name="nx" value="${ ax / norm}"/>
+      <xacro:property name="ny" value="${ ay / norm}"/>
+      <xacro:property name="nz" value="${ az / norm}"/>
+    </xacro:unless>
+
+    <!-- Compute Z-Y Euler to align child+X with (nx,ny,nz):
+         yaw = atan2(ny, nx)
+         pitch = atan2(-nz, sqrt(nx^2 + ny^2))
+         roll = 0 -->
+    <xacro:property name="hyp"   value="${max(sqrt(nx*nx + ny*ny), eps)}"/>
+    <xacro:property name="yaw"   value="${atan2(ny, nx)}"/>
+    <xacro:property name="pitch" value="${atan2(-nz, hyp)}"/>
+    <xacro:property name="roll"  value="0.0"/>
+
+    <xacro:add_thruster name="${name}" parent="${parent}" xyz="${xyz}" rpy="${roll} ${pitch} ${yaw}"/>
+  </xacro:macro>
+
+  <!-- Layout parameters (meters) -->
+  <xacro:property name="Xx" value="40.0"/>
+  <xacro:property name="Xy" value="15.0"/>
+  <xacro:property name="Yy" value="20.0"/>
+  <xacro:property name="Yz" value="10.0"/>
+  <xacro:property name="Zx" value="20.0"/>
+  <xacro:property name="Zz" value="10.0"/>
+
+  <!-- 12 thrusters; names must match YAML/URDF usage -->
+  <!-- Example definitions using THRUST directions for clarity -->
+
+  <!-- +X thrust -->
+  <xacro:add_thruster_axis name="thruster_xp1" parent="Root" xyz="${Xx} -${Xy} 0" ax="1" ay="0" az="0" axis_is_thrust="true"/>
+  <xacro:add_thruster_axis name="thruster_xp2" parent="Root" xyz="${Xx}  ${Xy} 0" ax="1" ay="0" az="0" axis_is_thrust="true"/>
+
+  <!-- -X thrust -->
+  <xacro:add_thruster_axis name="thruster_xn1" parent="Root" xyz="-${Xx} -${Xy} 0" ax="-1" ay="0" az="0" axis_is_thrust="true"/>
+  <xacro:add_thruster_axis name="thruster_xn2" parent="Root" xyz="-${Xx}  ${Xy} 0" ax="-1" ay="0" az="0" axis_is_thrust="true"/>
+
+  <!-- +Y thrust -->
+  <xacro:add_thruster_axis name="thruster_yp1" parent="Root" xyz="0 ${Yy} -${Yz}" ax="0" ay="1" az="0" axis_is_thrust="true"/>
+  <xacro:add_thruster_axis name="thruster_yp2" parent="Root" xyz="0 ${Yy}  ${Yz}" ax="0" ay="1" az="0" axis_is_thrust="true"/>
+
+  <!-- -Y thrust -->
+  <xacro:add_thruster_axis name="thruster_yn1" parent="Root" xyz="0 -${Yy} -${Yz}" ax="0" ay="-1" az="0" axis_is_thrust="true"/>
+  <xacro:add_thruster_axis name="thruster_yn2" parent="Root" xyz="0 -${Yy}  ${Yz}" ax="0" ay="-1" az="0" axis_is_thrust="true"/>
+
+  <!-- +Z thrust -->
+  <xacro:add_thruster_axis name="thruster_zp1" parent="Root" xyz="-${Zx} 0 ${Zz}" ax="0" ay="0" az="1" axis_is_thrust="true"/>
+  <xacro:add_thruster_axis name="thruster_zp2" parent="Root" xyz=" ${Zx} 0 ${Zz}" ax="0" ay="0" az="1" axis_is_thrust="true"/>
+
+  <!-- -Z thrust -->
+  <xacro:add_thruster_axis name="thruster_zn1" parent="Root" xyz="-${Zx} 0 -${Zz}" ax="0" ay="0" az="-1" axis_is_thrust="true"/>
+  <xacro:add_thruster_axis name="thruster_zn2" parent="Root" xyz=" ${Zx} 0 -${Zz}" ax="0" ay="0" az="-1" axis_is_thrust="true"/>
+
+</robot>


### PR DESCRIPTION
## Summary
This PR implements the robust thruster-based attitude control and actuator switching requested in #158  . It introduces a PD controller with LPF on angular rate, a hysteresis dead-zone, and a two-stage allocator (direct torque-only from A with YAML thruster table fallback). It also adds concise diagnostics and a ready-to-run launch file.

## Key changes

- control_torque.cpp:

  - PD control (kp_thruster, kd_thruster) with LPF (thruster_omega_lpf_tau) and hysteresis dead-zone (angle & rate).

  - Publishes compact diagnostics: 3xN per-thruster torque, tau_cmd vs tau_from_thr, and the body rotation matrix R.

- thruster_matrix.cpp/.hpp:

  - Direct torque-only allocation from allocation matrix A (pair selection per axis) with tolerance check.

  - Fallback to YAML table least-squares (non-negativity handling).

  - Stable column order from URDF, setBaseLink() rebuilds A and cached pinv(W).

- physics_motion.cpp: inertia/time-steps parameters and overwrite endpoints wired as before.

- launch/gnc_thruster_cmg_switch.launch.py: xacro-based model load, controller/plant params, per-node log-levels.

- config/eagle_thruster_table.yaml: explicit force/torque signs consistent with the station thruster layout.

- CMakeLists.txt & package.xml: link Eigen/URDF/YAML; declare Eigen module dependencies.

## How I tested

- Build with colcon build --symlink-install.

- Launch via ros2 launch space_station_gnc gnc_thruster_cmg_switch.launch.py.

- Switch to thruster mode: ros2 topic pub --once /gnc/mode_gnc_control std_msgs/String "{data: 'thruster'}"

- Step attitude: ros2 topic pub --once /gnc/attitude_overwrite geometry_msgs/msg/Quaternion "{w: 0.999962, x: 0.0, y: 0.0, z: 0.008727}"

- Verified convergence and consistent tau_cmd ≈ tau_from_thr, correct signs in 3xN torque printouts.

## Notes

- Defaults in the launch file set kp=kd=1e6, thruster_omega_lpf_tau=1.0, and reduced ISS-scale inertia to speed convergence.

- Table mode used: sixdof_phys.

Closes #158 