### PR TITLE
[A1.2] Add ssos_core package with system_manager lifecycle node

### DIFF
--- a/ssos_core/CMakeLists.txt
+++ b/ssos_core/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.14)
+project(ssos_core)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(space_station_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+
+# Include headers
+include_directories(include)
+
+# System manager library (for testability)
+add_library(system_manager_lib
+  src/system_manager.cpp
+)
+ament_target_dependencies(system_manager_lib
+  rclcpp
+  rclcpp_lifecycle
+  space_station_interfaces
+  std_msgs
+  lifecycle_msgs
+)
+
+# System manager executable
+add_executable(system_manager src/system_manager_main.cpp)
+target_link_libraries(system_manager system_manager_lib)
+ament_target_dependencies(system_manager
+  rclcpp
+  rclcpp_lifecycle
+)
+
+# Install
+install(TARGETS system_manager_lib
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS system_manager
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}/launch
+)
+
+install(DIRECTORY config/
+  DESTINATION share/${PROJECT_NAME}/config
+)
+
+# Testing
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_system_manager test/test_system_manager.cpp)
+  target_include_directories(test_system_manager PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(test_system_manager system_manager_lib)
+  ament_target_dependencies(test_system_manager
+    rclcpp
+    rclcpp_lifecycle
+    space_station_interfaces
+  )
+endif()
+
+ament_package()

--- a/ssos_core/config/system_manager_param.yaml
+++ b/ssos_core/config/system_manager_param.yaml
@@ -1,0 +1,4 @@
+system_manager:
+  ros__parameters:
+    heartbeat_timeout_s: 5.0
+    eval_period_s: 1.0

--- a/ssos_core/include/ssos_core/system_manager.hpp
+++ b/ssos_core/include/ssos_core/system_manager.hpp
@@ -1,0 +1,96 @@
+#ifndef SSOS_CORE__SYSTEM_MANAGER_HPP_
+#define SSOS_CORE__SYSTEM_MANAGER_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "space_station_interfaces/msg/system_state.hpp"
+#include "space_station_interfaces/msg/fault_event.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+#include "space_station_interfaces/srv/register_subsystem.hpp"
+
+namespace ssos_core
+{
+
+using SystemState = space_station_interfaces::msg::SystemState;
+using FaultEvent = space_station_interfaces::msg::FaultEvent;
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using RegisterSubsystem = space_station_interfaces::srv::RegisterSubsystem;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+/// Tracked state for a single registered subsystem
+struct SubsystemRecord
+{
+  std::string name;
+  std::vector<std::string> published_topics;
+  std::vector<std::string> subscribed_topics;
+  std::string heartbeat_topic;
+  SubsystemHeartbeat last_heartbeat;
+  rclcpp::Subscription<SubsystemHeartbeat>::SharedPtr heartbeat_sub;
+  rclcpp::Time last_heard;
+  bool registered{false};
+};
+
+/// Central system manager node.
+/// Aggregates subsystem heartbeats and fault events into a global system state.
+class SystemManager : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit SystemManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  // Lifecycle callbacks
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+  /// Get current system state (for testing)
+  uint8_t get_current_state() const { return current_state_; }
+
+  /// Evaluate and return what the system state should be (for testing)
+  uint8_t evaluate_system_state() const;
+
+private:
+  // Publishers
+  rclcpp_lifecycle::LifecyclePublisher<SystemState>::SharedPtr state_pub_;
+
+  // Subscribers
+  rclcpp::Subscription<FaultEvent>::SharedPtr fault_sub_;
+
+  // Services
+  rclcpp::Service<RegisterSubsystem>::SharedPtr register_srv_;
+
+  // Timer for periodic state evaluation
+  rclcpp::TimerBase::SharedPtr eval_timer_;
+
+  // State
+  uint8_t current_state_{SystemState::INIT};
+  std::map<std::string, SubsystemRecord> subsystems_;
+
+  // Parameters
+  double heartbeat_timeout_s_{5.0};
+  double eval_period_s_{1.0};
+
+  // Callbacks
+  void on_fault_event(const FaultEvent::SharedPtr msg);
+  void on_heartbeat(const std::string & subsystem_name, const SubsystemHeartbeat::SharedPtr msg);
+  void handle_register(
+    const RegisterSubsystem::Request::SharedPtr req,
+    RegisterSubsystem::Response::SharedPtr res);
+
+  /// Core state evaluation logic
+  void run_evaluation();
+
+  /// Publish a state transition
+  void publish_state(uint8_t new_state, const std::string & reason);
+};
+
+}  // namespace ssos_core
+
+#endif  // SSOS_CORE__SYSTEM_MANAGER_HPP_

