### PR TITLE
fixed deprecation of rosidl_target_interfaces()

### DIFF
--- a/space_station_eps/CMakeLists.txt
+++ b/space_station_eps/CMakeLists.txt
@@ -36,7 +36,8 @@ ament_export_dependencies(rosidl_default_runtime)
 include_directories(include)
 
 add_executable(battery_manager_node src/battery_health.cpp)
-rosidl_target_interfaces(battery_manager_node ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(battery_manager_node ${cpp_typesupport_target})
 ament_target_dependencies(battery_manager_node
   rclcpp
   std_srvs
@@ -49,7 +50,7 @@ target_link_libraries(battery_manager_node yaml-cpp)
 
 
 add_executable(bcdu_node src/bcdu_device.cpp)
-rosidl_target_interfaces(bcdu_node ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(bcdu_node ${cpp_typesupport_target})
 ament_target_dependencies(bcdu_node
   rclcpp 
   std_msgs sensor_msgs diagnostic_msgs std_srvs space_station_interfaces
@@ -64,7 +65,7 @@ ament_target_dependencies(mbsu_device
 )
 
 add_executable(ddcu_device src/ddcu_device.cpp)
-rosidl_target_interfaces(ddcu_device ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(ddcu_device ${cpp_typesupport_target})
 ament_target_dependencies(ddcu_device
   rclcpp
   std_msgs

--- a/space_station_gazebo/space_station_control/CMakeLists.txt
+++ b/space_station_gazebo/space_station_control/CMakeLists.txt
@@ -35,13 +35,13 @@ include_directories(include)
 add_executable(teleop src/teleop.cpp)
 ament_target_dependencies(teleop std_srvs rosidl_default_generators rclcpp sensor_msgs)
 
-rosidl_target_interfaces(teleop ${PROJECT_NAME} "rosidl_typesupport_cpp")
-
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(teleop ${cpp_typesupport_target})
 
 add_executable(mux src/mux.cpp)
 ament_target_dependencies(mux std_srvs rosidl_default_generators rclcpp sensor_msgs)
 
-rosidl_target_interfaces(mux ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(mux ${cpp_typesupport_target})
 
 install(TARGETS
   teleop

--- a/space_station_thermal_control/CMakeLists.txt
+++ b/space_station_thermal_control/CMakeLists.txt
@@ -50,11 +50,11 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 ament_export_dependencies(rosidl_default_runtime)
 
-
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 add_executable(radiator src/radiators.cpp)
 ament_target_dependencies(radiator rosidl_default_generators rclcpp sensor_msgs space_station_interfaces)
-rosidl_target_interfaces(radiator ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(radiator ${cpp_typesupport_target})
 
 
 add_executable(thermal_nodes src/thermals_solver.cpp)
@@ -62,25 +62,24 @@ ament_target_dependencies(thermal_nodes rosidl_default_generators rclcpp rclcpp_
 
 add_executable(cooling_server src/cooling.cpp)
 ament_target_dependencies(cooling_server rosidl_default_generators  behaviortree_cpp_v3 ament_index_cpp rclcpp rclcpp_action std_srvs sensor_msgs space_station_interfaces diagnostic_msgs)
-rosidl_target_interfaces(cooling_server ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(cooling_server ${cpp_typesupport_target})
 
-rosidl_target_interfaces(thermal_nodes ${PROJECT_NAME} "rosidl_typesupport_cpp")
 target_link_libraries(thermal_nodes
   yaml-cpp
+  ${cpp_typesupport_target}
 )
 
 add_executable(demand src/on_demand_publisher.cpp)
 ament_target_dependencies(demand rosidl_default_generators rclcpp sensor_msgs space_station_interfaces)
-rosidl_target_interfaces(demand ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(demand ${cpp_typesupport_target})
 
 add_executable(sun_vector src/sun_vector.cpp)
 ament_target_dependencies(sun_vector rosidl_default_generators rclcpp sensor_msgs space_station_interfaces)
-rosidl_target_interfaces(sun_vector ${PROJECT_NAME} "rosidl_typesupport_cpp")
-target_link_libraries(sun_vector ${BULLET_LIBRARIES})
+target_link_libraries(sun_vector ${BULLET_LIBRARIES} ${cpp_typesupport_target})
 
 add_executable(array_absorptivity src/solar_heat_node.cpp)
 ament_target_dependencies(array_absorptivity rosidl_default_generators rclcpp sensor_msgs space_station_interfaces)
-rosidl_target_interfaces(array_absorptivity ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(array_absorptivity ${cpp_typesupport_target})
 target_link_libraries(sun_vector ${BULLET_LIBRARIES})
 
 


### PR DESCRIPTION
Noticed a few deprecations while checking the bug in [v0.8.7] Space Station Interfaces : common interface for all space station OS packages.
`rosidl_target_interfaces()` throws deprecation errors during compile time. `rosidl_target_interfaces()` is replaced with `rosidl_get_typesupport_target()` + `target_link_libraries()` for

- space_station_control
- space_station_eps
- space_station_thermal_control