### PR TITLE
[GNC] Add /gnc/set_mode_actuation service and /gnc/mode_actuation topic (closes #162)

### DIFF
--- a/space_station_gnc/CMakeLists.txt
+++ b/space_station_gnc/CMakeLists.txt
@@ -24,18 +24,21 @@ find_package(SDL2 REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 find_package(rosidl_default_generators REQUIRED)
-find_package(rosidl_default_runtime REQUIRED)
+# find_package(rosidl_default_runtime REQUIRED)
 find_package(action_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(urdf REQUIRED)        # provides target urdf::urdf
 find_package(yaml-cpp REQUIRED)    # YAML tables support
 find_package(ament_index_cpp REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
-# Generate interfaces
+# Generate both the action and the service in one rosidl_generate_interfaces call
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Unloading.action"
+  "srv/SetGncModeActuation.srv"
   DEPENDENCIES action_msgs std_msgs
 )
+
 # Include directories
 include_directories(
   ${OpenCV_INCLUDE_DIRS}
@@ -72,6 +75,8 @@ ament_target_dependencies(control_torque rclcpp std_msgs tf2 tf2_ros nav_msgs tf
 ament_target_dependencies(thruster_matrix rclcpp)
 
 
+
+
 # --------------------------------------------------------------------------
 # Public include path for the library (exported)
 # --------------------------------------------------------------------------
@@ -86,6 +91,8 @@ target_include_directories(thruster_matrix
 # - Link the control nodes with the generated typesupport and thruster_matrix.
 # - Link thruster_matrix with Eigen, URDF, and YAML-CPP.
 # --------------------------------------------------------------------------
+#rosidl_target_interfaces(control_torque
+#  ${PROJECT_NAME} "rosidl_typesupport_cpp")
 rosidl_get_typesupport_target(cpp_typesupport_target
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
@@ -122,6 +129,65 @@ target_link_libraries(orbit_dynamics ${cpp_typesupport_target})
 target_link_libraries(demo1a_nauka_incident_estimate ${OpenCV_LIBRARIES} ${SDL2_LIBRARIES})
 target_link_libraries(demo1b_crisis_mainengine ${OpenCV_LIBRARIES} ${SDL2_LIBRARIES})
 target_link_libraries(demo1c_small_incident ${OpenCV_LIBRARIES} ${SDL2_LIBRARIES})
+
+
+
+
+# --------------------------------------------------------------------------
+# Testing
+# - Enable lint auto and add gtest-based unit tests if BUILD_TESTING is on.
+# --------------------------------------------------------------------------
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(AMENT_LINT_AUTO_EXCLUDE "flake8;lint_cmake;uncrustify")
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  # GoogleTest via ament
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # Unit test for thruster_matrix (URDF/YAML/Eigen required)
+  ament_add_gtest(test_thruster_matrix
+    tests/unit/test_thruster_matrix.cpp
+  )
+  if(TARGET test_thruster_matrix)
+    target_include_directories(test_thruster_matrix PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(test_thruster_matrix
+      thruster_matrix
+      Eigen3::Eigen
+      yaml-cpp
+      urdf::urdf
+    )
+  endif()
+endif()
+
+
+
+set(CONFIG_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config/config.json")
+set(OUTPUT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/jacob_cmgs_casadi.py ${CONFIG_PATH} ${OUTPUT_PATH}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  RESULT_VARIABLE result
+)
+
+if(NOT result EQUAL 0)
+  message(FATAL_ERROR "Matrix Code generation failed")
+endif()
+
+# --------------------------------------------------------------------------
+# Export include dirs for downstream consumers
+# --------------------------------------------------------------------------
+ament_export_include_directories(
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_export_dependencies(Eigen3)
+ament_export_dependencies(rosidl_default_runtime)
 
 # source by c++
 install(TARGETS
@@ -163,59 +229,6 @@ install(DIRECTORY rviz
 
 install(DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
-)
-
-
-# --------------------------------------------------------------------------
-# Testing
-# - Enable lint auto and add gtest-based unit tests if BUILD_TESTING is on.
-# --------------------------------------------------------------------------
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  set(AMENT_LINT_AUTO_EXCLUDE "flake8;lint_cmake;uncrustify")
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-
-  # GoogleTest via ament
-  find_package(ament_cmake_gtest REQUIRED)
-
-  # Unit test for thruster_matrix (URDF/YAML/Eigen required)
-  ament_add_gtest(test_thruster_matrix
-    tests/unit/test_thruster_matrix.cpp
-  )
-  if(TARGET test_thruster_matrix)
-    target_include_directories(test_thruster_matrix PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}/include
-    )
-    target_link_libraries(test_thruster_matrix
-      thruster_matrix
-      Eigen3::Eigen
-      yaml-cpp
-      urdf::urdf
-    )
-  endif()
-endif()
-
-
-set(CONFIG_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config/config.json")
-set(OUTPUT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
-execute_process(
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/jacob_cmgs_casadi.py ${CONFIG_PATH} ${OUTPUT_PATH}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  RESULT_VARIABLE result
-)
-
-if(NOT result EQUAL 0)
-  message(FATAL_ERROR "Matrix Code generation failed")
-endif()
-
-# --------------------------------------------------------------------------
-# Export include dirs for downstream consumers
-# --------------------------------------------------------------------------
-ament_export_include_directories(
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
 )
 
 ament_package()

--- a/space_station_gnc/package.xml
+++ b/space_station_gnc/package.xml
@@ -14,11 +14,16 @@
   <build_depend>ament_index_cpp</build_depend>
   <exec_depend>ament_index_cpp</exec_depend>
 
-  <exec_depend>rclcpp</exec_depend>
+  <!-- exec_depend>rclcpp</exec_depend -->
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <!-- exec_depend>std_msgs</exec_depend -->
 
   
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <depend>action_msgs</depend>

--- a/space_station_gnc/srv/SetGncModeActuation.srv
+++ b/space_station_gnc/srv/SetGncModeActuation.srv
@@ -1,0 +1,5 @@
+string mode
+---
+bool success
+string message
+string current_mode


### PR DESCRIPTION
### Summary
This PR replaces the legacy topic-based GNC mode switching with a service-based interface.

### Changes
- Added `SetGncModeActuation.srv` under `space_station_gnc/srv/`.
- Implemented `/gnc/set_mode_actuation` service in `control_torque.cpp`.
- Added latched state publisher `/gnc/mode_actuation` (std_msgs/String).
- Removed old `/gnc/mode_gnc_control` topic subscription.
- Updated CMakeLists.txt and package.xml for service generation.

### Test procedure
1. Launch:
ros2 launch space_station_gnc gnc_thruster_cmg_switch.launch.py
2. Confirm default mode:
ros2 topic echo /gnc/mode_actuation
3. Switch to thruster mode:
ros2 service call /gnc/set_mode_actuation space_station_gnc/srv/SetGncModeActuation "{mode: 'thruster'}"
and
ros2 service call /gnc/set_mode_actuation space_station_gnc/srv/SetGncModeActuation "{mode: 'cmg'}"
4. Step attitude: 
ros2 topic pub --once /gnc/attitude_overwrite geometry_msgs/msg/Quaternion "{w: 0.999962, x: 0.0, y: 0.0, z: 0.008727}"


### Result
- Service calls and latched state publication verified successfully.
- Ready for integration with OpenMCT frontend.

Closes #162