--- a/ssos_core/launch/system_manager.launch.py
+++ b/ssos_core/launch/system_manager.launch.py
@@ -1,0 +1,43 @@
+from launch import LaunchDescription
+from launch_ros.actions import LifecycleNode
+from launch_ros.events.lifecycle import ChangeState
+from launch.actions import EmitEvent, RegisterEventHandler, LogInfo
+from launch.event_handlers import OnProcessStart
+import lifecycle_msgs.msg
+
+
+def generate_launch_description():
+    system_manager = LifecycleNode(
+        package='ssos_core',
+        executable='system_manager',
+        name='system_manager',
+        namespace='',
+        output='screen',
+        parameters=[{
+            'heartbeat_timeout_s': 5.0,
+            'eval_period_s': 1.0,
+        }],
+    )
+
+    # Auto-configure on start
+    configure_event = EmitEvent(
+        event=ChangeState(
+            lifecycle_node_matcher=lambda node: True,
+            transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+        )
+    )
+
+    return LaunchDescription([
+        system_manager,
+        RegisterEventHandler(
+            OnProcessStart(
+                target_action=system_manager,
+                on_start=[
+                    LogInfo(msg='system_manager started, configuring...'),
+                    configure_event,
+                ],
+            )
+        ),
+        # To activate after configure completes:
+        #   ros2 lifecycle set /system_manager activate
+    ])

--- a/ssos_core/package.xml
+++ b/ssos_core/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ssos_core</name>
+  <version>0.9.0</version>
+  <description>SSOS core system manager — global state model, subsystem registration, fault aggregation</description>
+  <maintainer email="spacestationos@spacedata.co.jp">Space Station OS</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>space_station_interfaces</depend>
+  <depend>std_msgs</depend>
+  <depend>lifecycle_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ssos_core/src/system_manager.cpp
+++ b/ssos_core/src/system_manager.cpp
@@ -1,0 +1,286 @@
+#include "ssos_core/system_manager.hpp"
+
+#include <functional>
+#include <chrono>
+
+namespace ssos_core
+{
+
+using namespace std::chrono_literals;
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+SystemManager::SystemManager(const rclcpp::NodeOptions & options)
+: LifecycleNode("system_manager", options)
+{
+  // Declare parameters
+  this->declare_parameter("heartbeat_timeout_s", 5.0);
+  this->declare_parameter("eval_period_s", 1.0);
+
+  RCLCPP_INFO(get_logger(), "SystemManager created (unconfigured)");
+}
+
+CallbackReturn SystemManager::on_configure(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Configuring...");
+
+  // Read parameters
+  heartbeat_timeout_s_ = this->get_parameter("heartbeat_timeout_s").as_double();
+  eval_period_s_ = this->get_parameter("eval_period_s").as_double();
+
+  // Create state publisher (lifecycle-managed — only publishes when active)
+  state_pub_ = this->create_publisher<SystemState>("/ssos/system_state", 10);
+
+  // Subscribe to fault events
+  fault_sub_ = this->create_subscription<FaultEvent>(
+    "/ssos/fault_event", 10,
+    std::bind(&SystemManager::on_fault_event, this, _1));
+
+  // Registration service
+  register_srv_ = this->create_service<RegisterSubsystem>(
+    "/ssos/register_subsystem",
+    std::bind(&SystemManager::handle_register, this, _1, _2));
+
+  // Periodic state evaluation timer
+  auto eval_period = std::chrono::duration<double>(eval_period_s_);
+  eval_timer_ = this->create_wall_timer(
+    std::chrono::duration_cast<std::chrono::milliseconds>(eval_period),
+    std::bind(&SystemManager::run_evaluation, this));
+
+  current_state_ = SystemState::INIT;
+
+  RCLCPP_INFO(get_logger(), "Configured. Heartbeat timeout=%.1fs, eval period=%.1fs",
+    heartbeat_timeout_s_, eval_period_s_);
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn SystemManager::on_activate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Activating...");
+  state_pub_->on_activate();
+  publish_state(SystemState::INIT, "system_manager activated");
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn SystemManager::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Deactivating...");
+  state_pub_->on_deactivate();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn SystemManager::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "Cleaning up...");
+  state_pub_.reset();
+  fault_sub_.reset();
+  register_srv_.reset();
+  eval_timer_.reset();
+  subsystems_.clear();
+  current_state_ = SystemState::INIT;
+  return CallbackReturn::SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// Service: subsystem registration
+// ---------------------------------------------------------------------------
+void SystemManager::handle_register(
+  const RegisterSubsystem::Request::SharedPtr req,
+  RegisterSubsystem::Response::SharedPtr res)
+{
+  const auto & name = req->subsystem_name;
+
+  if (subsystems_.count(name) > 0) {
+    RCLCPP_WARN(get_logger(), "Subsystem '%s' already registered, updating", name.c_str());
+  }
+
+  // Create record
+  SubsystemRecord record;
+  record.name = name;
+  record.published_topics = req->published_topics;
+  record.subscribed_topics = req->subscribed_topics;
+  record.heartbeat_topic = req->heartbeat_topic;
+  record.registered = true;
+  record.last_heard = this->now();
+
+  // Initialize heartbeat with defaults
+  record.last_heartbeat.subsystem_name = name;
+  record.last_heartbeat.lifecycle_state = SubsystemHeartbeat::LIFECYCLE_UNCONFIGURED;
+  record.last_heartbeat.healthy = false;
+  record.last_heartbeat.status_message = "awaiting first heartbeat";
+
+  // Create dynamic subscription for this subsystem's heartbeat
+  record.heartbeat_sub = this->create_subscription<SubsystemHeartbeat>(
+    req->heartbeat_topic, 10,
+    [this, name](const SubsystemHeartbeat::SharedPtr msg) {
+      this->on_heartbeat(name, msg);
+    });
+
+  subsystems_[name] = std::move(record);
+
+  res->accepted = true;
+  res->message = "Registered subsystem '" + name + "', listening on " + req->heartbeat_topic;
+
+  RCLCPP_INFO(get_logger(), "Registered subsystem '%s' (heartbeat: %s)",
+    name.c_str(), req->heartbeat_topic.c_str());
+
+  // Re-evaluate immediately
+  run_evaluation();
+}
+
+// ---------------------------------------------------------------------------
+// Subscription callbacks
+// ---------------------------------------------------------------------------
+void SystemManager::on_heartbeat(
+  const std::string & subsystem_name,
+  const SubsystemHeartbeat::SharedPtr msg)
+{
+  auto it = subsystems_.find(subsystem_name);
+  if (it == subsystems_.end()) {
+    RCLCPP_WARN(get_logger(), "Heartbeat from unregistered subsystem '%s'",
+      subsystem_name.c_str());
+    return;
+  }
+
+  it->second.last_heartbeat = *msg;
+  it->second.last_heard = this->now();
+
+  // Immediate re-evaluation on health change
+  run_evaluation();
+}
+
+void SystemManager::on_fault_event(const FaultEvent::SharedPtr msg)
+{
+  RCLCPP_WARN(get_logger(), "Fault event: subsystem=%s type=%s severity=%d desc='%s'",
+    msg->subsystem_name.c_str(),
+    msg->fault_type.c_str(),
+    msg->severity,
+    msg->description.c_str());
+
+  // Emergency faults go straight to SAFE
+  if (msg->severity == FaultEvent::SEVERITY_EMERGENCY) {
+    publish_state(SystemState::SAFE,
+      "EMERGENCY fault from " + msg->subsystem_name + ": " + msg->description);
+    return;
+  }
+
+  // For non-emergency faults, let the normal evaluation handle it
+  run_evaluation();
+}
+
+// ---------------------------------------------------------------------------
+// State evaluation
+// ---------------------------------------------------------------------------
+uint8_t SystemManager::evaluate_system_state() const
+{
+  // If in SAFE mode, stay there (requires manual intervention)
+  if (current_state_ == SystemState::SAFE) {
+    return SystemState::SAFE;
+  }
+
+  // No subsystems registered yet — still booting
+  if (subsystems_.empty()) {
+    return SystemState::INIT;
+  }
+
+  bool all_active = true;
+  bool all_healthy = true;
+
+  auto now = this->now();
+
+  for (const auto & [name, record] : subsystems_) {
+    // Check for heartbeat timeout
+    double elapsed = (now - record.last_heard).seconds();
+    bool timed_out = elapsed > heartbeat_timeout_s_;
+
+    bool is_active =
+      record.last_heartbeat.lifecycle_state == SubsystemHeartbeat::LIFECYCLE_ACTIVE;
+
+    if (!is_active || timed_out) {
+      all_active = false;
+    }
+
+    if (!record.last_heartbeat.healthy || timed_out) {
+      all_healthy = false;
+    }
+  }
+
+  if (all_active && all_healthy) {
+    return SystemState::NOMINAL;
+  }
+
+  return SystemState::DEGRADED;
+}
+
+void SystemManager::run_evaluation()
+{
+  uint8_t new_state = evaluate_system_state();
+
+  if (new_state != current_state_) {
+    // Build reason string
+    std::string reason;
+    switch (new_state) {
+      case SystemState::NOMINAL:
+        reason = "all subsystems active and healthy";
+        break;
+      case SystemState::DEGRADED: {
+        reason = "degraded subsystems:";
+        auto now = this->now();
+        for (const auto & [name, record] : subsystems_) {
+          double elapsed = (now - record.last_heard).seconds();
+          bool timed_out = elapsed > heartbeat_timeout_s_;
+          if (!record.last_heartbeat.healthy ||
+            record.last_heartbeat.lifecycle_state != SubsystemHeartbeat::LIFECYCLE_ACTIVE ||
+            timed_out)
+          {
+            reason += " " + name;
+            if (timed_out) {
+              reason += "(timeout)";
+            }
+          }
+        }
+        break;
+      }
+      case SystemState::INIT:
+        reason = "no subsystems registered";
+        break;
+      default:
+        reason = "state transition";
+        break;
+    }
+    publish_state(new_state, reason);
+  }
+}
+
+void SystemManager::publish_state(uint8_t new_state, const std::string & reason)
+{
+  const char * state_names[] = {"INIT", "NOMINAL", "DEGRADED", "RECOVERY", "SAFE"};
+  const char * old_name = (current_state_ <= 4) ? state_names[current_state_] : "UNKNOWN";
+  const char * new_name = (new_state <= 4) ? state_names[new_state] : "UNKNOWN";
+
+  RCLCPP_INFO(get_logger(), "State transition: %s -> %s (%s)",
+    old_name, new_name, reason.c_str());
+
+  current_state_ = new_state;
+
+  auto msg = SystemState();
+  msg.stamp = this->now();
+  msg.state = new_state;
+  msg.triggering_event = reason;
+
+  // Build degraded subsystems list
+  auto now = this->now();
+  for (const auto & [name, record] : subsystems_) {
+    double elapsed = (now - record.last_heard).seconds();
+    bool timed_out = elapsed > heartbeat_timeout_s_;
+    if (!record.last_heartbeat.healthy ||
+      record.last_heartbeat.lifecycle_state != SubsystemHeartbeat::LIFECYCLE_ACTIVE ||
+      timed_out)
+    {
+      msg.degraded_subsystems.push_back(name);
+    }
+  }
+  state_pub_->publish(msg);
+}
+}  // namespace ssos_core

--- a/ssos_core/src/system_manager_main.cpp
+++ b/ssos_core/src/system_manager_main.cpp
@@ -1,0 +1,16 @@
+#include "ssos_core/system_manager.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<ssos_core::SystemManager>();
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ssos_core/test/test_system_manager.cpp
+++ b/ssos_core/test/test_system_manager.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+#include <memory>
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
+#include "ssos_core/system_manager.hpp"
+#include "space_station_interfaces/msg/system_state.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+#include "space_station_interfaces/srv/register_subsystem.hpp"
+
+using namespace std::chrono_literals;
+using SystemState = space_station_interfaces::msg::SystemState;
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using RegisterSubsystem = space_station_interfaces::srv::RegisterSubsystem;
+
+class SystemManagerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    manager_ = std::make_shared<ssos_core::SystemManager>();
+
+    manager_->configure();
+    manager_->activate();
+
+    client_ = std::make_shared<rclcpp::Node>("test_client");
+    register_client_ = client_->create_client<RegisterSubsystem>("/ssos/register_subsystem");
+
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(manager_->get_node_base_interface());
+    executor_->add_node(client_);
+  }
+
+  void TearDown() override
+  {
+    manager_.reset();
+    client_.reset();
+    executor_.reset();
+    rclcpp::shutdown();
+  }
+
+  void spin_for(std::chrono::milliseconds duration)
+  {
+    auto end = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < end) {
+      executor_->spin_some(10ms);
+    }
+  }
+
+  bool register_subsystem(const std::string & name, const std::string & heartbeat_topic)
+  {
+    auto req = std::make_shared<RegisterSubsystem::Request>();
+    req->subsystem_name = name;
+    req->heartbeat_topic = heartbeat_topic;
+
+    auto future = register_client_->async_send_request(req);
+    spin_for(500ms);
+
+    if (future.wait_for(0s) == std::future_status::ready) {
+      return future.get()->accepted;
+    }
+    return false;
+  }
+
+  std::shared_ptr<ssos_core::SystemManager> manager_;
+  std::shared_ptr<rclcpp::Node> client_;
+  rclcpp::Client<RegisterSubsystem>::SharedPtr register_client_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+};
+
+TEST_F(SystemManagerTest, StartsInInitState)
+{
+  EXPECT_EQ(manager_->get_current_state(), SystemState::INIT);
+}
+
+TEST_F(SystemManagerTest, StaysInitWithNoSubsystems)
+{
+  spin_for(200ms);
+  EXPECT_EQ(manager_->evaluate_system_state(), SystemState::INIT);
+}
+
+TEST_F(SystemManagerTest, RegisterSubsystemAccepted)
+{
+  ASSERT_TRUE(register_client_->wait_for_service(2s));
+  bool accepted = register_subsystem("eclss", "/ssos/eclss/heartbeat");
+  EXPECT_TRUE(accepted);
+}
+
+TEST_F(SystemManagerTest, DegradedWhenHeartbeatMissing)
+{
+  ASSERT_TRUE(register_client_->wait_for_service(2s));
+  register_subsystem("eclss", "/ssos/eclss/heartbeat");
+  spin_for(200ms);
+  EXPECT_EQ(manager_->get_current_state(), SystemState::DEGRADED);
+}
+
+TEST_F(SystemManagerTest, NominalWhenAllHealthy)
+{
+  ASSERT_TRUE(register_client_->wait_for_service(2s));
+  register_subsystem("eclss", "/ssos/eclss/heartbeat");
+
+  auto hb_pub = client_->create_publisher<SubsystemHeartbeat>("/ssos/eclss/heartbeat", 10);
+
+  auto hb = SubsystemHeartbeat();
+  hb.subsystem_name = "eclss";
+  hb.lifecycle_state = SubsystemHeartbeat::LIFECYCLE_ACTIVE;
+  hb.healthy = true;
+  hb.status_message = "OK";
+
+  spin_for(200ms);
+  hb_pub->publish(hb);
+  spin_for(500ms);
+
+  EXPECT_EQ(manager_->get_current_state(), SystemState::NOMINAL);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Introduces the `ssos_core` package containing the `system_manager` node — the
central spine of the SSOS global state model. This lifecycle node aggregates
subsystem heartbeats, receives fault events, and publishes a unified system
state on `/ssos/system_state`.

## What it does

The `system_manager` implements the Epic B global state model:

- **INIT** → no subsystems registered yet
- **NOMINAL** → all registered subsystems active and healthy
- **DEGRADED** → any subsystem unhealthy, inactive, or heartbeat timed out
- **SAFE** → emergency fault received (requires manual intervention)

Subsystems register dynamically via `/ssos/register_subsystem`, which creates
a per-subsystem heartbeat subscription at runtime. No hardcoded topic names.

## Topics and services

| Direction | Topic / Service | Type |
|-----------|----------------|------|
| PUB | `/ssos/system_state` | `SystemState` |
| SUB | `/ssos/fault_event` | `FaultEvent` |
| SUB | `/ssos/<name>/heartbeat` | `SubsystemHeartbeat` (dynamic) |
| SRV | `/ssos/register_subsystem` | `RegisterSubsystem` |

