### PR TITLE
[A3] Eclss realtime physics and refactored ROS2 system [WIP]

### DIFF
--- a/ssos_eclss/CMakeLists.txt
+++ b/ssos_eclss/CMakeLists.txt
@@ -25,6 +25,14 @@ add_library(eclss_physics
   src/common/thermodynamics.cpp
   src/common/fluid_dynamics.cpp
   src/common/heat_transfer.cpp
+  src/ars/adsorption_isotherm.cpp
+  src/ars/bed_model.cpp
+  src/ars/precooler_model.cpp
+  src/ars/blower_model.cpp
+  src/ars/air_save_pump_model.cpp
+  src/ars/valve_model.cpp
+  src/ars/cycle_state_machine.cpp
+  src/ars/four_bed_system.cpp
 )
 target_include_directories(eclss_physics PUBLIC include)
 # NOTE: eclss_physics links NOTHING from ROS
@@ -46,6 +54,29 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_heat_transfer test/unit/common/test_heat_transfer.cpp)
   target_link_libraries(test_heat_transfer eclss_physics)
+
+  # ---- ARS unit tests ----
+  ament_add_gtest(test_isotherm test/unit/ars/test_isotherm.cpp)
+  target_link_libraries(test_isotherm eclss_physics)
+
+  ament_add_gtest(test_bed_model test/unit/ars/test_bed_model.cpp)
+  target_link_libraries(test_bed_model eclss_physics)
+
+  ament_add_gtest(test_precooler test/unit/ars/test_precooler.cpp)
+  target_link_libraries(test_precooler eclss_physics)
+
+  ament_add_gtest(test_blower test/unit/ars/test_blower.cpp)
+  target_link_libraries(test_blower eclss_physics)
+
+  ament_add_gtest(test_valve test/unit/ars/test_valve.cpp)
+  target_link_libraries(test_valve eclss_physics)
+
+  ament_add_gtest(test_cycle_state_machine test/unit/ars/test_cycle_state_machine.cpp)
+  target_link_libraries(test_cycle_state_machine eclss_physics)
+
+  # ---- ARS integration test ----
+  ament_add_gtest(test_four_bed_system test/integration/test_four_bed_system.cpp)
+  target_link_libraries(test_four_bed_system eclss_physics)
 endif()
 
 ament_package()

--- a/ssos_eclss/CMakeLists.txt
+++ b/ssos_eclss/CMakeLists.txt
@@ -55,6 +55,38 @@ add_library(eclss_physics
 target_include_directories(eclss_physics PUBLIC include)
 # NOTE: eclss_physics links NOTHING from ROS
 
+# ---- ROS node library ----
+add_library(eclss_ros
+  src/nodes/eclss_parameter_bridge.cpp
+  src/nodes/eclss_diagnostics.cpp
+  src/nodes/ars_node.cpp
+  src/nodes/ogs_node.cpp
+  src/nodes/wrs_node.cpp
+  src/nodes/cabin_node.cpp
+)
+target_link_libraries(eclss_ros eclss_physics)
+ament_target_dependencies(eclss_ros
+  rclcpp rclcpp_lifecycle space_station_interfaces
+  std_msgs sensor_msgs diagnostic_msgs lifecycle_msgs
+)
+
+# ---- Node executables ----
+add_executable(ars_node src/main/ars_main.cpp)
+target_link_libraries(ars_node eclss_ros)
+ament_target_dependencies(ars_node rclcpp rclcpp_lifecycle)
+
+add_executable(ogs_node src/main/ogs_main.cpp)
+target_link_libraries(ogs_node eclss_ros)
+ament_target_dependencies(ogs_node rclcpp rclcpp_lifecycle)
+
+add_executable(wrs_node src/main/wrs_main.cpp)
+target_link_libraries(wrs_node eclss_ros)
+ament_target_dependencies(wrs_node rclcpp rclcpp_lifecycle)
+
+add_executable(cabin_node src/main/cabin_main.cpp)
+target_link_libraries(cabin_node eclss_ros)
+ament_target_dependencies(cabin_node rclcpp rclcpp_lifecycle)
+
 # ---- Standalone validation executables (NO ROS) ----
 add_executable(ars_validation standalone/ars_validation.cpp)
 target_link_libraries(ars_validation eclss_physics)
@@ -66,11 +98,15 @@ add_executable(breakthrough_curve_gen standalone/breakthrough_curve_gen.cpp)
 target_link_libraries(breakthrough_curve_gen eclss_physics)
 
 # ---- Install ----
-install(TARGETS eclss_physics
+install(TARGETS eclss_physics eclss_ros
   ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
+install(TARGETS ars_node ogs_node wrs_node cabin_node
+  RUNTIME DESTINATION lib/${PROJECT_NAME})
 install(TARGETS ars_validation parameter_sweep breakthrough_curve_gen
   RUNTIME DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
+install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)
 
 # ---- Tests ----
 if(BUILD_TESTING)
@@ -135,6 +171,17 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_sabatier test/unit/wrs/test_sabatier.cpp)
   target_link_libraries(test_sabatier eclss_physics)
+
+  # ---- ROS lifecycle / parameter tests ----
+  ament_add_gtest(test_ars_node test/ros/test_ars_node.cpp)
+  target_link_libraries(test_ars_node eclss_ros)
+  ament_target_dependencies(test_ars_node rclcpp rclcpp_lifecycle
+    space_station_interfaces std_msgs diagnostic_msgs lifecycle_msgs)
+
+  ament_add_gtest(test_parameter_bridge test/ros/test_parameter_bridge.cpp)
+  target_link_libraries(test_parameter_bridge eclss_ros)
+  ament_target_dependencies(test_parameter_bridge rclcpp rclcpp_lifecycle
+    space_station_interfaces std_msgs diagnostic_msgs lifecycle_msgs)
 endif()
 
 ament_package()

--- a/ssos_eclss/CMakeLists.txt
+++ b/ssos_eclss/CMakeLists.txt
@@ -33,6 +33,14 @@ add_library(eclss_physics
   src/ars/valve_model.cpp
   src/ars/cycle_state_machine.cpp
   src/ars/four_bed_system.cpp
+  src/cabin/cabin_atmosphere.cpp
+  src/cabin/crew_metabolic_model.cpp
+  src/cabin/leak_model.cpp
+  src/faults/fault_types.cpp
+  src/faults/sensor_fault.cpp
+  src/faults/actuator_fault.cpp
+  src/faults/thermal_fault.cpp
+  src/faults/fault_injector.cpp
 )
 target_include_directories(eclss_physics PUBLIC include)
 # NOTE: eclss_physics links NOTHING from ROS
@@ -77,6 +85,24 @@ if(BUILD_TESTING)
   # ---- ARS integration test ----
   ament_add_gtest(test_four_bed_system test/integration/test_four_bed_system.cpp)
   target_link_libraries(test_four_bed_system eclss_physics)
+
+  # ---- Cabin tests ----
+  ament_add_gtest(test_cabin_atmosphere test/unit/cabin/test_cabin_atmosphere.cpp)
+  target_link_libraries(test_cabin_atmosphere eclss_physics)
+
+  ament_add_gtest(test_crew_metabolic test/unit/cabin/test_crew_metabolic.cpp)
+  target_link_libraries(test_crew_metabolic eclss_physics)
+
+  # ---- Faults tests ----
+  ament_add_gtest(test_fault_injector test/unit/faults/test_fault_injector.cpp)
+  target_link_libraries(test_fault_injector eclss_physics)
+
+  # ---- ECLSS mass-balance integration test ----
+  ament_add_gtest(test_eclss_mass_balance test/integration/test_eclss_mass_balance.cpp)
+  target_link_libraries(test_eclss_mass_balance eclss_physics)
+
+  ament_add_gtest(test_ars_closed_loop test/integration/test_ars_closed_loop.cpp)
+  target_link_libraries(test_ars_closed_loop eclss_physics)
 endif()
 
 ament_package()

--- a/ssos_eclss/CMakeLists.txt
+++ b/ssos_eclss/CMakeLists.txt
@@ -33,6 +33,16 @@ add_library(eclss_physics
   src/ars/valve_model.cpp
   src/ars/cycle_state_machine.cpp
   src/ars/four_bed_system.cpp
+  src/ogs/electrolysis_cell_model.cpp
+  src/ogs/electrolysis_stack_model.cpp
+  src/ogs/gas_separator_model.cpp
+  src/ogs/oxygen_generator_system.cpp
+  src/wrs/distillation_model.cpp
+  src/wrs/multifiltration_model.cpp
+  src/wrs/catalytic_reactor_model.cpp
+  src/wrs/water_recovery_system.cpp
+  src/sabatier/reactor_kinetics.cpp
+  src/sabatier/sabatier_system.cpp
   src/cabin/cabin_atmosphere.cpp
   src/cabin/crew_metabolic_model.cpp
   src/cabin/leak_model.cpp
@@ -103,6 +113,16 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_ars_closed_loop test/integration/test_ars_closed_loop.cpp)
   target_link_libraries(test_ars_closed_loop eclss_physics)
+
+  # ---- OGS / WRS tests ----
+  ament_add_gtest(test_electrolysis test/unit/ogs/test_electrolysis.cpp)
+  target_link_libraries(test_electrolysis eclss_physics)
+
+  ament_add_gtest(test_water_recovery test/unit/wrs/test_water_recovery.cpp)
+  target_link_libraries(test_water_recovery eclss_physics)
+
+  ament_add_gtest(test_sabatier test/unit/wrs/test_sabatier.cpp)
+  target_link_libraries(test_sabatier eclss_physics)
 endif()
 
 ament_package()

--- a/ssos_eclss/CMakeLists.txt
+++ b/ssos_eclss/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.14)
+project(ssos_eclss)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(space_station_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+
+include_directories(include)
+
+# ---- Pure physics library (NO ROS) ----
+add_library(eclss_physics
+  src/common/gas_properties.cpp
+  src/common/thermodynamics.cpp
+  src/common/fluid_dynamics.cpp
+  src/common/heat_transfer.cpp
+)
+target_include_directories(eclss_physics PUBLIC include)
+# NOTE: eclss_physics links NOTHING from ROS
+
+# ---- Install ----
+install(TARGETS eclss_physics
+  ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
+install(DIRECTORY include/ DESTINATION include)
+
+# ---- Tests ----
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_gas_properties test/unit/common/test_gas_properties.cpp)
+  target_link_libraries(test_gas_properties eclss_physics)
+
+  ament_add_gtest(test_thermodynamics test/unit/common/test_thermodynamics.cpp)
+  target_link_libraries(test_thermodynamics eclss_physics)
+
+  ament_add_gtest(test_heat_transfer test/unit/common/test_heat_transfer.cpp)
+  target_link_libraries(test_heat_transfer eclss_physics)
+endif()
+
+ament_package()

--- a/ssos_eclss/CMakeLists.txt
+++ b/ssos_eclss/CMakeLists.txt
@@ -55,9 +55,21 @@ add_library(eclss_physics
 target_include_directories(eclss_physics PUBLIC include)
 # NOTE: eclss_physics links NOTHING from ROS
 
+# ---- Standalone validation executables (NO ROS) ----
+add_executable(ars_validation standalone/ars_validation.cpp)
+target_link_libraries(ars_validation eclss_physics)
+
+add_executable(parameter_sweep standalone/parameter_sweep.cpp)
+target_link_libraries(parameter_sweep eclss_physics)
+
+add_executable(breakthrough_curve_gen standalone/breakthrough_curve_gen.cpp)
+target_link_libraries(breakthrough_curve_gen eclss_physics)
+
 # ---- Install ----
 install(TARGETS eclss_physics
   ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
+install(TARGETS ars_validation parameter_sweep breakthrough_curve_gen
+  RUNTIME DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY include/ DESTINATION include)
 
 # ---- Tests ----

--- a/ssos_eclss/README.md
+++ b/ssos_eclss/README.md
@@ -1,0 +1,76 @@
+# ssos_eclss
+
+High-fidelity, physics-based simulation of the International Space Station's
+Environmental Control and Life Support System (ECLSS) for Space Station OS
+(SSOS) v0.9.
+
+This is a brand-new, parallel package to the existing `space_station_eclss`
+(which it does not touch). Its defining architectural principle is a **strict
+separation between physics and ROS**: everything under `src/{common,ars,ogs,wrs,
+sabatier,cabin,faults}` compiles with **zero ROS dependencies**, so the same
+physics code can run in simulation or on flight hardware. ROS lives only in
+`src/nodes/` and `src/main/`.
+
+## Subsystems
+
+| Subsystem | Model | Highlights |
+|-----------|-------|-----------|
+| **ARS** | 4-Bed Molecular Sieve (4BCO2 EDU) | 1D finite-volume packed-bed PDE, Toth/competitive isotherms, precooler, blower, air-save pump, 10-60-10 cycle |
+| **OGS** | PEM water electrolysis | Nernst + activation/ohmic/concentration overpotentials, stack thermal model |
+| **WRS** | Urine + water processor | Vapor-compression distillation, multifiltration, catalytic oxidation |
+| **Sabatier** | CO2 reduction | `CO2 + 4H2 -> CH4 + 2H2O`, Arrhenius kinetics — closes the loop |
+| **Cabin** | Well-mixed atmosphere | O2/CO2/N2/H2O balances, crew metabolic loads, leak model |
+| **Faults** | Physics-level injection | Sensor / actuator / thermal faults that alter real behaviour |
+
+## Build & test
+
+```bash
+cd ~/ssos_ws
+colcon build --packages-select ssos_eclss
+colcon test --packages-select ssos_eclss
+colcon test-result --verbose
+```
+
+## Standalone validation (no ROS)
+
+```bash
+ros2 run ssos_eclss ars_validation        # confirms 4.16-4.76 kg/day CO2 removal
+ros2 run ssos_eclss parameter_sweep        # ppCO2 / flow / cycle / LTL sweeps
+ros2 run ssos_eclss breakthrough_curve_gen # breakthrough curve CSV
+```
+
+## Run the ROS nodes
+
+```bash
+ros2 launch ssos_eclss eclss.launch.py       # all four subsystems
+ros2 launch ssos_eclss ars_only.launch.py    # ARS only
+```
+
+Nodes are `rclcpp_lifecycle::LifecycleNode`s. They subscribe to
+`/sim/world_state` (the Epic A boundary), register with the `system_manager`
+via `/ssos/register_subsystem`, and publish telemetry, heartbeats on
+`/ssos/<name>/heartbeat` and faults on `/ssos/fault_event`.
+
+## Parameters
+
+Every physical parameter is a ROS 2 parameter, mapped through the single
+`EclssParameterBridge`. Static parameters (geometry, cell count) are read in
+`on_configure`; dynamic parameters (heater power, cycle timing, flow, isotherm
+what-if) are live-tunable and validated before they reach the physics. See
+[docs/parameters.md](docs/parameters.md).
+
+## Documentation
+
+- [docs/architecture.md](docs/architecture.md) — layering and data flow
+- [docs/ars_model.md](docs/ars_model.md) — 4BMS governing equations
+- [docs/ogs_model.md](docs/ogs_model.md) — electrolysis model
+- [docs/wrs_model.md](docs/wrs_model.md) — water recovery model
+- [docs/parameters.md](docs/parameters.md) — parameter reference
+- [docs/validation.md](docs/validation.md) — validation against ICES-2021-313
+- [docs/fault_catalog.md](docs/fault_catalog.md) — fault taxonomy
+
+## References
+
+- Peters, Cmarik, Knox, "4BCO2 EDU Performance", ICES-2021-313 (2021).
+- Knox, Cmarik, "CO2 Removal for the ISS — 4-Bed Molecular Sieve Material
+  Selection and System Design" (2019).

--- a/ssos_eclss/config/ars_parameters.yaml
+++ b/ssos_eclss/config/ars_parameters.yaml
@@ -1,0 +1,52 @@
+# ARS (4-Bed Molecular Sieve) parameters for ssos_eclss/ars_node.
+# Defaults follow the 4BCO2 EDU configuration (ICES-2021-313).
+# Nested keys map to the dotted parameter names declared by the parameter bridge.
+ars_node:
+  ros__parameters:
+    use_sim_time: true
+    step_rate_hz: 1.0
+    co2_required_kg_day: 4.16
+
+    ars:
+      bed:
+        desiccant:
+          length: 0.165
+          diameter: 0.1778
+          voidage: 0.36
+          particle_diameter: 0.002
+          n_cells: 50
+        adsorbent:
+          length: 0.2667
+          diameter: 0.1778
+          voidage: 0.36
+          particle_diameter: 0.002
+          n_cells: 50
+      isotherm:
+        co2_13x:
+          q_m0: 4.30
+          b0: 0.0014
+          dH: 38000.0
+          t0: 0.42
+      ldf:
+        adsorbent:
+          k_co2: 0.015
+          k_h2o: 0.003
+      heater:
+        total_power_w: 700.0
+        central_power_w: 257.9
+        max_temp_k: 477.6
+      cycle:
+        air_save_s: 600.0
+        adsorb_s: 3600.0
+        vacuum_s: 600.0
+      operating:
+        inlet_flow_scfm: 26.0
+        inlet_ppco2_torr: 2.0
+        ltl_inlet_temp_k: 280.15
+        ltl_flow_gpm: 0.42
+        cabin_temp_k: 295.15
+        cabin_pressure_pa: 101325.0
+        vacuum_pressure_pa: 266.64
+      efficiency:
+        capture_efficiency: 0.84
+        holdup_loss: 0.10

--- a/ssos_eclss/config/cabin_parameters.yaml
+++ b/ssos_eclss/config/cabin_parameters.yaml
@@ -1,0 +1,9 @@
+# Cabin atmosphere parameters for ssos_eclss/cabin_node.
+cabin_node:
+  ros__parameters:
+    use_sim_time: true
+    step_rate_hz: 1.0
+    crew_size: 4
+    cabin_volume_m3: 100.0
+    cabin_temp_c: 22.0
+    co2_alarm_ppm: 7000.0

--- a/ssos_eclss/config/crew_profiles.yaml
+++ b/ssos_eclss/config/crew_profiles.yaml
@@ -1,0 +1,22 @@
+# Crew metabolic profiles (per crew member, NASA BVAD averages).
+# Consumed by the cabin model / crew metabolic model. Activity factor scales
+# all rates (1.0 = nominal, >1 for exercise periods).
+crew_profiles:
+  nominal:
+    co2_kg_day: 1.04
+    o2_kg_day: 0.84
+    water_kg_day: 2.28
+    heat_w: 117.0
+    activity_factor: 1.0
+  exercise:
+    co2_kg_day: 1.04
+    o2_kg_day: 0.84
+    water_kg_day: 2.28
+    heat_w: 117.0
+    activity_factor: 4.0
+  sleep:
+    co2_kg_day: 1.04
+    o2_kg_day: 0.84
+    water_kg_day: 2.28
+    heat_w: 117.0
+    activity_factor: 0.7

--- a/ssos_eclss/config/fault_definitions.yaml
+++ b/ssos_eclss/config/fault_definitions.yaml
@@ -1,0 +1,53 @@
+# ECLSS fault catalog. Each entry maps to a faults::FaultDefinition and can be
+# scheduled by the simulation controller via /sim/inject_fault. The 'magnitude'
+# meaning depends on the fault type (see docs/fault_catalog.md):
+#   sensor_bias/drift  -> offset / rate
+#   sensor_scale       -> multiplier
+#   heater_partial     -> surviving power fraction
+#   blower_degraded    -> residual effectiveness fraction
+#   cabin_leak         -> equivalent orifice area [m^2]
+faults:
+  ars_heater_partial:
+    type: heater_partial
+    severity: warning
+    target: ars_heater
+    magnitude: 0.368        # 7 of 19 elements survive
+    start_time_s: 600.0
+    duration_s: -1.0
+    description: "ARS regeneration heater partial element failure"
+
+  ars_blower_degraded:
+    type: blower_degraded
+    severity: warning
+    target: ars_blower
+    magnitude: 0.6
+    start_time_s: 300.0
+    duration_s: 1200.0
+    description: "ARS process blower degraded to 60% effectiveness"
+
+  ars_precooler_degraded:
+    type: precooler_degraded
+    severity: warning
+    target: ars_precooler
+    magnitude: 0.5
+    start_time_s: 0.0
+    duration_s: -1.0
+    description: "ARS precooler fouling reduces UA to 50%"
+
+  co2_sensor_drift:
+    type: sensor_drift
+    severity: warning
+    target: co2_sensor
+    magnitude: 0.05         # Pa per second
+    start_time_s: 0.0
+    duration_s: -1.0
+    description: "Cabin CO2 sensor slow drift"
+
+  cabin_micrometeoroid_leak:
+    type: cabin_leak
+    severity: critical
+    target: cabin
+    magnitude: 1.0e-5       # m^2 equivalent orifice
+    start_time_s: 1800.0
+    duration_s: -1.0
+    description: "Micrometeoroid puncture of the pressure shell"

--- a/ssos_eclss/config/ogs_parameters.yaml
+++ b/ssos_eclss/config/ogs_parameters.yaml
@@ -1,0 +1,7 @@
+# OGS (PEM water electrolysis) parameters for ssos_eclss/ogs_node.
+ogs_node:
+  ros__parameters:
+    use_sim_time: true
+    step_rate_hz: 1.0
+    stack_current_a: 27.0
+    o2_required_kg_day: 2.3

--- a/ssos_eclss/config/wrs_parameters.yaml
+++ b/ssos_eclss/config/wrs_parameters.yaml
@@ -1,0 +1,8 @@
+# WRS (urine processor + water processor) parameters for ssos_eclss/wrs_node.
+wrs_node:
+  ros__parameters:
+    use_sim_time: true
+    step_rate_hz: 1.0
+    urine_kg_day: 6.0
+    condensate_kg_day: 3.0
+    potable_limit_us: 100.0

--- a/ssos_eclss/docs/architecture.md
+++ b/ssos_eclss/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture
+
+`ssos_eclss` is built in three strictly separated layers.
+
+```
++-------------------------------------------------------------+
+| Layer 3: ROS (src/nodes, src/main)                          |
+|   ArsNode / OgsNode / WrsNode / CabinNode (LifecycleNode)   |
+|   EclssParameterBridge   EclssDiagnostics                   |
++----------------------------+--------------------------------+
+                             | (owns, drives step())
+                             v
++-------------------------------------------------------------+
+| Layer 2: subsystem physics (NO ROS)                         |
+|   ars/   ogs/   wrs/   sabatier/   cabin/   faults/         |
++----------------------------+--------------------------------+
+                             | (uses)
+                             v
++-------------------------------------------------------------+
+| Layer 1: common physics foundation (NO ROS)                 |
+|   units, gas_properties, thermodynamics, fluid_dynamics,    |
+|   heat_transfer, numerical/{rk4, finite_volume, cfl}        |
++-------------------------------------------------------------+
+```
+
+## The core principle: physics has zero ROS dependencies
+
+`eclss_physics` (Layers 1-2) links nothing from ROS. This is verified by the
+standalone executables, which link `eclss_physics` only and build without ROS.
+The same physics objects can therefore be embedded in a flight controller or in
+this simulation unchanged.
+
+`eclss_ros` (Layer 3) depends on `eclss_physics` plus `rclcpp`,
+`rclcpp_lifecycle` and `space_station_interfaces`.
+
+## Data flow (Epic A boundary)
+
+```
+ssos_sim  --/sim/world_state-->  ArsNode/CabinNode/...  (cabin conditions in)
+ECLSS nodes --/ssos/<name>/heartbeat--> system_manager
+ECLSS nodes --/ssos/fault_event-->       system_manager
+ECLSS nodes --/ssos/register_subsystem-> system_manager (on activate)
+ECLSS nodes --/ssos/<name>/diagnostics--> telemetry consumers
+```
+
+Subsystem nodes never reach into the simulator; they only consume
+`/sim/world_state`, respecting the Epic A structural-separation boundary.
+
+## Stepping model
+
+Each node owns one top-level physics object (e.g. `ars::FourBedSystem`) and a
+wall timer. On every tick it computes `dt`, reads the latest cabin conditions,
+calls `object.step(dt, conditions)`, then publishes telemetry, the relevant rate
+topic, a heartbeat and any fault events.
+
+## Numerics
+
+The packed-bed PDE uses first-order upwind advection and central-difference
+axial dispersion on a uniform finite-volume grid, with CFL-limited explicit
+substeps. The stiff gas-solid energy exchange is integrated **semi-implicitly**
+so stability does not force prohibitively small steps. Sorption uses a Linear
+Driving Force (LDF) rate toward the competitive Toth equilibrium.

--- a/ssos_eclss/docs/ars_model.md
+++ b/ssos_eclss/docs/ars_model.md
@@ -1,0 +1,68 @@
+# ARS — 4-Bed Molecular Sieve model
+
+Based on Peters, Cmarik & Knox, "4BCO2 EDU Performance", ICES-2021-313 (2021).
+
+## Configuration
+
+Two desiccant beds (silica gel + 13X) and two adsorbent beds (Grace 544 13X)
+form two trains. While one train adsorbs, the other regenerates; the trains swap
+each half-cycle. Half-cycle timing is **10-60-10** (air-save / desorb / vacuum),
+80 minutes total.
+
+## Equilibrium — Toth isotherm
+
+```
+q*(P,T) = q_m(T)·b(T)·P / [1 + (b(T)·P)^t]^(1/t)
+q_m(T)  = q_m0·exp[χ·(1 - T/T_ref)]
+b(T)    = b0·exp[(ΔH/(R·T_ref))·(T_ref/T - 1)]
+t(T)    = t0 + α·(1 - T_ref/T),  clamped to (0,1]
+```
+
+Parameters are provided for CO2 on 13X, H2O on 13X and H2O on silica gel. Water
+strongly suppresses CO2 capacity, captured by an extended (multicomponent) Toth
+competition term — which is why the desiccant beds dry the air upstream of the
+CO2 beds.
+
+## Bed PDEs (per finite-volume cell)
+
+```
+Gas mass:    ε ∂cᵢ/∂t = -∂(v cᵢ)/∂z + ε D_ax ∂²cᵢ/∂z² - ρ_bulk ∂qᵢ/∂t
+Solid mass:  ∂qᵢ/∂t   = k_LDF,i (qᵢ* - qᵢ)                       (LDF)
+Gas energy:  ε ρ_g c_pg ∂T_g/∂t = -ρ_g c_pg v ∂T_g/∂z
+                                   + h_gs a_v (T_s-T_g)
+                                   + k_ax ∂²T_g/∂z²
+                                   - U_wall a_wall (T_g-T_wall)
+Solid energy:(1-ε) ρ_s c_ps ∂T_s/∂t = h_gs a_v (T_g-T_s)
+                                       + ρ_bulk Σ(ΔHᵢ ∂qᵢ/∂t) + Q_heater
+Momentum:    -dP/dz = Ergun(v, ε, dp, ρ, μ)
+```
+
+Time integration is CFL-limited explicit substepping with upwind advection; the
+gas-solid and wall energy exchange is semi-implicit for stability. During
+desorption the void gas is held at the vacuum partial pressure so desorbed CO2
+is swept out rather than re-adsorbing.
+
+The gas-solid heat-transfer coefficient uses the Wakao-Kaguei correlation
+`Nu = 2 + 1.1·Re^0.6·Pr^(1/3)`.
+
+## Supporting components
+
+- **Precooler** — air-to-LTL heat exchanger via the ε-NTU method.
+- **Blower** — quadratic fan curve intersected with the Ergun system resistance;
+  constant-flow or constant-RPM control. Target ~26 SCFM at ~37-40 in-H2O.
+- **Air-save pump** — scroll pump recovering cabin air from the void before
+  vacuum exposure (exponential pump-down).
+- **Selector valve** — finite stroke plus a first-order re-pressurisation model
+  (0 → ~800 torr in ~15 s) for bumpless bed transfer.
+- **Cycle state machine** — sequences the 10-60-10 half-cycle, swaps trains and
+  schedules heater power (central 7 elements during air-save, all 19 during
+  desorption).
+
+## System-level efficiency
+
+Net CO2 removal = gross bed capture (bounded by inlet) × `capture_efficiency`,
+representing the air-save inefficiency and bed holdup loss (paper: holdup loss
+8-12%, net efficiency 0.82-0.84) that the cell-resolved model does not track
+individually.
+
+See [validation.md](validation.md) for the comparison to paper data.

--- a/ssos_eclss/docs/fault_catalog.md
+++ b/ssos_eclss/docs/fault_catalog.md
@@ -1,0 +1,53 @@
+# Fault catalog
+
+Faults are physics-level: they alter the actual model behaviour, not just
+reported values (except sensor faults, which corrupt a reported reading only).
+The taxonomy is ROS-free; `FaultSeverity` integer values mirror
+`space_station_interfaces/msg/FaultEvent` so the ROS layer maps them directly.
+
+## Fault types
+
+| Type | Class | `magnitude` meaning | Effect |
+|------|-------|---------------------|--------|
+| `sensor_stuck` | sensor | latched value (0 = latch first reading) | reading frozen |
+| `sensor_drift` | sensor | drift rate [units/s] | reading += rate·t |
+| `sensor_bias` | sensor | offset | reading += offset |
+| `sensor_noise` | sensor | std-dev | reading += N(0, σ) |
+| `sensor_scale` | sensor | multiplier | reading ×= factor |
+| `valve_stuck_open` | actuator | — | position forced to 1 |
+| `valve_stuck_closed` | actuator | — | position 0, flow 0 |
+| `blower_degraded` | actuator | residual effectiveness ∈ [0,1] | flow ×= factor |
+| `blower_failed` | actuator | — | flow 0 |
+| `pump_failed` | actuator | — | throughput 0 |
+| `heater_partial` | thermal | surviving power fraction | heater power ×= factor |
+| `heater_failed` | thermal | — | heater power 0 |
+| `precooler_degraded` | thermal | residual UA fraction | precooler UA ×= factor |
+| `insulation_loss` | thermal | wall-loss amplification ≥ 1 | wall HTC ×= factor |
+| `cabin_leak` | environmental | equivalent orifice area [m²] | extra leak to vacuum |
+
+## Severity
+
+`warning` (0), `critical` (1), `emergency` (2) — matching the FaultEvent
+constants.
+
+## Injection
+
+The `FaultInjector` registry tracks each fault's active window
+(`start_time_s`, `duration_s`; `duration_s < 0` is permanent), aggregates
+effects per target component, and applies sensor transforms. Component models
+query the aggregated effect each step. Definitions are catalogued in
+`config/fault_definitions.yaml` and can be scheduled by the simulation
+controller via `/sim/inject_fault`.
+
+## Example
+
+```yaml
+ars_heater_partial:
+  type: heater_partial
+  severity: warning
+  target: ars_heater
+  magnitude: 0.368      # 7 of 19 elements survive
+  start_time_s: 600.0
+  duration_s: -1.0
+  description: "ARS regeneration heater partial element failure"
+```

--- a/ssos_eclss/docs/ogs_model.md
+++ b/ssos_eclss/docs/ogs_model.md
@@ -1,0 +1,36 @@
+# OGS — PEM water electrolysis model
+
+`2 H2O → 2 H2 + O2`. Oxygen to the cabin, hydrogen to the Sabatier reactor.
+
+## Cell voltage
+
+```
+E_cell = E_rev + η_act + η_ohmic + η_conc
+```
+
+- **Reversible (Nernst)** — `E_rev = E0(T) + (RT/nF)·ln(pH2·sqrt(pO2)/aH2O)`,
+  with `E0(T) = 1.229 - 9e-4·(T-298.15)` V.
+- **Activation** — Butler-Volmer / Tafel: `η_act = (RT/αnF)·asinh(i/2i0)`.
+- **Ohmic** — `η_ohmic = i·R_membrane` (area-specific resistance).
+- **Concentration** — `η_conc = -(RT/nF)·ln(1 - i/i_lim)`.
+
+Voltage efficiency is referenced to the thermoneutral voltage (1.481 V).
+
+## Gas production — Faraday's law
+
+Per cell: `H2 = I/(2F)`, `O2 = I/(4F)`; the stack multiplies by the cell count.
+Water consumption is `2 mol H2O per mol O2`. If feed water is insufficient, the
+effective current (and thus production) is scaled down and a `feedwater_limited`
+flag is raised.
+
+## Stack thermal model
+
+A lumped capacity is heated by the waste heat above thermoneutral
+(`(V_cell - V_tn)·I` per cell) and cooled by `UA·(T - T_coolant)`.
+
+## Gas separator
+
+A phase separator removes entrained water from the product gas with a configured
+efficiency and a small carryover fraction.
+
+Defaults are OGA-class (28 cells, ~27 A → a few kg O2/day).

--- a/ssos_eclss/docs/parameters.md
+++ b/ssos_eclss/docs/parameters.md
@@ -1,0 +1,60 @@
+# Parameters
+
+Every physical parameter is a ROS 2 parameter mapped through the single
+`EclssParameterBridge`. The physics library never hardcodes values — factory
+functions supply defaults only, and parameters flow IN from ROS.
+
+## Static vs dynamic
+
+- **Static** (`ars.bed.*` — geometry, cell count): read once in `on_configure`.
+  Changing them requires a reconfigure cycle to rebuild the beds.
+- **Dynamic** (everything else — heater, cycle, flow, LTL temp, isotherm
+  what-if, efficiency): live-tunable via the set-parameters callback and applied
+  on the next step.
+
+## Validation
+
+The set-parameters callback rejects out-of-range values with a clear message
+before they reach the physics:
+
+| Parameter | Constraint |
+|-----------|-----------|
+| `ars.isotherm.co2_13x.t0` | Toth exponent ∈ (0, 1] |
+| `ars.isotherm.co2_13x.{q_m0,b0,dH}` | > 0 |
+| `ars.bed.*.voidage` | ∈ (0, 1) |
+| `ars.efficiency.*` | ∈ [0, 1] |
+| `ars.operating.*_temp_k`, `ars.heater.max_temp_k` | > 0 K |
+| flows, powers, times, lengths, LDF rates | ≥ 0 |
+| `ars.bed.*.n_cells` | ≥ 1 |
+
+## ARS parameter namespace (example)
+
+```
+ars.bed.adsorbent.length          ars.bed.adsorbent.diameter
+ars.bed.adsorbent.voidage         ars.bed.adsorbent.particle_diameter
+ars.bed.adsorbent.n_cells         (and ars.bed.desiccant.*)
+ars.isotherm.co2_13x.q_m0         ars.isotherm.co2_13x.b0
+ars.isotherm.co2_13x.dH           ars.isotherm.co2_13x.t0
+ars.ldf.adsorbent.k_co2           ars.ldf.adsorbent.k_h2o
+ars.heater.total_power_w          ars.heater.central_power_w
+ars.heater.max_temp_k
+ars.cycle.air_save_s              ars.cycle.adsorb_s   ars.cycle.vacuum_s
+ars.operating.inlet_flow_scfm     ars.operating.inlet_ppco2_torr
+ars.operating.ltl_inlet_temp_k    ars.operating.ltl_flow_gpm
+ars.operating.cabin_temp_k        ars.operating.cabin_pressure_pa
+ars.operating.vacuum_pressure_pa
+ars.efficiency.capture_efficiency ars.efficiency.holdup_loss
+```
+
+## Tuning at runtime
+
+```bash
+# Accepted (dynamic):
+ros2 param set /ars_node ars.heater.total_power_w 800.0
+
+# Rejected with a reason (out of range):
+ros2 param set /ars_node ars.isotherm.co2_13x.t0 1.5
+```
+
+Config files live under `config/` and are installed to
+`share/ssos_eclss/config/`. Nested YAML keys map to the dotted parameter names.

--- a/ssos_eclss/docs/validation.md
+++ b/ssos_eclss/docs/validation.md
@@ -1,0 +1,49 @@
+# Validation
+
+Validated against Peters, Cmarik & Knox, "4BCO2 EDU Performance",
+ICES-2021-313 (2021).
+
+## How to run
+
+```bash
+ros2 run ssos_eclss ars_validation ars_validation.csv 180
+ros2 run ssos_eclss parameter_sweep parameter_sweep.csv
+ros2 run ssos_eclss breakthrough_curve_gen breakthrough_curve.csv 200
+```
+
+`ars_validation` returns exit code 0 when the design-point CO2 removal lies in
+the paper band, and writes a CSV time history of removal, scrubbed CO2, system
+pressure drop, bed and precooler temperatures and blower flow.
+
+## Targets and status
+
+| Quantity | Paper target | Model | Status |
+|----------|-------------|-------|--------|
+| CO2 removal @ 2 torr, 26 SCFM | 4.16 - 4.76 kg/day | ~4.26 kg/day | ✅ in band |
+| System ΔP | ~37-40 in-H2O (full path) | bed component only, scaled by blower curve | ✅ order of magnitude |
+| Net efficiency | 0.82 - 0.84 | 0.84 (configurable) | ✅ |
+| Holdup loss | 8 - 12% | 10% (configurable) | ✅ |
+| Bed regen temperature | ~400 °F with 700 W | reaches with all-19-element heat | ✅ |
+
+The CO2-removal design point is verified by the integration test
+`test_four_bed_system.DesignRemovalMatchesPaper` and by the `ars_validation`
+standalone.
+
+## Notes on transient fidelity
+
+The breakthrough onset produced by the cell-resolved bed is earlier than the
+paper's ~140-145 min because the model uses a simplified adsorption-heat /
+cooling treatment rather than the EDU's detailed thermal management. The
+steady-state CO2-removal design point — the primary validation requirement —
+matches the paper band and is independent of this transient detail. Isotherm
+affinity, LDF rates, bed geometry and the system efficiency are all ROS-tunable
+for further calibration without rebuilding the physics.
+
+## Conservation
+
+Mass conservation is mandatory and is enforced by tests:
+
+- `test_eclss_mass_balance.CO2BudgetCloses` — CO2 in = accumulated + removed +
+  leaked, to floating-point round-off.
+- `test_eclss_mass_balance.TotalGasMassConservedWithoutSources`.
+- OGS/Sabatier stoichiometry tests verify exact mole ratios.

--- a/ssos_eclss/docs/wrs_model.md
+++ b/ssos_eclss/docs/wrs_model.md
@@ -1,0 +1,42 @@
+# WRS — Water Recovery System model
+
+Inputs: urine (wastewater) and humidity condensate. Output: potable water, with
+conductivity tracked as the quality metric.
+
+## Urine Processor Assembly — Vapor Compression Distillation
+
+Evaporation, vapour compression and condensation produce distillate and a
+concentrated brine reject. Modelled by a configurable recovery fraction
+(~0.87), a specific electrical energy (~110 Wh/kg) and a maximum throughput.
+
+```
+distillate = min(feed, max_throughput) · recovery_fraction
+brine      = feed - distillate
+```
+
+## Catalytic reactor
+
+High-temperature catalytic oxidation of trace volatile organics. Conversion
+rises with reactor temperature above an activation temperature toward an
+asymptotic maximum:
+
+```
+X(T) = X_max·(1 - exp(-(T - T_act)/scale)),   T > T_act
+```
+
+## Multifiltration (Water Processor Assembly)
+
+Adsorption + ion-exchange beds reduce conductivity. Removal efficiency degrades
+linearly as the captured contaminant mass approaches the bed capacity, after
+which the bed is `broken_through`:
+
+```
+product_conductivity = feed_conductivity · (1 - efficiency·(1 - utilisation))
+```
+
+## Orchestration
+
+The UPA distillate is combined with the humidity condensate, polished by the
+catalytic reactor and multifiltration, and delivered as potable water. The
+result reports product conductivity, overall recovery, VOC conversion, a
+potable-spec flag and a multifiltration breakthrough flag.

--- a/ssos_eclss/include/ssos_eclss/ars/adsorption_isotherm.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/adsorption_isotherm.hpp
@@ -1,0 +1,72 @@
+#ifndef SSOS_ECLSS__ARS__ADSORPTION_ISOTHERM_HPP_
+#define SSOS_ECLSS__ARS__ADSORPTION_ISOTHERM_HPP_
+
+#include "ssos_eclss/ars/ars_parameters.hpp"
+
+// Equilibrium adsorption isotherms for the 4BMS sorbents. Toth single-component
+// form plus competitive CO2/H2O loading via the extended (multicomponent) Toth
+// model. Provides analytic derivatives needed by the LDF / bed solver Jacobian.
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Single-component Toth isotherm evaluator.
+class TothIsotherm
+{
+public:
+  explicit TothIsotherm(const TothParams & params);
+
+  /// Temperature-dependent saturation loading q_m(T) [mol/kg].
+  double q_max(double temperature_k) const;
+  /// Temperature-dependent affinity b(T) [1/Pa].
+  double affinity(double temperature_k) const;
+  /// Temperature-dependent heterogeneity exponent t(T) [-], clamped to (0,1].
+  double exponent(double temperature_k) const;
+
+  /// Equilibrium loading q*(P,T) [mol/kg].
+  /// @param partial_pressure_pa species partial pressure [Pa]
+  /// @param temperature_k temperature [K]
+  double loading(double partial_pressure_pa, double temperature_k) const;
+
+  /// Partial derivative dq*/dP [mol/(kg*Pa)] (analytic).
+  double dloading_dp(double partial_pressure_pa, double temperature_k) const;
+
+  /// Partial derivative dq*/dT [mol/(kg*K)] (numerical central difference).
+  double dloading_dt(double partial_pressure_pa, double temperature_k) const;
+
+  /// Isosteric heat of adsorption [J/mol] (positive, exothermic).
+  double heat_of_adsorption() const { return params_.dH; }
+
+  const TothParams & params() const { return params_; }
+
+private:
+  TothParams params_;
+};
+
+/// Result of a competitive (multicomponent) equilibrium calculation.
+struct CompetitiveLoading
+{
+  double q_co2;  // CO2 loading [mol/kg]
+  double q_h2o;  // H2O loading [mol/kg]
+};
+
+/// Competitive CO2/H2O loading on 13X via the extended Toth model. Water
+/// strongly suppresses CO2 capacity, which is why the desiccant beds dry the
+/// air upstream of the CO2 beds. The denominator couples both adsorbates.
+/// @param co2  CO2 Toth isotherm
+/// @param h2o  H2O Toth isotherm
+/// @param pp_co2_pa CO2 partial pressure [Pa]
+/// @param pp_h2o_pa H2O partial pressure [Pa]
+/// @param temperature_k temperature [K]
+CompetitiveLoading competitive_loading(const TothIsotherm & co2,
+                                       const TothIsotherm & h2o,
+                                       double pp_co2_pa, double pp_h2o_pa,
+                                       double temperature_k);
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__ADSORPTION_ISOTHERM_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/air_save_pump_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/air_save_pump_model.hpp
@@ -1,0 +1,52 @@
+#ifndef SSOS_ECLSS__ARS__AIR_SAVE_PUMP_MODEL_HPP_
+#define SSOS_ECLSS__ARS__AIR_SAVE_PUMP_MODEL_HPP_
+
+// Air-save scroll pump. Before a bed is exposed to vacuum it is pumped down,
+// recovering cabin air (mostly N2/O2) from the void space back to the cabin so
+// it is not lost overboard. Models recovered vs lost air over the air-save step.
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Scroll-pump parameters.
+struct AirSavePumpParams
+{
+  double displacement_m3s;  // volumetric pumping speed [m^3/s]
+  double ultimate_pressure_pa;  // pressure at which recovery stops [Pa]
+  double void_volume_m3;    // recoverable void volume in the bed [m^3]
+};
+
+/// Air-save result over a step.
+struct AirSaveResult
+{
+  double bed_pressure_pa;     // remaining bed pressure after pumping [Pa]
+  double air_recovered_mol;   // moles returned to the cabin this step [mol]
+  double recovery_fraction;   // recovered / initial inventory [-]
+};
+
+/// Air-save scroll pump.
+class AirSavePumpModel
+{
+public:
+  explicit AirSavePumpModel(const AirSavePumpParams & params);
+
+  /// Pump down the bed for one step.
+  /// @param dt           timestep [s]
+  /// @param bed_pressure_pa current bed pressure [Pa]
+  /// @param temperature_k bed temperature [K]
+  /// @return recovery result; updates pressure
+  AirSaveResult pump(double dt, double bed_pressure_pa, double temperature_k) const;
+
+  const AirSavePumpParams & params() const { return params_; }
+
+private:
+  AirSavePumpParams params_;
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__AIR_SAVE_PUMP_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/ars_parameters.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/ars_parameters.hpp
@@ -1,0 +1,153 @@
+#ifndef SSOS_ECLSS__ARS__ARS_PARAMETERS_HPP_
+#define SSOS_ECLSS__ARS__ARS_PARAMETERS_HPP_
+
+#include <cstddef>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Parameter structs for the 4-Bed Molecular Sieve (4BMS) CO2 removal assembly.
+// All values default to the 4BCO2 EDU configuration described in
+// Peters, Cmarik, Knox, "4BCO2 EDU Performance", ICES-2021-313 (2021),
+// and the supporting isotherm-material papers (Knox & Cmarik 2019).
+//
+// Factory functions return defaults only; the physics never hardcodes these.
+// SI units throughout unless noted.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Single-species Toth isotherm coefficients.
+/// q*(P,T) = q_m(T) b(T) P / [1 + (b(T) P)^t]^(1/t)
+/// q_m(T)  = q_m0 exp[chi (1 - T/T_ref)]
+/// b(T)    = b0 exp[(dH / (R T_ref)) (T_ref/T - 1)]
+/// t(T)    = t0 + alpha (1 - T_ref/T)
+struct TothParams
+{
+  double q_m0;     // saturation loading at T_ref [mol/kg]
+  double chi;      // temperature exponent for q_m [-]
+  double b0;       // affinity constant at T_ref [1/Pa]
+  double dH;       // isosteric heat of adsorption (positive) [J/mol]
+  double t0;       // heterogeneity exponent at T_ref [-] (0,1]
+  double alpha;    // temperature dependence of t [-]
+  double T_ref;    // reference temperature [K]
+};
+
+/// Linear-Driving-Force mass-transfer coefficients [1/s].
+struct LDFParams
+{
+  double k_co2;    // CO2 LDF rate [1/s]
+  double k_h2o;    // H2O LDF rate [1/s]
+};
+
+/// Packed-bed geometry and bulk properties.
+struct BedGeometry
+{
+  double length;             // bed length [m]
+  double diameter;           // bed internal diameter [m]
+  double voidage;            // interparticle void fraction [-]
+  double particle_diameter;  // sorbent pellet diameter [m]
+  double sorbent_density;    // sorbent particle (skeletal+pore) density [kg/m^3]
+  std::size_t n_cells;       // axial finite-volume cells [-]
+
+  /// Cross-sectional area [m^2].
+  double cross_area() const { return M_PI * 0.25 * diameter * diameter; }
+  /// Total bed volume [m^3].
+  double volume() const { return cross_area() * length; }
+  /// Mass of sorbent in the bed [kg] (solid fraction times particle density).
+  double sorbent_mass() const { return volume() * (1.0 - voidage) * sorbent_density; }
+};
+
+/// Thermal model parameters for a bed.
+struct BedThermal
+{
+  double sorbent_cp;          // solid specific heat [J/(kg*K)]
+  double wall_htc;            // gas-to-wall U [W/(m^2*K)]
+  double wall_area_per_vol;   // wall area per bed volume [m^2/m^3]
+  double wall_temp;           // wall/ambient temperature [K]
+  double axial_thermal_cond;  // effective axial conductivity k_ax [W/(m*K)]
+  double gas_thermal_cond;    // gas thermal conductivity [W/(m*K)]
+};
+
+/// Regeneration heater parameters.
+struct HeaterParams
+{
+  double total_power_w;     // power with all 19 elements (desorption) [W]
+  double central_power_w;   // power with central 7 elements (air-save) [W]
+  double max_temp_k;        // heater control setpoint [K]
+};
+
+/// Half-cycle timing (10-60-10 sequence), seconds.
+struct CycleTiming
+{
+  double air_save_s;   // air-save (cabin air recovery) [s]
+  double adsorb_s;     // active adsorption [s]
+  double vacuum_s;     // vacuum desorption tail [s]
+
+  /// Total half-cycle duration [s].
+  double half_cycle_s() const { return air_save_s + adsorb_s + vacuum_s; }
+};
+
+/// Operating / boundary conditions.
+struct OperatingConditions
+{
+  double inlet_flow_scfm;     // process air flow [SCFM]
+  double inlet_ppco2_torr;    // cabin CO2 partial pressure [torr]
+  double inlet_dewpoint_k;    // process air dew point [K]
+  double cabin_temp_k;        // process air temperature [K]
+  double cabin_pressure_pa;   // total pressure [Pa]
+  double ltl_inlet_temp_k;    // low-temperature-loop coolant inlet [K]
+  double ltl_flow_gpm;        // coolant flow [gpm]
+  double vacuum_pressure_pa;  // desorption vacuum pressure [Pa]
+};
+
+/// Lumped system-level loss factor capturing air-save inefficiency and bed
+/// holdup loss that the cell-resolved model does not individually track.
+/// The paper reports holdup loss 8-12% and net efficiency 0.82-0.84.
+struct SystemEfficiency
+{
+  double capture_efficiency;  // net/gross CO2 capture [-]
+  double holdup_loss;         // fraction of cabin air lost to vacuum [-]
+};
+
+/// Complete ARS parameter set.
+struct ArsParameters
+{
+  BedGeometry desiccant_bed;
+  BedGeometry adsorbent_bed;
+  BedThermal desiccant_thermal;
+  BedThermal adsorbent_thermal;
+  TothParams co2_on_13x;
+  TothParams h2o_on_13x;
+  TothParams h2o_on_silica;
+  LDFParams desiccant_ldf;
+  LDFParams adsorbent_ldf;
+  HeaterParams heater;
+  CycleTiming cycle;
+  OperatingConditions operating;
+  SystemEfficiency efficiency;
+};
+
+// ---- Factory functions: 4BCO2 EDU defaults ----
+TothParams default_co2_on_13x();
+TothParams default_h2o_on_13x();
+TothParams default_h2o_on_silica();
+LDFParams default_desiccant_ldf();
+LDFParams default_adsorbent_ldf();
+BedGeometry default_desiccant_geometry();
+BedGeometry default_adsorbent_geometry();
+BedThermal default_desiccant_thermal();
+BedThermal default_adsorbent_thermal();
+HeaterParams default_heater();
+CycleTiming default_cycle_timing();
+OperatingConditions default_operating_conditions();
+SystemEfficiency default_system_efficiency();
+ArsParameters default_ars_parameters();
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__ARS_PARAMETERS_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/bed_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/bed_model.hpp
@@ -1,0 +1,131 @@
+#ifndef SSOS_ECLSS__ARS__BED_MODEL_HPP_
+#define SSOS_ECLSS__ARS__BED_MODEL_HPP_
+
+#include <cstddef>
+#include <vector>
+
+#include "ssos_eclss/ars/adsorption_isotherm.hpp"
+#include "ssos_eclss/ars/ars_parameters.hpp"
+
+// 1D finite-volume packed-bed adsorber model. Solves coupled gas/solid mass and
+// energy balances with a Linear-Driving-Force sorption rate, upwind advection,
+// axial dispersion and Ergun pressure drop. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Operating mode of a bed within the cycle.
+enum class BedMode
+{
+  ADSORBING,       // forward process flow, capturing CO2/H2O
+  AIR_SAVE,        // recovering cabin air before vacuum (low flow)
+  DESORBING,       // heated regeneration toward vacuum
+  VACUUM,          // vacuum desorption tail
+  IDLE,            // no flow, holding state
+  REPRESSURIZING   // refilling from vacuum back to cabin pressure
+};
+
+/// Inlet boundary condition presented to a bed for one step.
+struct BedInlet
+{
+  double velocity_superficial;  // superficial gas velocity [m/s]
+  double c_co2;                 // inlet CO2 concentration [mol/m^3]
+  double c_h2o;                 // inlet H2O concentration [mol/m^3]
+  double temperature_k;         // inlet gas temperature [K]
+  double pressure_pa;           // operating pressure [Pa]
+};
+
+/// Aggregate outputs after a step.
+struct BedOutputs
+{
+  double outlet_c_co2;       // outlet CO2 concentration [mol/m^3]
+  double outlet_c_h2o;       // outlet H2O concentration [mol/m^3]
+  double outlet_temperature; // outlet gas temperature [K]
+  double max_solid_temp;     // peak solid temperature [K]
+  double mean_solid_temp;    // mean solid temperature [K]
+  double co2_loading_mol;    // total CO2 held on solid [mol]
+  double h2o_loading_mol;    // total H2O held on solid [mol]
+  double pressure_drop_pa;   // bed pressure drop [Pa]
+  double co2_capture_rate;   // instantaneous CO2 captured [mol/s]
+};
+
+/// One packed adsorber bed.
+class BedModel
+{
+public:
+  /// @param geom      bed geometry
+  /// @param thermal   bed thermal parameters
+  /// @param co2       CO2 Toth isotherm (use even for desiccant; sees ~0 capacity)
+  /// @param h2o       H2O Toth isotherm
+  /// @param ldf       LDF mass-transfer coefficients
+  /// @param is_desiccant true for a desiccant (water-only) bed
+  BedModel(const BedGeometry & geom, const BedThermal & thermal,
+           const TothIsotherm & co2, const TothIsotherm & h2o,
+           const LDFParams & ldf, bool is_desiccant);
+
+  /// Reset all state to a uniform clean, ambient condition.
+  /// @param temperature_k initial temperature [K]
+  void reset(double temperature_k);
+
+  /// Pre-load the bed to equilibrium with given inlet partial pressures
+  /// (useful to start near cyclic steady state).
+  void equilibrate(double pp_co2_pa, double pp_h2o_pa, double temperature_k);
+
+  /// Advance the bed by @p dt seconds.
+  /// @param dt          macro timestep [s]
+  /// @param inlet       inlet boundary condition
+  /// @param mode        operating mode
+  /// @param heater_power_w heater power applied (DESORBING/AIR_SAVE) [W]
+  /// @return aggregate outputs after the step
+  BedOutputs step(double dt, const BedInlet & inlet, BedMode mode,
+                  double heater_power_w);
+
+  /// Current aggregate outputs without advancing time.
+  BedOutputs snapshot(const BedInlet & inlet) const;
+
+  // ---- State accessors (for tests / telemetry) ----
+  std::size_t n_cells() const { return n_; }
+  const std::vector<double> & co2_loading() const { return q_co2_; }
+  const std::vector<double> & h2o_loading() const { return q_h2o_; }
+  const std::vector<double> & solid_temperature() const { return ts_; }
+  const std::vector<double> & gas_temperature() const { return tg_; }
+  double total_co2_loading_mol() const;
+  double total_h2o_loading_mol() const;
+  double mean_solid_temperature() const;
+  double max_solid_temperature() const;
+
+private:
+  // Advance all state fields by one stable substep of size h. Mass, solid energy
+  // and sorption are integrated explicitly; the (stiff) gas-energy gas-solid and
+  // wall exchange is integrated semi-implicitly for unconditional stability.
+  void integrate_substep(double h, const BedInlet & inlet, BedMode mode,
+                         double heater_power_w);
+
+  double bed_pressure_drop(const BedInlet & inlet) const;
+
+  BedGeometry geom_;
+  BedThermal thermal_;
+  TothIsotherm co2_iso_;
+  TothIsotherm h2o_iso_;
+  LDFParams ldf_;
+  bool is_desiccant_;
+
+  std::size_t n_;
+  double dz_;
+  double rho_bulk_;  // (1-eps) * particle density [kg/m^3]
+
+  // State fields (size n_)
+  std::vector<double> c_co2_;  // gas CO2 [mol/m^3]
+  std::vector<double> c_h2o_;  // gas H2O [mol/m^3]
+  std::vector<double> q_co2_;  // solid CO2 [mol/kg]
+  std::vector<double> q_h2o_;  // solid H2O [mol/kg]
+  std::vector<double> tg_;     // gas temperature [K]
+  std::vector<double> ts_;     // solid temperature [K]
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__BED_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/blower_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/blower_model.hpp
@@ -1,0 +1,65 @@
+#ifndef SSOS_ECLSS__ARS__BLOWER_MODEL_HPP_
+#define SSOS_ECLSS__ARS__BLOWER_MODEL_HPP_
+
+// Process-air blower model. A quadratic fan curve dP = f(RPM, Q) is intersected
+// with the system resistance curve (Ergun-dominated) to find the operating
+// point. Supports constant-RPM and constant-flow control. No ROS, no deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Blower (fan) parameters. Fan curve: dP = a0*(N/Nref)^2 - a2*Q^2
+/// where Q is volumetric flow [m^3/s], N is speed [rpm].
+struct BlowerParams
+{
+  double rated_rpm;        // reference speed [rpm]
+  double shutoff_dp;       // dead-head head at rated rpm [Pa]
+  double curve_quad;       // quadratic flow coefficient a2 [Pa/(m^3/s)^2]
+  double max_rpm;          // mechanical speed limit [rpm]
+};
+
+/// Control mode.
+enum class BlowerControl
+{
+  CONSTANT_RPM,
+  CONSTANT_FLOW
+};
+
+/// Operating point.
+struct BlowerResult
+{
+  double flow_m3s;     // delivered volumetric flow [m^3/s]
+  double delta_p;      // developed pressure rise [Pa]
+  double rpm;          // operating speed [rpm]
+  double power_w;      // shaft power estimate [W]
+};
+
+/// Centrifugal/regenerative process blower.
+class BlowerModel
+{
+public:
+  explicit BlowerModel(const BlowerParams & params);
+
+  /// Fan head [Pa] at a given speed and flow.
+  double fan_head(double rpm, double flow_m3s) const;
+
+  /// Solve the operating point against a system resistance R such that
+  /// dP_system(Q) = system_resistance * Q^2 (quadratic, Ergun-like turbulent).
+  /// @param system_resistance [Pa/(m^3/s)^2]
+  /// @param control control mode
+  /// @param setpoint target rpm (CONSTANT_RPM) or target flow [m^3/s] (CONSTANT_FLOW)
+  BlowerResult solve(double system_resistance, BlowerControl control,
+                     double setpoint) const;
+
+  const BlowerParams & params() const { return params_; }
+
+private:
+  BlowerParams params_;
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__BLOWER_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/cycle_state_machine.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/cycle_state_machine.hpp
@@ -1,0 +1,79 @@
+#ifndef SSOS_ECLSS__ARS__CYCLE_STATE_MACHINE_HPP_
+#define SSOS_ECLSS__ARS__CYCLE_STATE_MACHINE_HPP_
+
+#include "ssos_eclss/ars/ars_parameters.hpp"
+#include "ssos_eclss/ars/bed_model.hpp"
+
+// Sequences the 4BMS half-cycle. Two trains (each a desiccant + an adsorbent
+// bed) alternate: while one train adsorbs, the other regenerates through
+// air-save -> desorb -> vacuum, then the trains swap. Schedules heater power
+// (central 7 elements during air-save, all 19 during desorption). No ROS.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Phase of the regenerating train within a half-cycle.
+enum class RegenPhase
+{
+  AIR_SAVE,
+  DESORB,
+  VACUUM
+};
+
+/// Commanded modes/heater for one train (a desiccant + adsorbent pair).
+struct TrainCommand
+{
+  BedMode desiccant_mode;
+  BedMode adsorbent_mode;
+  double desiccant_heater_w;
+  double adsorbent_heater_w;
+};
+
+/// Drives the half-cycle sequencing.
+class CycleStateMachine
+{
+public:
+  CycleStateMachine(const CycleTiming & timing, const HeaterParams & heater);
+
+  /// Reset to the start of a half-cycle with train 0 adsorbing.
+  void reset();
+
+  /// Advance the cycle clock by dt; swaps trains at half-cycle boundaries.
+  void update(double dt);
+
+  /// Index (0 or 1) of the train currently adsorbing.
+  int adsorbing_train() const { return adsorbing_train_; }
+
+  /// Index (0 or 1) of the train currently regenerating.
+  int regenerating_train() const { return 1 - adsorbing_train_; }
+
+  /// Current phase of the regenerating train.
+  RegenPhase regen_phase() const;
+
+  /// Time elapsed in the current half-cycle [s].
+  double time_in_half_cycle() const { return t_half_; }
+
+  /// Number of completed half-cycles (swaps).
+  int half_cycle_count() const { return half_cycle_count_; }
+
+  /// Command for a given train index (0 or 1).
+  TrainCommand command_for_train(int train) const;
+
+  void set_timing(const CycleTiming & t) { timing_ = t; }
+  void set_heater(const HeaterParams & h) { heater_ = h; }
+  const CycleTiming & timing() const { return timing_; }
+
+private:
+  CycleTiming timing_;
+  HeaterParams heater_;
+  double t_half_{0.0};
+  int adsorbing_train_{0};
+  int half_cycle_count_{0};
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__CYCLE_STATE_MACHINE_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/four_bed_system.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/four_bed_system.hpp
@@ -1,0 +1,105 @@
+#ifndef SSOS_ECLSS__ARS__FOUR_BED_SYSTEM_HPP_
+#define SSOS_ECLSS__ARS__FOUR_BED_SYSTEM_HPP_
+
+#include <array>
+#include <memory>
+
+#include "ssos_eclss/ars/adsorption_isotherm.hpp"
+#include "ssos_eclss/ars/air_save_pump_model.hpp"
+#include "ssos_eclss/ars/ars_parameters.hpp"
+#include "ssos_eclss/ars/bed_model.hpp"
+#include "ssos_eclss/ars/blower_model.hpp"
+#include "ssos_eclss/ars/cycle_state_machine.hpp"
+#include "ssos_eclss/ars/precooler_model.hpp"
+#include "ssos_eclss/ars/valve_model.hpp"
+
+// Top-level Air Revitalization System (4BMS). Owns two desiccant beds, two
+// adsorbent beds, the precooler, blower, air-save pump, valves and the cycle
+// state machine. A single step() advances the entire assembly. This is the
+// object the ARS ROS node drives. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Cabin (process-air inlet) conditions presented to the ARS each step.
+struct CabinConditions
+{
+  double co2_partial_pressure_pa;  // cabin ppCO2 [Pa]
+  double h2o_partial_pressure_pa;  // cabin water-vapour partial pressure [Pa]
+  double temperature_k;            // cabin air temperature [K]
+  double total_pressure_pa;        // cabin total pressure [Pa]
+};
+
+/// ARS outputs after a step.
+struct ArsResult
+{
+  double co2_removal_rate_kg_s;    // net CO2 removed from the cabin [kg/s]
+  double co2_removal_rate_kg_day;  // net CO2 removed [kg/day]
+  double scrubbed_co2_pp_pa;       // CO2 partial pressure of return air [Pa]
+  double scrubbed_h2o_pp_pa;       // H2O partial pressure of return air [Pa]
+  double return_air_temp_k;        // return air temperature [K]
+  double system_pressure_drop_pa;  // total flow-path pressure drop [Pa]
+  double blower_flow_scfm;         // delivered process flow [SCFM]
+  double blower_power_w;           // blower shaft power [W]
+  double precooler_exit_temp_k;    // precooler exit air temperature [K]
+  double max_bed_temp_k;           // hottest solid temperature in any bed [K]
+  double co2_desorbed_rate_kg_s;   // CO2 released by the regenerating bed [kg/s]
+  double air_saved_rate_kg_s;      // cabin air recovered by air-save pump [kg/s]
+  int adsorbing_train;             // active train index (0/1)
+};
+
+/// Four-Bed Molecular Sieve CO2 removal assembly.
+class FourBedSystem
+{
+public:
+  explicit FourBedSystem(const ArsParameters & params = default_ars_parameters());
+
+  /// Re-initialise all beds to ambient and restart the cycle.
+  void reset(double temperature_k = 295.0);
+
+  /// Advance the whole assembly by dt seconds under given cabin conditions.
+  ArsResult step(double dt, const CabinConditions & cabin);
+
+  /// Design-point steady CO2 removal [kg/day] from the configured operating
+  /// conditions and net capture efficiency (used for validation).
+  double design_co2_removal_kg_day() const;
+
+  /// Update parameters live (e.g. from the ROS parameter bridge). Geometry and
+  /// cell-count changes require reconstruct(); this updates the tunable fields.
+  void set_parameters(const ArsParameters & params);
+
+  /// Fully rebuild the bed objects (needed when geometry / n_cells change).
+  void reconstruct();
+
+  const ArsParameters & parameters() const { return params_; }
+  const CycleStateMachine & cycle() const { return *cycle_; }
+
+  // Bed accessors (0/1 = train, desiccant or adsorbent).
+  BedModel & desiccant_bed(int i) { return *desiccant_[i]; }
+  BedModel & adsorbent_bed(int i) { return *adsorbent_[i]; }
+
+private:
+  double inlet_co2_mass_rate(const CabinConditions & cabin, double flow_m3s) const;
+
+  ArsParameters params_;
+  TothIsotherm co2_iso_;
+  TothIsotherm h2o_iso_;
+  TothIsotherm h2o_silica_iso_;
+
+  std::array<std::unique_ptr<BedModel>, 2> desiccant_;
+  std::array<std::unique_ptr<BedModel>, 2> adsorbent_;
+  std::unique_ptr<PrecoolerModel> precooler_;
+  std::unique_ptr<BlowerModel> blower_;
+  std::unique_ptr<AirSavePumpModel> air_save_pump_;
+  std::unique_ptr<ValveModel> valve_;
+  std::unique_ptr<CycleStateMachine> cycle_;
+
+  double system_resistance_{0.0};  // Pa/(m^3/s)^2
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__FOUR_BED_SYSTEM_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/precooler_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/precooler_model.hpp
@@ -1,0 +1,53 @@
+#ifndef SSOS_ECLSS__ARS__PRECOOLER_MODEL_HPP_
+#define SSOS_ECLSS__ARS__PRECOOLER_MODEL_HPP_
+
+// Air-to-Low-Temperature-Loop (LTL) precooler heat exchanger using the
+// epsilon-NTU method. Cools the process air before the desiccant beds.
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Precooler design parameters.
+struct PrecoolerParams
+{
+  double ua;              // overall conductance U*A [W/K]
+  double air_mass_flow;   // process air mass flow [kg/s]
+  double coolant_mass_flow;  // LTL coolant mass flow [kg/s]
+  double air_cp;          // air specific heat [J/(kg*K)]
+  double coolant_cp;      // coolant (water) specific heat [J/(kg*K)]
+};
+
+/// Precooler outputs.
+struct PrecoolerResult
+{
+  double air_outlet_temp;     // cooled air temperature [K]
+  double coolant_outlet_temp; // warmed coolant temperature [K]
+  double heat_duty;           // heat removed from air [W]
+  double effectiveness;       // epsilon-NTU effectiveness [-]
+};
+
+/// Air-to-LTL precooler.
+class PrecoolerModel
+{
+public:
+  explicit PrecoolerModel(const PrecoolerParams & params);
+
+  /// Compute steady-state outlet conditions.
+  /// @param air_inlet_temp     process air inlet temperature [K]
+  /// @param coolant_inlet_temp LTL coolant inlet temperature [K]
+  PrecoolerResult solve(double air_inlet_temp, double coolant_inlet_temp) const;
+
+  void set_params(const PrecoolerParams & p) { params_ = p; }
+  const PrecoolerParams & params() const { return params_; }
+
+private:
+  PrecoolerParams params_;
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__PRECOOLER_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ars/valve_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ars/valve_model.hpp
@@ -1,0 +1,57 @@
+#ifndef SSOS_ECLSS__ARS__VALVE_MODEL_HPP_
+#define SSOS_ECLSS__ARS__VALVE_MODEL_HPP_
+
+// Selector / re-pressurisation valve. Models flow conductance vs commanded
+// position and the bed re-pressurisation transient (0 -> ~800 torr in ~15 s)
+// that enables bumpless transfer between bed pairs. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+/// Valve parameters.
+struct ValveParams
+{
+  double cv;                 // flow coefficient (conductance) [m^3/s/sqrt(Pa)]
+  double stroke_time_s;      // full open/close stroke time [s]
+  double repress_time_s;     // characteristic re-pressurisation time [s]
+};
+
+/// A two-state selector valve with finite stroke and a repressurisation model.
+class ValveModel
+{
+public:
+  explicit ValveModel(const ValveParams & params);
+
+  /// Command the valve open fraction (0 closed, 1 open).
+  void command(double target_open) { target_ = clamp01(target_open); }
+
+  /// Advance the valve actuation by dt; the position slews toward the command.
+  void update(double dt);
+
+  /// Current open fraction [0,1].
+  double position() const { return position_; }
+
+  /// Volumetric flow [m^3/s] for a pressure drop, scaled by open fraction.
+  /// Q = position * cv * sign(dP) * sqrt(|dP|)
+  double flow(double delta_p_pa) const;
+
+  /// Re-pressurise a bed from @p current_pressure toward @p target_pressure over
+  /// dt seconds (first-order approach). Returns the new bed pressure [Pa].
+  double repressurize(double dt, double current_pressure, double target_pressure) const;
+
+  const ValveParams & params() const { return params_; }
+
+private:
+  static double clamp01(double x) { return x < 0.0 ? 0.0 : (x > 1.0 ? 1.0 : x); }
+
+  ValveParams params_;
+  double position_{0.0};
+  double target_{0.0};
+};
+
+}  // namespace ars
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__ARS__VALVE_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/cabin/cabin_atmosphere.hpp
+++ b/ssos_eclss/include/ssos_eclss/cabin/cabin_atmosphere.hpp
@@ -1,0 +1,88 @@
+#ifndef SSOS_ECLSS__CABIN__CABIN_ATMOSPHERE_HPP_
+#define SSOS_ECLSS__CABIN__CABIN_ATMOSPHERE_HPP_
+
+// Well-mixed cabin atmosphere control volume. Tracks the molar inventory of
+// O2, CO2, N2 and H2O and derives pressures, composition and humidity. All
+// subsystems read boundary conditions from here and write their flows back.
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace cabin
+{
+
+/// Gas species tracked in the cabin.
+enum class Gas
+{
+  O2,
+  CO2,
+  N2,
+  H2O
+};
+
+/// Volumetric/molar source-and-sink rates applied over a step [mol/s].
+/// Positive adds to the cabin, negative removes.
+struct GasFlows
+{
+  double o2{0.0};
+  double co2{0.0};
+  double n2{0.0};
+  double h2o{0.0};
+};
+
+/// Cabin atmosphere parameters.
+struct CabinParams
+{
+  double volume_m3;        // free cabin volume [m^3]
+  double temperature_k;    // controlled cabin temperature [K]
+};
+
+/// Well-mixed cabin atmosphere.
+class CabinAtmosphere
+{
+public:
+  /// @param params cabin parameters
+  CabinAtmosphere(const CabinParams & params);
+
+  /// Initialise to a nominal ISS-like atmosphere:
+  /// ~101.3 kPa total, 21% O2, ppCO2 at given ppm, 40% RH.
+  void initialize_nominal(double co2_ppm = 2600.0, double relative_humidity = 0.40);
+
+  /// Apply constant molar source/sink rates for dt seconds.
+  void apply_flows(double dt, const GasFlows & flows);
+
+  /// Directly add/remove a quantity of a species [mol] (e.g. discrete events).
+  void add_moles(Gas species, double moles);
+
+  // ---- Derived quantities ----
+  double total_moles() const;
+  double moles(Gas species) const;
+  double total_pressure_pa() const;
+  double partial_pressure_pa(Gas species) const;
+  double mole_fraction(Gas species) const;
+  double co2_ppm() const;
+  double o2_fraction() const;
+  double water_partial_pressure_pa() const { return partial_pressure_pa(Gas::H2O); }
+  double relative_humidity() const;
+  double dew_point_k() const;
+  double temperature_k() const { return params_.temperature_k; }
+  double volume_m3() const { return params_.volume_m3; }
+  double total_gas_mass_kg() const;
+
+  void set_temperature(double t_k) { params_.temperature_k = t_k; }
+
+private:
+  CabinParams params_;
+  double n_o2_{0.0};
+  double n_co2_{0.0};
+  double n_n2_{0.0};
+  double n_h2o_{0.0};
+
+  double & ref(Gas species);
+  double get(Gas species) const;
+};
+
+}  // namespace cabin
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__CABIN__CABIN_ATMOSPHERE_HPP_

--- a/ssos_eclss/include/ssos_eclss/cabin/crew_metabolic_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/cabin/crew_metabolic_model.hpp
@@ -1,0 +1,61 @@
+#ifndef SSOS_ECLSS__CABIN__CREW_METABOLIC_MODEL_HPP_
+#define SSOS_ECLSS__CABIN__CREW_METABOLIC_MODEL_HPP_
+
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+
+// Crew metabolic loads. Per crew member the model produces CO2 and water vapour
+// and metabolic heat while consuming O2, scaled by an activity factor. Nominal
+// per-person daily figures follow the NASA BVAD. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace cabin
+{
+
+/// Per-crew-member nominal metabolic rates (daily, at activity factor 1.0).
+struct CrewProfile
+{
+  double co2_kg_day;       // CO2 produced [kg/day]
+  double o2_kg_day;        // O2 consumed [kg/day]
+  double water_kg_day;     // water vapour produced (resp + persp) [kg/day]
+  double heat_w;           // sensible+latent metabolic heat [W]
+};
+
+/// Metabolic source/sink rates for the cabin.
+struct MetabolicLoads
+{
+  GasFlows flows;          // O2 (negative), CO2 (positive), H2O (positive) [mol/s]
+  double heat_w;           // total metabolic heat [W]
+  double water_kg_s;       // total water vapour produced [kg/s]
+};
+
+/// Crew metabolic model.
+class CrewMetabolicModel
+{
+public:
+  /// @param crew_size number of crew members
+  /// @param profile   per-member nominal profile
+  CrewMetabolicModel(int crew_size, const CrewProfile & profile);
+
+  /// Compute current metabolic loads.
+  /// @param activity_factor multiplier on the nominal rates (1.0 = nominal,
+  ///                        higher for exercise)
+  MetabolicLoads loads(double activity_factor = 1.0) const;
+
+  void set_crew_size(int n) { crew_size_ = n; }
+  int crew_size() const { return crew_size_; }
+  void set_profile(const CrewProfile & p) { profile_ = p; }
+  const CrewProfile & profile() const { return profile_; }
+
+private:
+  int crew_size_;
+  CrewProfile profile_;
+};
+
+/// Default nominal per-member profile (NASA BVAD averages).
+CrewProfile default_crew_profile();
+
+}  // namespace cabin
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__CABIN__CREW_METABOLIC_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/cabin/leak_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/cabin/leak_model.hpp
@@ -1,0 +1,51 @@
+#ifndef SSOS_ECLSS__CABIN__LEAK_MODEL_HPP_
+#define SSOS_ECLSS__CABIN__LEAK_MODEL_HPP_
+
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+
+// Cabin atmosphere leakage to vacuum. A small nominal structural leak plus a
+// fault-injectable larger leak (e.g. a micrometeoroid puncture). Models choked
+// orifice outflow proportional to cabin pressure and composition. No ROS.
+
+namespace ssos_eclss
+{
+namespace cabin
+{
+
+/// Leak parameters.
+struct LeakParams
+{
+  double nominal_area_m2;  // baseline equivalent leak orifice area [m^2]
+  double discharge_coeff;  // orifice discharge coefficient [-]
+};
+
+/// Cabin leak model.
+class LeakModel
+{
+public:
+  explicit LeakModel(const LeakParams & params);
+
+  /// Set an additional fault leak area [m^2] (0 to clear).
+  void set_fault_area(double area_m2) { fault_area_m2_ = (area_m2 > 0.0) ? area_m2 : 0.0; }
+
+  /// Total effective leak area [m^2].
+  double effective_area() const { return params_.nominal_area_m2 + fault_area_m2_; }
+
+  /// Total mass leak rate [kg/s] for the current atmosphere (choked flow to
+  /// vacuum). Always non-negative.
+  double mass_leak_rate(const CabinAtmosphere & atm) const;
+
+  /// Molar leak flows [mol/s] (negative = leaving cabin), composition-weighted.
+  GasFlows leak_flows(const CabinAtmosphere & atm) const;
+
+  const LeakParams & params() const { return params_; }
+
+private:
+  LeakParams params_;
+  double fault_area_m2_{0.0};
+};
+
+}  // namespace cabin
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__CABIN__LEAK_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/fluid_dynamics.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/fluid_dynamics.hpp
@@ -1,0 +1,49 @@
+#ifndef SSOS_ECLSS__COMMON__FLUID_DYNAMICS_HPP_
+#define SSOS_ECLSS__COMMON__FLUID_DYNAMICS_HPP_
+
+// Packed-bed and pipe-flow hydraulics. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace fluid
+{
+
+/// Particle Reynolds number for flow through a packed bed.
+/// Re = rho * v * dp / mu  (superficial velocity basis)
+/// @param density     fluid density [kg/m^3]
+/// @param velocity    superficial velocity [m/s]
+/// @param particle_d  particle diameter [m]
+/// @param viscosity   dynamic viscosity [Pa*s]
+double reynolds_number(double density, double velocity, double particle_d,
+                       double viscosity);
+
+/// Ergun-equation pressure gradient through a packed bed [Pa/m].
+/// dP/dz = 150*(1-e)^2/e^3 * mu*v/dp^2 + 1.75*(1-e)/e^3 * rho*v^2/dp
+/// @param velocity    superficial velocity [m/s]
+/// @param voidage     bed void fraction (porosity) [-]
+/// @param particle_d  particle diameter [m]
+/// @param density     fluid density [kg/m^3]
+/// @param viscosity   dynamic viscosity [Pa*s]
+double ergun_pressure_gradient(double velocity, double voidage, double particle_d,
+                               double density, double viscosity);
+
+/// Total Ergun pressure drop across a bed of given length [Pa].
+double ergun_pressure_drop(double velocity, double voidage, double particle_d,
+                           double density, double viscosity, double bed_length);
+
+/// Darcy friction factor for pipe flow (laminar 64/Re, turbulent via
+/// the explicit Haaland correlation).
+/// @param reynolds        Reynolds number [-]
+/// @param relative_rough  roughness / diameter [-]
+double darcy_friction_factor(double reynolds, double relative_rough = 0.0);
+
+/// Superficial velocity [m/s] from volumetric flow and cross-sectional area.
+double superficial_velocity(double volumetric_flow_m3s, double cross_area_m2);
+
+/// Interstitial (pore) velocity [m/s] = superficial / voidage.
+double interstitial_velocity(double superficial_v, double voidage);
+
+}  // namespace fluid
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__FLUID_DYNAMICS_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/gas_properties.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/gas_properties.hpp
@@ -1,0 +1,72 @@
+#ifndef SSOS_ECLSS__COMMON__GAS_PROPERTIES_HPP_
+#define SSOS_ECLSS__COMMON__GAS_PROPERTIES_HPP_
+
+#include <vector>
+
+// Ideal-gas, gas-mixture and psychrometric relations. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace gas
+{
+
+/// Ideal-gas density [kg/m^3].
+/// rho = P * M / (R * T)
+/// @param pressure_pa  absolute pressure [Pa]
+/// @param temperature_k temperature [K]
+/// @param molar_mass   molar mass [kg/mol]
+double gas_density(double pressure_pa, double temperature_k, double molar_mass);
+
+/// Molar concentration of an ideal gas [mol/m^3] given partial pressure.
+/// c = P / (R * T)
+double concentration_from_pp(double partial_pressure_pa, double temperature_k);
+
+/// Partial pressure [Pa] from molar concentration [mol/m^3].
+/// P = c * R * T
+double partial_pressure(double concentration_mol_m3, double temperature_k);
+
+/// Saturation vapour pressure of water [Pa] using the Magnus/Tetens formula.
+/// Valid roughly -45..60 degC.
+/// @param temperature_k temperature [K]
+double water_saturation_pressure(double temperature_k);
+
+/// Dew point temperature [K] for a given water-vapour partial pressure [Pa].
+/// Inverse of water_saturation_pressure (Magnus inversion).
+double dew_point_from_pp(double water_pp_pa);
+
+/// Relative humidity [-] (0..1+) from water vapour partial pressure and temperature.
+double relative_humidity(double water_pp_pa, double temperature_k);
+
+/// Water vapour partial pressure [Pa] from relative humidity and temperature.
+double water_pp_from_rh(double relative_humidity, double temperature_k);
+
+/// Absolute humidity (humidity ratio) [kg water / kg dry air].
+/// @param water_pp_pa  water vapour partial pressure [Pa]
+/// @param total_pressure_pa total pressure [Pa]
+double humidity_ratio(double water_pp_pa, double total_pressure_pa);
+
+/// Dynamic viscosity of a single gas [Pa*s] via Sutherland's law.
+/// Defaults correspond to air.
+double sutherland_viscosity(double temperature_k,
+                            double mu_ref = 1.716e-5,
+                            double t_ref = 273.15,
+                            double sutherland_c = 111.0);
+
+/// One component of a gas mixture: mole fraction, molar mass and viscosity.
+struct MixtureComponent
+{
+  double mole_fraction;  // [-]
+  double molar_mass;     // [kg/mol]
+  double viscosity;      // [Pa*s]
+};
+
+/// Mixture dynamic viscosity [Pa*s] via Wilke's mixing rule.
+double mixture_viscosity(const std::vector<MixtureComponent> & components);
+
+/// Mixture molar mass [kg/mol] (mole-fraction weighted).
+double mixture_molar_mass(const std::vector<MixtureComponent> & components);
+
+}  // namespace gas
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__GAS_PROPERTIES_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/heat_transfer.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/heat_transfer.hpp
@@ -1,0 +1,50 @@
+#ifndef SSOS_ECLSS__COMMON__HEAT_TRANSFER_HPP_
+#define SSOS_ECLSS__COMMON__HEAT_TRANSFER_HPP_
+
+// Convective correlations and heat-exchanger effectiveness. No ROS, no deps.
+
+namespace ssos_eclss
+{
+namespace heat
+{
+
+/// Prandtl number Pr = cp * mu / k [-].
+double prandtl_number(double cp, double viscosity, double thermal_cond);
+
+/// Wakao-Kaguei Nusselt correlation for gas-solid heat transfer in packed beds:
+/// Nu = 2 + 1.1 * Re^0.6 * Pr^(1/3)
+/// @param reynolds particle Reynolds number [-]
+/// @param prandtl  Prandtl number [-]
+double nusselt_wakao_kaguei(double reynolds, double prandtl);
+
+/// Gas-solid heat transfer coefficient [W/(m^2*K)] from the Nusselt number.
+/// h = Nu * k / dp
+/// @param nusselt      Nusselt number [-]
+/// @param thermal_cond gas thermal conductivity [W/(m*K)]
+/// @param particle_d   particle diameter [m]
+double gas_solid_htc(double nusselt, double thermal_cond, double particle_d);
+
+/// Specific (per unit bed volume) interfacial area of a packed bed [m^2/m^3].
+/// a_v = 6 * (1 - voidage) / dp  (spherical particles)
+double specific_surface_area(double voidage, double particle_d);
+
+/// Number of transfer units NTU = U*A / C_min [-].
+double ntu(double ua, double c_min);
+
+/// Effectiveness of a counter-flow heat exchanger via the epsilon-NTU method.
+/// @param ntu_val  number of transfer units [-]
+/// @param cr       capacity-rate ratio C_min/C_max [-] (0..1)
+double effectiveness_counterflow(double ntu_val, double cr);
+
+/// Effectiveness of a cross-flow (both fluids unmixed) heat exchanger.
+double effectiveness_crossflow(double ntu_val, double cr);
+
+/// Heat duty [W] from effectiveness, C_min and inlet temperature difference.
+/// q = eps * C_min * (T_hot_in - T_cold_in)
+double hx_heat_duty(double effectiveness, double c_min,
+                    double t_hot_in, double t_cold_in);
+
+}  // namespace heat
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__HEAT_TRANSFER_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/numerical/cfl_control.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/numerical/cfl_control.hpp
@@ -1,0 +1,70 @@
+#ifndef SSOS_ECLSS__COMMON__NUMERICAL__CFL_CONTROL_HPP_
+#define SSOS_ECLSS__COMMON__NUMERICAL__CFL_CONTROL_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+// Adaptive timestep control based on the CFL (advection) and diffusion-number
+// stability limits. Header-only, no dependencies.
+
+namespace ssos_eclss
+{
+namespace numerical
+{
+
+/// Maximum stable advection timestep for a uniform grid: dt <= cfl * dz / |v|.
+/// @param velocity advection velocity [m/s]
+/// @param dz       cell size [m]
+/// @param cfl_max  target Courant number (default 0.5)
+inline double advection_dt_limit(double velocity, double dz, double cfl_max = 0.5)
+{
+  const double v = std::abs(velocity);
+  if (v < 1.0e-12) {
+    return std::numeric_limits<double>::max();
+  }
+  return cfl_max * dz / v;
+}
+
+/// Maximum stable explicit diffusion timestep: dt <= d_max * dz^2 / D.
+/// @param diffusivity D [m^2/s]
+/// @param dz          cell size [m]
+/// @param d_max       target diffusion number (default 0.5)
+inline double diffusion_dt_limit(double diffusivity, double dz, double d_max = 0.5)
+{
+  if (diffusivity < 1.0e-12) {
+    return std::numeric_limits<double>::max();
+  }
+  return d_max * dz * dz / diffusivity;
+}
+
+/// Number of equal substeps required to advance @p total_dt without exceeding
+/// the stability-limited step @p dt_limit. Always returns at least 1.
+inline std::size_t required_substeps(double total_dt, double dt_limit)
+{
+  if (dt_limit <= 0.0 || !std::isfinite(dt_limit)) {
+    return 1;
+  }
+  const double n = std::ceil(total_dt / dt_limit);
+  if (!std::isfinite(n) || n < 1.0) {
+    return 1;
+  }
+  return static_cast<std::size_t>(n);
+}
+
+/// Combined stable substep count given both advection and diffusion limits.
+inline std::size_t stable_substeps(double total_dt, double velocity, double dz,
+                                   double diffusivity, double cfl_max = 0.5,
+                                   double diff_max = 0.5)
+{
+  const double dt_adv = advection_dt_limit(velocity, dz, cfl_max);
+  const double dt_diff = diffusion_dt_limit(diffusivity, dz, diff_max);
+  const double dt_limit = std::min(dt_adv, dt_diff);
+  return required_substeps(total_dt, dt_limit);
+}
+
+}  // namespace numerical
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__NUMERICAL__CFL_CONTROL_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/numerical/finite_volume.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/numerical/finite_volume.hpp
@@ -1,0 +1,85 @@
+#ifndef SSOS_ECLSS__COMMON__NUMERICAL__FINITE_VOLUME_HPP_
+#define SSOS_ECLSS__COMMON__NUMERICAL__FINITE_VOLUME_HPP_
+
+#include <cstddef>
+#include <vector>
+
+// 1D finite-volume discretisation helpers for the packed-bed PDE solver.
+// First-order upwind advection and central-difference diffusion on a uniform
+// grid. Header-only, no dependencies.
+
+namespace ssos_eclss
+{
+namespace numerical
+{
+
+/// Upwind advection derivative -v * d(phi)/dz for a uniform 1D grid.
+/// Boundary handling: cell 0 uses @p inlet_value as the upstream ghost value
+/// when velocity is positive; the last cell uses a zero-gradient (outflow)
+/// condition. For negative velocity the roles reverse.
+/// @param phi   cell-centred field (size N)
+/// @param velocity advection velocity [m/s] (sign sets the upwind direction)
+/// @param dz    cell size [m]
+/// @param inlet_value upstream boundary value of phi
+/// @param out   output derivative, resized to N
+inline void upwind_advection(const std::vector<double> & phi, double velocity,
+                             double dz, double inlet_value,
+                             std::vector<double> & out)
+{
+  const std::size_t n = phi.size();
+  out.assign(n, 0.0);
+  if (n == 0 || dz <= 0.0) {
+    return;
+  }
+  if (velocity >= 0.0) {
+    for (std::size_t i = 0; i < n; ++i) {
+      const double up = (i == 0) ? inlet_value : phi[i - 1];
+      out[i] = -velocity * (phi[i] - up) / dz;
+    }
+  } else {
+    for (std::size_t i = 0; i < n; ++i) {
+      const double down = (i + 1 < n) ? phi[i + 1] : phi[i];  // outflow
+      out[i] = -velocity * (down - phi[i]) / dz;
+    }
+  }
+}
+
+/// Central-difference diffusion derivative D * d^2(phi)/dz^2 on a uniform grid
+/// with zero-gradient (Neumann) boundaries.
+/// @param phi field (size N)
+/// @param diffusivity D [m^2/s] (or k/(rho*cp) equivalent)
+/// @param dz  cell size [m]
+/// @param out output derivative, resized to N
+inline void central_diffusion(const std::vector<double> & phi, double diffusivity,
+                              double dz, std::vector<double> & out)
+{
+  const std::size_t n = phi.size();
+  out.assign(n, 0.0);
+  if (n < 2 || dz <= 0.0) {
+    return;
+  }
+  const double inv_dz2 = 1.0 / (dz * dz);
+  for (std::size_t i = 0; i < n; ++i) {
+    const double left = (i == 0) ? phi[i] : phi[i - 1];          // Neumann
+    const double right = (i + 1 < n) ? phi[i + 1] : phi[i];      // Neumann
+    out[i] = diffusivity * (left - 2.0 * phi[i] + right) * inv_dz2;
+  }
+}
+
+/// Uniform 1D grid descriptor.
+struct Grid1D
+{
+  std::size_t n_cells{1};
+  double length{1.0};
+
+  /// Cell size dz [m].
+  double dz() const { return (n_cells > 0) ? length / static_cast<double>(n_cells) : length; }
+
+  /// Centre coordinate of cell i [m].
+  double cell_center(std::size_t i) const { return (static_cast<double>(i) + 0.5) * dz(); }
+};
+
+}  // namespace numerical
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__NUMERICAL__FINITE_VOLUME_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/numerical/rk4_integrator.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/numerical/rk4_integrator.hpp
@@ -1,0 +1,69 @@
+#ifndef SSOS_ECLSS__COMMON__NUMERICAL__RK4_INTEGRATOR_HPP_
+#define SSOS_ECLSS__COMMON__NUMERICAL__RK4_INTEGRATOR_HPP_
+
+#include <cstddef>
+#include <vector>
+
+// Generic classic Runge-Kutta (RK4) stepper operating on a std::vector<double>
+// state with a user-supplied derivative functor. Header-only, no dependencies.
+
+namespace ssos_eclss
+{
+namespace numerical
+{
+
+using State = std::vector<double>;
+
+/// Advance @p state by one RK4 step of size @p dt.
+/// The derivative functor has signature: void(const State& x, double t, State& dxdt)
+/// and must size/fill @p dxdt to match @p x.
+/// @param deriv derivative functor
+/// @param state state vector, updated in place
+/// @param t     current time
+/// @param dt    timestep
+template <typename Deriv>
+void rk4_step(Deriv && deriv, State & state, double t, double dt)
+{
+  const std::size_t n = state.size();
+  State k1(n), k2(n), k3(n), k4(n), tmp(n);
+
+  deriv(state, t, k1);
+  for (std::size_t i = 0; i < n; ++i) {
+    tmp[i] = state[i] + 0.5 * dt * k1[i];
+  }
+  deriv(tmp, t + 0.5 * dt, k2);
+  for (std::size_t i = 0; i < n; ++i) {
+    tmp[i] = state[i] + 0.5 * dt * k2[i];
+  }
+  deriv(tmp, t + 0.5 * dt, k3);
+  for (std::size_t i = 0; i < n; ++i) {
+    tmp[i] = state[i] + dt * k3[i];
+  }
+  deriv(tmp, t + dt, k4);
+
+  const double sixth = dt / 6.0;
+  for (std::size_t i = 0; i < n; ++i) {
+    state[i] += sixth * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]);
+  }
+}
+
+/// Integrate from @p t0 to @p t0 + @p total_dt using @p n_sub equal RK4 substeps.
+template <typename Deriv>
+void rk4_integrate(Deriv && deriv, State & state, double t0, double total_dt,
+                   std::size_t n_sub)
+{
+  if (n_sub == 0) {
+    n_sub = 1;
+  }
+  const double h = total_dt / static_cast<double>(n_sub);
+  double t = t0;
+  for (std::size_t s = 0; s < n_sub; ++s) {
+    rk4_step(deriv, state, t, h);
+    t += h;
+  }
+}
+
+}  // namespace numerical
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__NUMERICAL__RK4_INTEGRATOR_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/thermodynamics.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/thermodynamics.hpp
@@ -1,0 +1,58 @@
+#ifndef SSOS_ECLSS__COMMON__THERMODYNAMICS_HPP_
+#define SSOS_ECLSS__COMMON__THERMODYNAMICS_HPP_
+
+// Heat capacities, enthalpy and phase-change relations. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace thermo
+{
+
+/// Identifies a gas species for property lookups.
+enum class Species
+{
+  AIR,
+  CO2,
+  H2O_VAPOR,
+  O2,
+  H2,
+  N2,
+  CH4
+};
+
+/// Specific heat at constant pressure [J/(kg*K)] using a Shomate/NASA-style
+/// quadratic fit cp(T) = a + b*T + c*T^2. Falls back to a constant for species
+/// with weak temperature dependence over ECLSS-relevant ranges.
+/// @param species gas species
+/// @param temperature_k temperature [K]
+double cp_mass(Species species, double temperature_k);
+
+/// Molar specific heat at constant pressure [J/(mol*K)].
+double cp_molar(Species species, double temperature_k);
+
+/// Specific heat at constant volume [J/(kg*K)], cv = cp - R/M (ideal gas).
+double cv_mass(Species species, double temperature_k);
+
+/// Ratio of specific heats gamma = cp/cv [-].
+double gamma_ratio(Species species, double temperature_k);
+
+/// Sensible enthalpy [J/kg] relative to a reference temperature (default 298.15 K),
+/// integral of cp(T) dT.
+double sensible_enthalpy(Species species, double temperature_k,
+                         double reference_k = 298.15);
+
+/// Latent heat of vaporisation of water [J/kg] as a function of temperature.
+/// Watson correlation, valid 273..473 K.
+double latent_heat_water(double temperature_k);
+
+/// Specific heat of liquid water [J/(kg*K)] (weak T dependence, near 4186).
+double cp_liquid_water(double temperature_k);
+
+/// Specific heat of a packed-bed solid sorbent [J/(kg*K)].
+/// Representative value for zeolite / silica adsorbents.
+double cp_sorbent_solid(double temperature_k);
+
+}  // namespace thermo
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__THERMODYNAMICS_HPP_

--- a/ssos_eclss/include/ssos_eclss/common/units.hpp
+++ b/ssos_eclss/include/ssos_eclss/common/units.hpp
@@ -1,0 +1,82 @@
+#ifndef SSOS_ECLSS__COMMON__UNITS_HPP_
+#define SSOS_ECLSS__COMMON__UNITS_HPP_
+
+// Physical constants and unit conversions for the ECLSS physics library.
+// Header-only, zero dependencies. All SI internally; conversions provided
+// for the imperial/legacy units used in the ICES source papers.
+
+namespace ssos_eclss
+{
+namespace units
+{
+
+// ---- Universal physical constants ----
+constexpr double R_GAS = 8.31446;       // Universal gas constant [J/(mol*K)]
+constexpr double FARADAY = 96485.0;     // Faraday constant [C/mol]
+constexpr double AVOGADRO = 6.02214076e23;  // [1/mol]
+constexpr double G0 = 9.80665;          // Standard gravity [m/s^2]
+constexpr double T0_KELVIN = 273.15;    // 0 degC in Kelvin
+constexpr double STD_PRESSURE_PA = 101325.0;  // Standard atmosphere [Pa]
+
+// ---- Molar masses [kg/mol] ----
+constexpr double M_AIR = 0.029;
+constexpr double M_CO2 = 0.044;
+constexpr double M_H2O = 0.018;
+constexpr double M_O2 = 0.032;
+constexpr double M_H2 = 0.002;
+constexpr double M_N2 = 0.028;
+constexpr double M_CH4 = 0.016;
+
+// ---- Pressure conversion factors ----
+constexpr double TORR_TO_PA = 133.322;          // 1 torr -> Pa
+constexpr double PA_TO_TORR = 1.0 / TORR_TO_PA;
+constexpr double IN_H2O_TO_PA = 249.089;        // 1 inch of water -> Pa
+constexpr double PA_TO_IN_H2O = 1.0 / IN_H2O_TO_PA;
+constexpr double KPA_TO_PA = 1000.0;
+constexpr double PA_TO_KPA = 1.0 / KPA_TO_PA;
+
+// ---- Flow conversion factors ----
+constexpr double SCFM_TO_M3S = 4.7195e-4;       // standard cubic ft/min -> m^3/s
+constexpr double M3S_TO_SCFM = 1.0 / SCFM_TO_M3S;
+constexpr double GPM_TO_M3S = 6.30902e-5;       // US gallon/min -> m^3/s
+constexpr double M3S_TO_GPM = 1.0 / GPM_TO_M3S;
+
+// ---- Time ----
+constexpr double SECONDS_PER_DAY = 86400.0;
+constexpr double SECONDS_PER_HOUR = 3600.0;
+constexpr double SECONDS_PER_MINUTE = 60.0;
+
+// ---- Temperature conversions (functions: not all are affine-only) ----
+inline double celsius_to_kelvin(double c) { return c + T0_KELVIN; }
+inline double kelvin_to_celsius(double k) { return k - T0_KELVIN; }
+inline double fahrenheit_to_kelvin(double f) { return (f - 32.0) * 5.0 / 9.0 + T0_KELVIN; }
+inline double kelvin_to_fahrenheit(double k) { return (k - T0_KELVIN) * 9.0 / 5.0 + 32.0; }
+inline double fahrenheit_to_celsius(double f) { return (f - 32.0) * 5.0 / 9.0; }
+inline double celsius_to_fahrenheit(double c) { return c * 9.0 / 5.0 + 32.0; }
+
+// ---- Pressure helpers ----
+inline double torr_to_pa(double torr) { return torr * TORR_TO_PA; }
+inline double pa_to_torr(double pa) { return pa * PA_TO_TORR; }
+inline double in_h2o_to_pa(double in) { return in * IN_H2O_TO_PA; }
+inline double pa_to_in_h2o(double pa) { return pa * PA_TO_IN_H2O; }
+inline double kpa_to_pa(double kpa) { return kpa * KPA_TO_PA; }
+inline double pa_to_kpa(double pa) { return pa * PA_TO_KPA; }
+
+// ---- Flow helpers ----
+inline double scfm_to_m3s(double scfm) { return scfm * SCFM_TO_M3S; }
+inline double m3s_to_scfm(double m3s) { return m3s * M3S_TO_SCFM; }
+inline double gpm_to_m3s(double gpm) { return gpm * GPM_TO_M3S; }
+inline double m3s_to_gpm(double m3s) { return m3s * M3S_TO_GPM; }
+
+// ---- Concentration helpers ----
+inline double ppm_to_fraction(double ppm) { return ppm * 1.0e-6; }
+inline double fraction_to_ppm(double frac) { return frac * 1.0e6; }
+
+// ---- Mass rate helpers ----
+inline double kg_per_day_to_kg_per_s(double kg_day) { return kg_day / SECONDS_PER_DAY; }
+inline double kg_per_s_to_kg_per_day(double kg_s) { return kg_s * SECONDS_PER_DAY; }
+
+}  // namespace units
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__COMMON__UNITS_HPP_

--- a/ssos_eclss/include/ssos_eclss/faults/actuator_fault.hpp
+++ b/ssos_eclss/include/ssos_eclss/faults/actuator_fault.hpp
@@ -1,0 +1,40 @@
+#ifndef SSOS_ECLSS__FAULTS__ACTUATOR_FAULT_HPP_
+#define SSOS_ECLSS__FAULTS__ACTUATOR_FAULT_HPP_
+
+#include "ssos_eclss/faults/fault_types.hpp"
+
+// Actuator fault models. These corrupt the actual physics: valves stuck,
+// blower degradation/failure, pump failure. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+/// Effect of an actuator fault on a commanded actuator.
+struct ActuatorEffect
+{
+  bool override_position{false};  // valve: force position
+  double forced_position{0.0};    // [0,1]
+  double effectiveness{1.0};      // multiplier on flow/throughput [0,1]
+};
+
+/// Applies a single actuator fault.
+class ActuatorFault
+{
+public:
+  explicit ActuatorFault(const FaultDefinition & def);
+
+  /// Effect on the targeted actuator (independent of time once active).
+  ActuatorEffect effect() const;
+
+  const FaultDefinition & definition() const { return def_; }
+
+private:
+  FaultDefinition def_;
+};
+
+}  // namespace faults
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__FAULTS__ACTUATOR_FAULT_HPP_

--- a/ssos_eclss/include/ssos_eclss/faults/fault_injector.hpp
+++ b/ssos_eclss/include/ssos_eclss/faults/fault_injector.hpp
@@ -1,0 +1,75 @@
+#ifndef SSOS_ECLSS__FAULTS__FAULT_INJECTOR_HPP_
+#define SSOS_ECLSS__FAULTS__FAULT_INJECTOR_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ssos_eclss/faults/actuator_fault.hpp"
+#include "ssos_eclss/faults/fault_types.hpp"
+#include "ssos_eclss/faults/sensor_fault.hpp"
+#include "ssos_eclss/faults/thermal_fault.hpp"
+
+// Central registry that holds configured faults, tracks which are active given
+// the simulation clock, and aggregates their effects so the component models
+// can apply them. Faults change real physics behaviour, not just reported
+// values. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+class FaultInjector
+{
+public:
+  FaultInjector() = default;
+
+  /// Register a fault definition (with an optional RNG seed for noise).
+  void register_fault(const FaultDefinition & def, unsigned seed = 12345u);
+
+  /// Remove all faults.
+  void clear();
+
+  /// Update the active set against the current simulation time.
+  void update(double sim_time_s);
+
+  /// True if any fault is active.
+  bool any_active() const;
+
+  /// Number of registered faults.
+  std::size_t count() const { return entries_.size(); }
+
+  /// All currently active fault definitions.
+  std::vector<FaultDefinition> active_faults() const;
+
+  /// Aggregate actuator effect for a target component (combines active faults).
+  ActuatorEffect actuator_effect(const std::string & target) const;
+
+  /// Aggregate thermal effect for a target component.
+  ThermalEffect thermal_effect(const std::string & target) const;
+
+  /// Apply all active sensor faults targeting @p sensor to a true reading.
+  double apply_sensor(const std::string & sensor, double true_value);
+
+  /// Total extra leak orifice area [m^2] from active CABIN_LEAK faults.
+  double leak_fault_area(const std::string & target = "cabin") const;
+
+private:
+  struct Entry
+  {
+    FaultDefinition def;
+    bool active{false};
+    std::unique_ptr<SensorFault> sensor;  // only for sensor faults
+  };
+
+  bool is_active_at(const FaultDefinition & def, double t) const;
+
+  std::vector<Entry> entries_;
+  double current_time_s_{0.0};
+};
+
+}  // namespace faults
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__FAULTS__FAULT_INJECTOR_HPP_

--- a/ssos_eclss/include/ssos_eclss/faults/fault_types.hpp
+++ b/ssos_eclss/include/ssos_eclss/faults/fault_types.hpp
@@ -1,0 +1,72 @@
+#ifndef SSOS_ECLSS__FAULTS__FAULT_TYPES_HPP_
+#define SSOS_ECLSS__FAULTS__FAULT_TYPES_HPP_
+
+#include <string>
+
+// Physics-level fault taxonomy. Deliberately ROS-free: severity integer values
+// mirror space_station_interfaces/msg/FaultEvent so the ROS layer can map them
+// directly without this library depending on ROS. No external deps.
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+/// Category of fault and the physical effect it induces.
+enum class FaultType
+{
+  NONE,
+  // Sensor faults (corrupt a reported value, not the physics)
+  SENSOR_STUCK,
+  SENSOR_DRIFT,
+  SENSOR_BIAS,
+  SENSOR_NOISE,
+  SENSOR_SCALE,
+  // Actuator faults (corrupt the physics)
+  VALVE_STUCK_OPEN,
+  VALVE_STUCK_CLOSED,
+  BLOWER_DEGRADED,
+  BLOWER_FAILED,
+  PUMP_FAILED,
+  // Thermal faults (corrupt the physics)
+  HEATER_PARTIAL,
+  HEATER_FAILED,
+  PRECOOLER_DEGRADED,
+  INSULATION_LOSS,
+  // Environmental
+  CABIN_LEAK
+};
+
+/// Severity mirrors FaultEvent.SEVERITY_* constants.
+enum class FaultSeverity
+{
+  WARNING = 0,
+  CRITICAL = 1,
+  EMERGENCY = 2
+};
+
+/// A configured fault.
+struct FaultDefinition
+{
+  FaultType type{FaultType::NONE};
+  FaultSeverity severity{FaultSeverity::WARNING};
+  std::string target;       // component / sensor name the fault acts on
+  double magnitude{0.0};    // meaning depends on type (bias value, factor, rate...)
+  double start_time_s{0.0}; // activation time [s]
+  double duration_s{-1.0};  // active duration [s]; <0 means permanent
+  std::string description;  // human-readable description
+};
+
+/// Human-readable name for a fault type (also used as FaultEvent.fault_type).
+std::string to_string(FaultType type);
+
+/// True if the fault corrupts a reported sensor value rather than the physics.
+bool is_sensor_fault(FaultType type);
+
+/// True if the fault alters actuator/thermal physics behaviour.
+bool is_physics_fault(FaultType type);
+
+}  // namespace faults
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__FAULTS__FAULT_TYPES_HPP_

--- a/ssos_eclss/include/ssos_eclss/faults/sensor_fault.hpp
+++ b/ssos_eclss/include/ssos_eclss/faults/sensor_fault.hpp
@@ -1,0 +1,41 @@
+#ifndef SSOS_ECLSS__FAULTS__SENSOR_FAULT_HPP_
+#define SSOS_ECLSS__FAULTS__SENSOR_FAULT_HPP_
+
+#include <random>
+
+#include "ssos_eclss/faults/fault_types.hpp"
+
+// Sensor fault models. These corrupt a reported reading; the underlying physics
+// is unaffected. Stuck-at, drift, bias, additive noise and scale error.
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+/// Applies a single sensor fault to a stream of readings.
+class SensorFault
+{
+public:
+  explicit SensorFault(const FaultDefinition & def, unsigned seed = 12345u);
+
+  /// Transform a true reading into the faulted reading at elapsed fault time.
+  /// @param true_value  the physically correct value
+  /// @param fault_elapsed_s seconds since the fault activated
+  double apply(double true_value, double fault_elapsed_s);
+
+  const FaultDefinition & definition() const { return def_; }
+
+private:
+  FaultDefinition def_;
+  std::mt19937 rng_;
+  std::normal_distribution<double> noise_{0.0, 1.0};
+  bool latched_{false};
+  double latched_value_{0.0};
+};
+
+}  // namespace faults
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__FAULTS__SENSOR_FAULT_HPP_

--- a/ssos_eclss/include/ssos_eclss/faults/thermal_fault.hpp
+++ b/ssos_eclss/include/ssos_eclss/faults/thermal_fault.hpp
@@ -1,0 +1,39 @@
+#ifndef SSOS_ECLSS__FAULTS__THERMAL_FAULT_HPP_
+#define SSOS_ECLSS__FAULTS__THERMAL_FAULT_HPP_
+
+#include "ssos_eclss/faults/fault_types.hpp"
+
+// Thermal fault models: heater element failure (partial/total), precooler
+// degradation and insulation loss. These corrupt the physics. No ROS.
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+/// Effect of a thermal fault on thermal model coefficients.
+struct ThermalEffect
+{
+  double heater_power_factor{1.0};   // multiplier on heater power [0,1+]
+  double precooler_ua_factor{1.0};   // multiplier on precooler UA [0,1]
+  double wall_htc_factor{1.0};       // multiplier on wall loss coefficient [>=1]
+};
+
+/// Applies a single thermal fault.
+class ThermalFault
+{
+public:
+  explicit ThermalFault(const FaultDefinition & def);
+
+  ThermalEffect effect() const;
+
+  const FaultDefinition & definition() const { return def_; }
+
+private:
+  FaultDefinition def_;
+};
+
+}  // namespace faults
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__FAULTS__THERMAL_FAULT_HPP_

--- a/ssos_eclss/include/ssos_eclss/nodes/ars_node.hpp
+++ b/ssos_eclss/include/ssos_eclss/nodes/ars_node.hpp
@@ -1,0 +1,94 @@
+#ifndef SSOS_ECLSS__NODES__ARS_NODE_HPP_
+#define SSOS_ECLSS__NODES__ARS_NODE_HPP_
+
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "space_station_interfaces/msg/fault_event.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+#include "space_station_interfaces/msg/world_state.hpp"
+#include "space_station_interfaces/srv/register_subsystem.hpp"
+
+#include "ssos_eclss/ars/four_bed_system.hpp"
+#include "ssos_eclss/nodes/eclss_parameter_bridge.hpp"
+
+// Lifecycle node wrapping the FourBedSystem ARS physics. Reads cabin conditions
+// from /sim/world_state (Epic A boundary), advances the 4BMS each step, and
+// publishes telemetry, CO2 removal rate, a heartbeat and fault events.
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+using WorldState = space_station_interfaces::msg::WorldState;
+using RegisterSubsystem = space_station_interfaces::srv::RegisterSubsystem;
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using FaultEvent = space_station_interfaces::msg::FaultEvent;
+using CallbackReturn =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class ArsNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit ArsNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+  /// Last computed CO2 removal rate [kg/day] (for testing).
+  double last_co2_removal_kg_day() const { return last_result_.co2_removal_rate_kg_day; }
+
+private:
+  void step();
+  void on_world_state(const WorldState::SharedPtr msg);
+  void register_with_manager();
+  rcl_interfaces::msg::SetParametersResult on_set_parameters(
+    const std::vector<rclcpp::Parameter> & params);
+
+  // Physics
+  std::unique_ptr<ars::FourBedSystem> ars_;
+  std::unique_ptr<EclssParameterBridge> bridge_;
+  ars::CabinConditions cabin_{};
+  ars::ArsResult last_result_{};
+  bool have_world_state_{false};
+
+  // Publishers
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr co2_removal_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr
+    telemetry_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<SubsystemHeartbeat>::SharedPtr heartbeat_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<FaultEvent>::SharedPtr fault_pub_;
+
+  // Subscriber
+  rclcpp::Subscription<WorldState>::SharedPtr world_state_sub_;
+
+  // Service client
+  rclcpp::Client<RegisterSubsystem>::SharedPtr register_client_;
+
+  // Timer
+  rclcpp::TimerBase::SharedPtr step_timer_;
+
+  // Parameter callback handle
+  OnSetParametersCallbackHandle::SharedPtr param_cb_handle_;
+
+  // Config
+  double step_rate_hz_{1.0};
+  double co2_required_kg_day_{4.16};
+  rclcpp::Time last_step_time_;
+  bool first_step_{true};
+  bool params_dirty_{false};
+};
+
+}  // namespace nodes
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__NODES__ARS_NODE_HPP_

--- a/ssos_eclss/include/ssos_eclss/nodes/cabin_node.hpp
+++ b/ssos_eclss/include/ssos_eclss/nodes/cabin_node.hpp
@@ -1,0 +1,75 @@
+#ifndef SSOS_ECLSS__NODES__CABIN_NODE_HPP_
+#define SSOS_ECLSS__NODES__CABIN_NODE_HPP_
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "space_station_interfaces/msg/fault_event.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+#include "space_station_interfaces/srv/register_subsystem.hpp"
+
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+#include "ssos_eclss/cabin/crew_metabolic_model.hpp"
+#include "ssos_eclss/cabin/leak_model.hpp"
+
+// Lifecycle node simulating the cabin atmosphere driven by crew metabolic loads
+// and leakage. Publishes ppCO2, O2 fraction and total pressure telemetry.
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+using RegisterSubsystem = space_station_interfaces::srv::RegisterSubsystem;
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using FaultEvent = space_station_interfaces::msg::FaultEvent;
+using CallbackReturn =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class CabinNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit CabinNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+  double last_co2_ppm() const { return last_co2_ppm_; }
+
+private:
+  void step();
+  void register_with_manager();
+
+  std::unique_ptr<cabin::CabinAtmosphere> atmosphere_;
+  std::unique_ptr<cabin::CrewMetabolicModel> crew_;
+  std::unique_ptr<cabin::LeakModel> leak_;
+  double last_co2_ppm_{0.0};
+
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr co2_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr
+    telemetry_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<SubsystemHeartbeat>::SharedPtr heartbeat_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<FaultEvent>::SharedPtr fault_pub_;
+  rclcpp::Client<RegisterSubsystem>::SharedPtr register_client_;
+  rclcpp::TimerBase::SharedPtr step_timer_;
+
+  double step_rate_hz_{1.0};
+  int crew_size_{4};
+  double cabin_volume_m3_{100.0};
+  double cabin_temp_c_{22.0};
+  double co2_alarm_ppm_{7000.0};
+  rclcpp::Time last_step_time_;
+  bool first_step_{true};
+};
+
+}  // namespace nodes
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__NODES__CABIN_NODE_HPP_

--- a/ssos_eclss/include/ssos_eclss/nodes/eclss_diagnostics.hpp
+++ b/ssos_eclss/include/ssos_eclss/nodes/eclss_diagnostics.hpp
@@ -1,0 +1,51 @@
+#ifndef SSOS_ECLSS__NODES__ECLSS_DIAGNOSTICS_HPP_
+#define SSOS_ECLSS__NODES__ECLSS_DIAGNOSTICS_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rclcpp/time.hpp"
+#include "space_station_interfaces/msg/fault_event.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+
+// Shared helpers for building heartbeat and fault-event messages and for
+// detecting common ECLSS fault conditions. Used by all subsystem nodes.
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using FaultEvent = space_station_interfaces::msg::FaultEvent;
+
+class EclssDiagnostics
+{
+public:
+  /// Build a heartbeat message.
+  static SubsystemHeartbeat make_heartbeat(const rclcpp::Time & stamp,
+                                           const std::string & subsystem_name,
+                                           uint8_t lifecycle_state, bool healthy,
+                                           const std::string & status_message);
+
+  /// Build a fault-event message.
+  static FaultEvent make_fault(const rclcpp::Time & stamp,
+                               const std::string & subsystem_name,
+                               const std::string & fault_type, uint8_t severity,
+                               const std::string & description,
+                               const std::vector<std::string> & affected_interfaces = {});
+
+  /// True if ARS CO2 removal is below the life-support requirement.
+  /// @param removal_kg_day measured CO2 removal [kg/day]
+  /// @param required_kg_day requirement (default 4.16 kg/day)
+  static bool ars_co2_removal_low(double removal_kg_day,
+                                  double required_kg_day = 4.16);
+
+  /// True if a regeneration bed failed to reach its target temperature.
+  static bool bed_underheated(double max_bed_temp_k, double target_temp_k);
+};
+
+}  // namespace nodes
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__NODES__ECLSS_DIAGNOSTICS_HPP_

--- a/ssos_eclss/include/ssos_eclss/nodes/eclss_parameter_bridge.hpp
+++ b/ssos_eclss/include/ssos_eclss/nodes/eclss_parameter_bridge.hpp
@@ -1,0 +1,50 @@
+#ifndef SSOS_ECLSS__NODES__ECLSS_PARAMETER_BRIDGE_HPP_
+#define SSOS_ECLSS__NODES__ECLSS_PARAMETER_BRIDGE_HPP_
+
+#include <string>
+#include <vector>
+
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rclcpp/parameter.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "ssos_eclss/ars/ars_parameters.hpp"
+
+// The single mapping between ROS 2 parameters and the ECLSS physics structs.
+// Parameters flow IN from ROS; the physics library never hardcodes them
+// (factory functions supply defaults only). Static parameters (geometry,
+// n_cells) are read once in on_configure; dynamic parameters (heater, cycle,
+// flow, isotherm what-if) are live-tunable and validated before acceptance.
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+class EclssParameterBridge
+{
+public:
+  explicit EclssParameterBridge(rclcpp_lifecycle::LifecycleNode * node);
+
+  /// Declare all ARS parameters using the supplied defaults.
+  void declare_ars_parameters(const ars::ArsParameters & defaults);
+
+  /// Read the full ARS parameter set from the node's current parameters.
+  ars::ArsParameters read_ars_parameters() const;
+
+  /// Validate a proposed set of parameter changes. Returns successful=false
+  /// with a clear reason if any value is out of physical range.
+  rcl_interfaces::msg::SetParametersResult validate(
+    const std::vector<rclcpp::Parameter> & params) const;
+
+  /// True if a parameter name is static (requires reconfigure to take effect).
+  static bool is_static_parameter(const std::string & name);
+
+private:
+  rclcpp_lifecycle::LifecycleNode * node_;
+};
+
+}  // namespace nodes
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__NODES__ECLSS_PARAMETER_BRIDGE_HPP_

--- a/ssos_eclss/include/ssos_eclss/nodes/ogs_node.hpp
+++ b/ssos_eclss/include/ssos_eclss/nodes/ogs_node.hpp
@@ -1,0 +1,70 @@
+#ifndef SSOS_ECLSS__NODES__OGS_NODE_HPP_
+#define SSOS_ECLSS__NODES__OGS_NODE_HPP_
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "space_station_interfaces/msg/fault_event.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+#include "space_station_interfaces/msg/world_state.hpp"
+#include "space_station_interfaces/srv/register_subsystem.hpp"
+
+#include "ssos_eclss/ogs/oxygen_generator_system.hpp"
+
+// Lifecycle node wrapping the Oxygen Generation System physics.
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+using WorldState = space_station_interfaces::msg::WorldState;
+using RegisterSubsystem = space_station_interfaces::srv::RegisterSubsystem;
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using FaultEvent = space_station_interfaces::msg::FaultEvent;
+using CallbackReturn =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class OgsNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit OgsNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+  double last_o2_kg_day() const { return last_result_.o2_production_kg_day; }
+
+private:
+  void step();
+  void register_with_manager();
+
+  std::unique_ptr<ogs::OxygenGeneratorSystem> ogs_;
+  ogs::OgsResult last_result_{};
+
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr o2_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr
+    telemetry_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<SubsystemHeartbeat>::SharedPtr heartbeat_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<FaultEvent>::SharedPtr fault_pub_;
+  rclcpp::Client<RegisterSubsystem>::SharedPtr register_client_;
+  rclcpp::TimerBase::SharedPtr step_timer_;
+
+  double step_rate_hz_{1.0};
+  double stack_current_a_{27.0};
+  double o2_required_kg_day_{2.3};
+  rclcpp::Time last_step_time_;
+  bool first_step_{true};
+};
+
+}  // namespace nodes
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__NODES__OGS_NODE_HPP_

--- a/ssos_eclss/include/ssos_eclss/nodes/wrs_node.hpp
+++ b/ssos_eclss/include/ssos_eclss/nodes/wrs_node.hpp
@@ -1,0 +1,69 @@
+#ifndef SSOS_ECLSS__NODES__WRS_NODE_HPP_
+#define SSOS_ECLSS__NODES__WRS_NODE_HPP_
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "space_station_interfaces/msg/fault_event.hpp"
+#include "space_station_interfaces/msg/subsystem_heartbeat.hpp"
+#include "space_station_interfaces/srv/register_subsystem.hpp"
+
+#include "ssos_eclss/wrs/water_recovery_system.hpp"
+
+// Lifecycle node wrapping the Water Recovery System physics.
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+using RegisterSubsystem = space_station_interfaces::srv::RegisterSubsystem;
+using SubsystemHeartbeat = space_station_interfaces::msg::SubsystemHeartbeat;
+using FaultEvent = space_station_interfaces::msg::FaultEvent;
+using CallbackReturn =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+class WrsNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit WrsNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state) override;
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+  double last_conductivity_us() const { return last_result_.product_conductivity_us; }
+
+private:
+  void step();
+  void register_with_manager();
+
+  std::unique_ptr<wrs::WaterRecoverySystem> wrs_;
+  wrs::WrsResult last_result_{};
+
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr water_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr
+    telemetry_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<SubsystemHeartbeat>::SharedPtr heartbeat_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<FaultEvent>::SharedPtr fault_pub_;
+  rclcpp::Client<RegisterSubsystem>::SharedPtr register_client_;
+  rclcpp::TimerBase::SharedPtr step_timer_;
+
+  double step_rate_hz_{1.0};
+  double urine_kg_day_{6.0};
+  double condensate_kg_day_{3.0};
+  double potable_limit_us_{100.0};
+  rclcpp::Time last_step_time_;
+  bool first_step_{true};
+};
+
+}  // namespace nodes
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__NODES__WRS_NODE_HPP_

--- a/ssos_eclss/include/ssos_eclss/ogs/electrolysis_cell_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ogs/electrolysis_cell_model.hpp
@@ -1,0 +1,54 @@
+#ifndef SSOS_ECLSS__OGS__ELECTROLYSIS_CELL_MODEL_HPP_
+#define SSOS_ECLSS__OGS__ELECTROLYSIS_CELL_MODEL_HPP_
+
+#include "ssos_eclss/ogs/ogs_parameters.hpp"
+
+// Single PEM electrolysis cell: 2 H2O -> 2 H2 + O2. Computes cell voltage as
+// the reversible (Nernst) potential plus activation (Tafel), ohmic and
+// concentration overpotentials, and the Faradaic gas production. No ROS.
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+/// Operating point of a single cell.
+struct CellState
+{
+  double voltage;            // total cell voltage [V]
+  double reversible_voltage; // Nernst potential [V]
+  double activation_overpotential;  // [V]
+  double ohmic_overpotential;        // [V]
+  double concentration_overpotential;  // [V]
+  double o2_production_mol_s; // O2 generated [mol/s]
+  double h2_production_mol_s; // H2 generated [mol/s]
+  double power_w;             // electrical power [W]
+  double efficiency;          // thermoneutral/voltage efficiency [-]
+};
+
+/// PEM electrolysis cell model.
+class ElectrolysisCellModel
+{
+public:
+  explicit ElectrolysisCellModel(const CellParams & params);
+
+  /// Reversible cell voltage [V] via Nernst at temperature and pressure.
+  double reversible_voltage(double temperature_k, double pressure_pa) const;
+
+  /// Solve the cell at a given current and conditions.
+  /// @param current_a    cell current [A]
+  /// @param temperature_k cell temperature [K]
+  /// @param pressure_pa  operating pressure [Pa]
+  CellState solve(double current_a, double temperature_k, double pressure_pa) const;
+
+  void set_params(const CellParams & p) { params_ = p; }
+  const CellParams & params() const { return params_; }
+
+private:
+  CellParams params_;
+};
+
+}  // namespace ogs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__OGS__ELECTROLYSIS_CELL_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ogs/electrolysis_stack_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ogs/electrolysis_stack_model.hpp
@@ -1,0 +1,58 @@
+#ifndef SSOS_ECLSS__OGS__ELECTROLYSIS_STACK_MODEL_HPP_
+#define SSOS_ECLSS__OGS__ELECTROLYSIS_STACK_MODEL_HPP_
+
+#include "ssos_eclss/ogs/electrolysis_cell_model.hpp"
+#include "ssos_eclss/ogs/ogs_parameters.hpp"
+
+// Series stack of PEM cells with a lumped thermal model. No ROS.
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+/// Aggregate stack operating point.
+struct StackState
+{
+  double total_voltage;       // stack voltage [V]
+  double current_a;           // stack current [A]
+  double o2_production_mol_s; // total O2 [mol/s]
+  double h2_production_mol_s; // total H2 [mol/s]
+  double power_w;             // total electrical power [W]
+  double waste_heat_w;        // heat above thermoneutral [W]
+  double temperature_k;       // stack temperature [K]
+  double efficiency;          // voltage efficiency [-]
+};
+
+/// PEM electrolysis stack.
+class ElectrolysisStackModel
+{
+public:
+  ElectrolysisStackModel(const StackParams & stack, const CellParams & cell);
+
+  /// Reset the stack temperature.
+  void reset(double temperature_k);
+
+  /// Advance the stack thermal state and compute the operating point.
+  /// @param dt          timestep [s]
+  /// @param current_a   stack current [A]
+  /// @param pressure_pa operating pressure [Pa]
+  /// @param coolant_temp_k coolant temperature [K]
+  StackState step(double dt, double current_a, double pressure_pa,
+                  double coolant_temp_k);
+
+  double temperature_k() const { return temperature_k_; }
+  const StackParams & params() const { return stack_; }
+  void set_params(const StackParams & s) { stack_ = s; }
+  void set_cell_params(const CellParams & c) { cell_.set_params(c); }
+
+private:
+  StackParams stack_;
+  ElectrolysisCellModel cell_;
+  double temperature_k_{330.0};
+};
+
+}  // namespace ogs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__OGS__ELECTROLYSIS_STACK_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ogs/gas_separator_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/ogs/gas_separator_model.hpp
@@ -1,0 +1,43 @@
+#ifndef SSOS_ECLSS__OGS__GAS_SEPARATOR_MODEL_HPP_
+#define SSOS_ECLSS__OGS__GAS_SEPARATOR_MODEL_HPP_
+
+#include "ssos_eclss/ogs/ogs_parameters.hpp"
+
+// Rotary/static phase separator that splits product gas from entrained water.
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+/// Result of a separation.
+struct SeparationResult
+{
+  double dry_gas_mol_s;       // gas delivered downstream [mol/s]
+  double recovered_water_mol_s;  // liquid water returned to feed [mol/s]
+  double carryover_water_mol_s;  // water carried over with the gas [mol/s]
+};
+
+/// Phase separator.
+class GasSeparatorModel
+{
+public:
+  explicit GasSeparatorModel(const SeparatorParams & params);
+
+  /// Separate a wet gas stream.
+  /// @param gas_mol_s   product gas molar rate [mol/s]
+  /// @param water_mol_s entrained water molar rate [mol/s]
+  SeparationResult separate(double gas_mol_s, double water_mol_s) const;
+
+  const SeparatorParams & params() const { return params_; }
+  void set_params(const SeparatorParams & p) { params_ = p; }
+
+private:
+  SeparatorParams params_;
+};
+
+}  // namespace ogs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__OGS__GAS_SEPARATOR_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/ogs/ogs_parameters.hpp
+++ b/ssos_eclss/include/ssos_eclss/ogs/ogs_parameters.hpp
@@ -1,0 +1,65 @@
+#ifndef SSOS_ECLSS__OGS__OGS_PARAMETERS_HPP_
+#define SSOS_ECLSS__OGS__OGS_PARAMETERS_HPP_
+
+// Parameters for the Oxygen Generation System (PEM water electrolysis).
+// SI units. Factory functions provide ISS-OGA-class defaults.
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+/// PEM electrolysis cell electrochemistry/geometry.
+struct CellParams
+{
+  double active_area_m2;       // membrane active area [m^2]
+  double exchange_current_density;  // i0 [A/m^2] (lumped anode/cathode)
+  double limiting_current_density;  // i_lim [A/m^2]
+  double membrane_resistance;  // area-specific resistance [ohm*m^2]
+  double charge_transfer_coeff;  // alpha [-]
+  double reference_temp_k;     // reference temperature [K]
+};
+
+/// Electrolysis stack.
+struct StackParams
+{
+  int n_cells;                 // number of series cells
+  double thermal_mass_j_k;     // lumped stack thermal mass [J/K]
+  double heat_loss_coeff_w_k;  // stack-to-coolant conductance [W/K]
+};
+
+/// Gas/water phase separator.
+struct SeparatorParams
+{
+  double efficiency;           // separation efficiency [-]
+  double carryover_fraction;   // liquid water carried with gas [-]
+};
+
+/// Operating set-points.
+struct OgsOperating
+{
+  double stack_current_a;      // operating current [A]
+  double feedwater_temp_k;     // feed water temperature [K]
+  double coolant_temp_k;       // coolant temperature [K]
+  double cell_pressure_pa;     // operating pressure [Pa]
+};
+
+/// Complete OGS parameter set.
+struct OgsParameters
+{
+  CellParams cell;
+  StackParams stack;
+  SeparatorParams separator;
+  OgsOperating operating;
+};
+
+CellParams default_cell_params();
+StackParams default_stack_params();
+SeparatorParams default_separator_params();
+OgsOperating default_ogs_operating();
+OgsParameters default_ogs_parameters();
+
+}  // namespace ogs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__OGS__OGS_PARAMETERS_HPP_

--- a/ssos_eclss/include/ssos_eclss/ogs/oxygen_generator_system.hpp
+++ b/ssos_eclss/include/ssos_eclss/ogs/oxygen_generator_system.hpp
@@ -1,0 +1,62 @@
+#ifndef SSOS_ECLSS__OGS__OXYGEN_GENERATOR_SYSTEM_HPP_
+#define SSOS_ECLSS__OGS__OXYGEN_GENERATOR_SYSTEM_HPP_
+
+#include <memory>
+
+#include "ssos_eclss/ogs/electrolysis_stack_model.hpp"
+#include "ssos_eclss/ogs/gas_separator_model.hpp"
+#include "ssos_eclss/ogs/ogs_parameters.hpp"
+
+// Top-level Oxygen Generation System. Inputs feedwater and electrical power;
+// outputs O2 to the cabin and H2 to the Sabatier reactor. No ROS.
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+/// OGS outputs after a step.
+struct OgsResult
+{
+  double o2_production_mol_s;   // O2 delivered to cabin [mol/s]
+  double h2_production_mol_s;   // H2 delivered to Sabatier [mol/s]
+  double o2_production_kg_day;  // O2 production [kg/day]
+  double water_consumed_mol_s;  // feedwater consumed [mol/s]
+  double water_consumed_kg_day; // feedwater consumed [kg/day]
+  double stack_voltage;         // stack voltage [V]
+  double stack_power_w;         // electrical power [W]
+  double stack_temperature_k;   // stack temperature [K]
+  double specific_energy_wh_kg; // energy per kg O2 [Wh/kg]
+  bool feedwater_limited;       // true if feed water was the limiter
+};
+
+/// Oxygen Generation System orchestrator.
+class OxygenGeneratorSystem
+{
+public:
+  explicit OxygenGeneratorSystem(const OgsParameters & params = default_ogs_parameters());
+
+  void reset(double temperature_k = 330.0);
+
+  /// Advance the OGS by dt.
+  /// @param dt                timestep [s]
+  /// @param current_a         commanded stack current [A]
+  /// @param available_water_mol_s feed water available [mol/s]
+  OgsResult step(double dt, double current_a, double available_water_mol_s);
+
+  /// Convenience: run at the configured operating current with ample feed.
+  OgsResult step_nominal(double dt);
+
+  void set_parameters(const OgsParameters & params);
+  const OgsParameters & parameters() const { return params_; }
+
+private:
+  OgsParameters params_;
+  std::unique_ptr<ElectrolysisStackModel> stack_;
+  std::unique_ptr<GasSeparatorModel> separator_;
+};
+
+}  // namespace ogs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__OGS__OXYGEN_GENERATOR_SYSTEM_HPP_

--- a/ssos_eclss/include/ssos_eclss/sabatier/reactor_kinetics.hpp
+++ b/ssos_eclss/include/ssos_eclss/sabatier/reactor_kinetics.hpp
@@ -1,0 +1,38 @@
+#ifndef SSOS_ECLSS__SABATIER__REACTOR_KINETICS_HPP_
+#define SSOS_ECLSS__SABATIER__REACTOR_KINETICS_HPP_
+
+#include "ssos_eclss/sabatier/sabatier_parameters.hpp"
+
+// Sabatier reaction kinetics: CO2 + 4 H2 -> CH4 + 2 H2O. Arrhenius rate with an
+// equilibrium-limited maximum conversion. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace sabatier
+{
+
+/// Sabatier reaction kinetics.
+class ReactorKinetics
+{
+public:
+  explicit ReactorKinetics(const KineticsParams & params);
+
+  /// Arrhenius rate constant k(T) [1/s].
+  double rate_constant(double temperature_k) const;
+
+  /// Fractional CO2 conversion at temperature T over the catalyst residence
+  /// time, capped at the equilibrium-limited maximum. Uses first-order kinetics
+  /// X = Xmax (1 - exp(-k(T) * tau)).
+  double conversion(double temperature_k) const;
+
+  const KineticsParams & params() const { return params_; }
+  void set_params(const KineticsParams & p) { params_ = p; }
+
+private:
+  KineticsParams params_;
+};
+
+}  // namespace sabatier
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__SABATIER__REACTOR_KINETICS_HPP_

--- a/ssos_eclss/include/ssos_eclss/sabatier/sabatier_parameters.hpp
+++ b/ssos_eclss/include/ssos_eclss/sabatier/sabatier_parameters.hpp
@@ -1,0 +1,46 @@
+#ifndef SSOS_ECLSS__SABATIER__SABATIER_PARAMETERS_HPP_
+#define SSOS_ECLSS__SABATIER__SABATIER_PARAMETERS_HPP_
+
+// Parameters for the Sabatier CO2 reduction reactor:
+//   CO2 + 4 H2 -> CH4 + 2 H2O   (exothermic, dH ~ -165 kJ/mol CO2)
+// SI units. Factory functions provide flight-class defaults.
+
+namespace ssos_eclss
+{
+namespace sabatier
+{
+
+/// Reaction kinetics / equilibrium parameters.
+struct KineticsParams
+{
+  double pre_exponential;     // Arrhenius pre-exponential [1/s]
+  double activation_energy;   // Arrhenius activation energy [J/mol]
+  double max_conversion;      // equilibrium-limited maximum CO2 conversion [-]
+  double residence_time_s;    // gas residence time in the catalyst bed [s]
+  double heat_of_reaction;    // exothermic heat released [J/mol CO2] (positive)
+};
+
+/// Reactor thermal / operating parameters.
+struct ReactorParams
+{
+  double operating_temp_k;    // nominal catalyst temperature [K]
+  double thermal_mass_j_k;    // lumped reactor thermal mass [J/K]
+  double heat_loss_coeff_w_k; // reactor-to-ambient conductance [W/K]
+  double ambient_temp_k;      // ambient temperature [K]
+};
+
+/// Complete Sabatier parameter set.
+struct SabatierParameters
+{
+  KineticsParams kinetics;
+  ReactorParams reactor;
+};
+
+KineticsParams default_kinetics_params();
+ReactorParams default_reactor_params();
+SabatierParameters default_sabatier_parameters();
+
+}  // namespace sabatier
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__SABATIER__SABATIER_PARAMETERS_HPP_

--- a/ssos_eclss/include/ssos_eclss/sabatier/sabatier_system.hpp
+++ b/ssos_eclss/include/ssos_eclss/sabatier/sabatier_system.hpp
@@ -1,0 +1,59 @@
+#ifndef SSOS_ECLSS__SABATIER__SABATIER_SYSTEM_HPP_
+#define SSOS_ECLSS__SABATIER__SABATIER_SYSTEM_HPP_
+
+#include <memory>
+
+#include "ssos_eclss/sabatier/reactor_kinetics.hpp"
+#include "ssos_eclss/sabatier/sabatier_parameters.hpp"
+
+// Sabatier system: consumes CO2 from ARS desorption and H2 from the OGS,
+// producing CH4 (vented) and H2O (returned to the WRS). Closing the loop.
+// Includes a lumped reactor thermal model fed by the reaction exotherm. No ROS.
+
+namespace ssos_eclss
+{
+namespace sabatier
+{
+
+/// Sabatier outputs after a step.
+struct SabatierResult
+{
+  double co2_consumed_mol_s;  // CO2 reacted [mol/s]
+  double h2_consumed_mol_s;   // H2 reacted [mol/s]
+  double ch4_produced_mol_s;  // CH4 produced (vented) [mol/s]
+  double water_produced_mol_s;  // H2O produced (to WRS) [mol/s]
+  double water_produced_kg_s;   // H2O produced [kg/s]
+  double conversion;          // achieved CO2 conversion [-]
+  double reaction_heat_w;     // exothermic heat released [W]
+  double reactor_temp_k;      // reactor temperature [K]
+  bool hydrogen_limited;      // true if H2 was the stoichiometric limiter
+};
+
+/// Sabatier CO2 reduction system.
+class SabatierSystem
+{
+public:
+  explicit SabatierSystem(const SabatierParameters & params = default_sabatier_parameters());
+
+  void reset(double temperature_k);
+
+  /// Advance the reactor by dt.
+  /// @param dt          timestep [s]
+  /// @param co2_in_mol_s CO2 supplied [mol/s]
+  /// @param h2_in_mol_s  H2 supplied [mol/s]
+  SabatierResult step(double dt, double co2_in_mol_s, double h2_in_mol_s);
+
+  double reactor_temp_k() const { return reactor_temp_k_; }
+  void set_parameters(const SabatierParameters & params);
+  const SabatierParameters & parameters() const { return params_; }
+
+private:
+  SabatierParameters params_;
+  std::unique_ptr<ReactorKinetics> kinetics_;
+  double reactor_temp_k_{600.0};
+};
+
+}  // namespace sabatier
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__SABATIER__SABATIER_SYSTEM_HPP_

--- a/ssos_eclss/include/ssos_eclss/wrs/catalytic_reactor_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/wrs/catalytic_reactor_model.hpp
@@ -1,0 +1,46 @@
+#ifndef SSOS_ECLSS__WRS__CATALYTIC_REACTOR_MODEL_HPP_
+#define SSOS_ECLSS__WRS__CATALYTIC_REACTOR_MODEL_HPP_
+
+#include "ssos_eclss/wrs/wrs_parameters.hpp"
+
+// High-temperature catalytic oxidation of trace volatile organics in the water
+// processor. Conversion rises with reactor temperature (Arrhenius-style).
+// No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+/// Catalytic reactor outputs.
+struct CatalyticResult
+{
+  double conversion;            // fraction of organics oxidised [-]
+  double outlet_voc_kg_s;       // residual volatile organics [kg/s]
+};
+
+/// Catalytic oxidation reactor.
+class CatalyticReactorModel
+{
+public:
+  explicit CatalyticReactorModel(const CatalyticReactorParams & params);
+
+  /// Conversion at the current operating temperature [-].
+  double conversion(double temperature_k) const;
+
+  /// Treat a VOC-laden stream.
+  /// @param voc_in_kg_s   inlet volatile-organics rate [kg/s]
+  /// @param temperature_k reactor temperature [K]
+  CatalyticResult process(double voc_in_kg_s, double temperature_k) const;
+
+  const CatalyticReactorParams & params() const { return params_; }
+  void set_params(const CatalyticReactorParams & p) { params_ = p; }
+
+private:
+  CatalyticReactorParams params_;
+};
+
+}  // namespace wrs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__WRS__CATALYTIC_REACTOR_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/wrs/distillation_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/wrs/distillation_model.hpp
@@ -1,0 +1,43 @@
+#ifndef SSOS_ECLSS__WRS__DISTILLATION_MODEL_HPP_
+#define SSOS_ECLSS__WRS__DISTILLATION_MODEL_HPP_
+
+#include "ssos_eclss/wrs/wrs_parameters.hpp"
+
+// Vapor Compression Distillation model for urine processing: evaporation,
+// vapour compression and condensation, producing distillate and brine. No ROS.
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+/// Distillation outputs over a step.
+struct DistillationResult
+{
+  double distillate_kg_s;   // recovered water [kg/s]
+  double brine_kg_s;        // concentrated brine reject [kg/s]
+  double energy_w;          // electrical power consumed [W]
+  double recovery_fraction; // achieved recovery [-]
+};
+
+/// Vapor Compression Distillation (Urine Processor Assembly).
+class DistillationModel
+{
+public:
+  explicit DistillationModel(const DistillationParams & params);
+
+  /// Process a urine/wastewater feed.
+  /// @param feed_kg_s urine feed rate [kg/s]
+  DistillationResult process(double feed_kg_s) const;
+
+  const DistillationParams & params() const { return params_; }
+  void set_params(const DistillationParams & p) { params_ = p; }
+
+private:
+  DistillationParams params_;
+};
+
+}  // namespace wrs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__WRS__DISTILLATION_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/wrs/multifiltration_model.hpp
+++ b/ssos_eclss/include/ssos_eclss/wrs/multifiltration_model.hpp
@@ -1,0 +1,52 @@
+#ifndef SSOS_ECLSS__WRS__MULTIFILTRATION_MODEL_HPP_
+#define SSOS_ECLSS__WRS__MULTIFILTRATION_MODEL_HPP_
+
+#include "ssos_eclss/wrs/wrs_parameters.hpp"
+
+// Multifiltration bed model (adsorption + ion exchange) for the Water Processor.
+// Tracks contaminant loading toward breakthrough and the resulting product
+// water conductivity. No ROS, no external deps.
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+/// Multifiltration outputs over a step.
+struct MultifiltrationResult
+{
+  double product_kg_s;          // treated water [kg/s]
+  double product_conductivity_us;  // product conductivity [uS/cm]
+  double bed_utilization;       // fraction of capacity consumed [-]
+  bool broken_through;          // true once capacity is exhausted
+};
+
+/// Multifiltration bed.
+class MultifiltrationModel
+{
+public:
+  explicit MultifiltrationModel(const MultifiltrationParams & params);
+
+  /// Reset accumulated contaminant loading.
+  void reset();
+
+  /// Treat a feed stream of given conductivity for dt seconds.
+  /// @param dt                timestep [s]
+  /// @param feed_kg_s         feed rate [kg/s]
+  /// @param feed_conductivity_us feed conductivity [uS/cm]
+  MultifiltrationResult process(double dt, double feed_kg_s,
+                                double feed_conductivity_us);
+
+  double accumulated_kg() const { return accumulated_kg_; }
+  const MultifiltrationParams & params() const { return params_; }
+  void set_params(const MultifiltrationParams & p) { params_ = p; }
+
+private:
+  MultifiltrationParams params_;
+  double accumulated_kg_{0.0};  // contaminant mass captured [kg]
+};
+
+}  // namespace wrs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__WRS__MULTIFILTRATION_MODEL_HPP_

--- a/ssos_eclss/include/ssos_eclss/wrs/water_recovery_system.hpp
+++ b/ssos_eclss/include/ssos_eclss/wrs/water_recovery_system.hpp
@@ -1,0 +1,63 @@
+#ifndef SSOS_ECLSS__WRS__WATER_RECOVERY_SYSTEM_HPP_
+#define SSOS_ECLSS__WRS__WATER_RECOVERY_SYSTEM_HPP_
+
+#include <memory>
+
+#include "ssos_eclss/wrs/catalytic_reactor_model.hpp"
+#include "ssos_eclss/wrs/distillation_model.hpp"
+#include "ssos_eclss/wrs/multifiltration_model.hpp"
+#include "ssos_eclss/wrs/wrs_parameters.hpp"
+
+// Top-level Water Recovery System. Inputs urine and humidity condensate; the
+// urine is distilled (UPA) and combined with condensate, then polished by the
+// catalytic reactor + multifiltration (WPA) into potable water. Tracks product
+// water conductivity as the quality metric. No ROS.
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+/// WRS outputs after a step.
+struct WrsResult
+{
+  double potable_water_kg_s;        // potable water produced [kg/s]
+  double brine_kg_s;                // urine brine reject [kg/s]
+  double product_conductivity_us;   // product water conductivity [uS/cm]
+  double overall_recovery;          // recovered / input water [-]
+  double power_w;                   // total electrical power [W]
+  double voc_conversion;            // catalytic VOC conversion [-]
+  bool potable_in_spec;             // conductivity below the potable limit
+  bool multifiltration_broken_through;
+};
+
+/// Water Recovery System orchestrator.
+class WaterRecoverySystem
+{
+public:
+  explicit WaterRecoverySystem(const WrsParameters & params = default_wrs_parameters());
+
+  void reset();
+
+  /// Advance the WRS by dt.
+  /// @param dt            timestep [s]
+  /// @param urine_kg_s    urine feed [kg/s]
+  /// @param condensate_kg_s humidity condensate feed [kg/s]
+  /// @param voc_kg_s      trace volatile organics in feed [kg/s]
+  WrsResult step(double dt, double urine_kg_s, double condensate_kg_s,
+                 double voc_kg_s);
+
+  void set_parameters(const WrsParameters & params);
+  const WrsParameters & parameters() const { return params_; }
+
+private:
+  WrsParameters params_;
+  std::unique_ptr<DistillationModel> distillation_;
+  std::unique_ptr<MultifiltrationModel> multifiltration_;
+  std::unique_ptr<CatalyticReactorModel> catalytic_;
+};
+
+}  // namespace wrs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__WRS__WATER_RECOVERY_SYSTEM_HPP_

--- a/ssos_eclss/include/ssos_eclss/wrs/wrs_parameters.hpp
+++ b/ssos_eclss/include/ssos_eclss/wrs/wrs_parameters.hpp
@@ -1,0 +1,53 @@
+#ifndef SSOS_ECLSS__WRS__WRS_PARAMETERS_HPP_
+#define SSOS_ECLSS__WRS__WRS_PARAMETERS_HPP_
+
+// Parameters for the Water Recovery System (urine processor + water processor).
+// SI units. Factory functions provide ISS WRS-class defaults.
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+/// Vapor Compression Distillation (Urine Processor Assembly) parameters.
+struct DistillationParams
+{
+  double recovery_fraction;     // water recovered from urine [-]
+  double specific_energy_j_kg;  // electrical energy per kg distillate [J/kg]
+  double max_throughput_kg_s;   // maximum processing rate [kg/s]
+  double brine_solids_fraction; // dissolved solids that stay in brine [-]
+};
+
+/// Multifiltration (Water Processor Assembly) parameters.
+struct MultifiltrationParams
+{
+  double bed_capacity_kg;       // contaminant capacity before breakthrough [kg]
+  double removal_efficiency;    // fraction of contaminant removed [-]
+  double inlet_conductivity_us; // typical feed conductivity [uS/cm]
+};
+
+/// Catalytic reactor (volatile removal) parameters.
+struct CatalyticReactorParams
+{
+  double operating_temp_k;      // reactor temperature [K]
+  double activation_temp_k;     // characteristic temperature for conversion [K]
+  double max_conversion;        // asymptotic conversion [-]
+};
+
+/// Complete WRS parameter set.
+struct WrsParameters
+{
+  DistillationParams distillation;
+  MultifiltrationParams multifiltration;
+  CatalyticReactorParams catalytic;
+};
+
+DistillationParams default_distillation_params();
+MultifiltrationParams default_multifiltration_params();
+CatalyticReactorParams default_catalytic_params();
+WrsParameters default_wrs_parameters();
+
+}  // namespace wrs
+}  // namespace ssos_eclss
+
+#endif  // SSOS_ECLSS__WRS__WRS_PARAMETERS_HPP_

--- a/ssos_eclss/launch/ars_only.launch.py
+++ b/ssos_eclss/launch/ars_only.launch.py
@@ -1,0 +1,38 @@
+"""Launch just the ARS lifecycle node, auto-configured and activated."""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import EmitEvent, RegisterEventHandler, LogInfo
+from launch.event_handlers import OnProcessStart
+from launch_ros.event_handlers import OnStateTransition
+from launch_ros.actions import LifecycleNode
+from launch_ros.events.lifecycle import ChangeState
+import lifecycle_msgs.msg
+
+
+def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('ssos_eclss'), 'config', 'ars_parameters.yaml')
+
+    ars = LifecycleNode(
+        package='ssos_eclss', executable='ars_node', name='ars_node',
+        namespace='', output='screen', parameters=[config])
+
+    configure = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda node: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE))
+
+    activate = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda node: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE))
+
+    return LaunchDescription([
+        ars,
+        RegisterEventHandler(OnProcessStart(
+            target_action=ars,
+            on_start=[LogInfo(msg='ars_node started; configuring...'), configure])),
+        RegisterEventHandler(OnStateTransition(
+            target_lifecycle_node=ars, goal_state='inactive',
+            entities=[LogInfo(msg='ars_node configured; activating...'), activate])),
+    ])

--- a/ssos_eclss/launch/eclss.launch.py
+++ b/ssos_eclss/launch/eclss.launch.py
@@ -1,0 +1,52 @@
+"""Launch the full ECLSS suite (ARS, OGS, WRS, cabin) as lifecycle nodes,
+each auto-configured and activated from its config file."""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import EmitEvent, RegisterEventHandler, LogInfo
+from launch.event_handlers import OnProcessStart
+from launch_ros.event_handlers import OnStateTransition
+from launch_ros.actions import LifecycleNode
+from launch_ros.events.lifecycle import ChangeState
+import lifecycle_msgs.msg
+
+
+def _lifecycle(pkg_share, executable, name, config_file):
+    config = os.path.join(pkg_share, 'config', config_file)
+    return LifecycleNode(
+        package='ssos_eclss', executable=executable, name=name,
+        namespace='', output='screen', parameters=[config])
+
+
+def _auto_manage(node, label):
+    configure = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda n: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE))
+    activate = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda n: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE))
+    return [
+        RegisterEventHandler(OnProcessStart(
+            target_action=node,
+            on_start=[LogInfo(msg=f'{label} started; configuring...'), configure])),
+        RegisterEventHandler(OnStateTransition(
+            target_lifecycle_node=node, goal_state='inactive',
+            entities=[LogInfo(msg=f'{label} configured; activating...'), activate])),
+    ]
+
+
+def generate_launch_description():
+    share = get_package_share_directory('ssos_eclss')
+
+    ars = _lifecycle(share, 'ars_node', 'ars_node', 'ars_parameters.yaml')
+    ogs = _lifecycle(share, 'ogs_node', 'ogs_node', 'ogs_parameters.yaml')
+    wrs = _lifecycle(share, 'wrs_node', 'wrs_node', 'wrs_parameters.yaml')
+    cabin = _lifecycle(share, 'cabin_node', 'cabin_node', 'cabin_parameters.yaml')
+
+    ld = LaunchDescription([ars, ogs, wrs, cabin])
+    for node, label in [(ars, 'ars_node'), (ogs, 'ogs_node'),
+                        (wrs, 'wrs_node'), (cabin, 'cabin_node')]:
+        for handler in _auto_manage(node, label):
+            ld.add_action(handler)
+    return ld

--- a/ssos_eclss/launch/eclss_with_faults.launch.py
+++ b/ssos_eclss/launch/eclss_with_faults.launch.py
@@ -1,0 +1,33 @@
+"""Launch the full ECLSS suite plus the fault-definitions config exposed as a
+launch argument, so the simulation controller can schedule faults against the
+ECLSS subsystems via /sim/inject_fault.
+
+This reuses eclss.launch.py for the subsystem nodes and additionally publishes
+the path to fault_definitions.yaml as a parameter for tooling/inspection."""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    share = get_package_share_directory('ssos_eclss')
+    faults_file = os.path.join(share, 'config', 'fault_definitions.yaml')
+
+    fault_arg = DeclareLaunchArgument(
+        'fault_definitions', default_value=faults_file,
+        description='Path to the ECLSS fault-definitions YAML')
+
+    eclss = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(share, 'launch', 'eclss.launch.py')))
+
+    return LaunchDescription([
+        fault_arg,
+        LogInfo(msg=['ECLSS with faults; definitions: ',
+                     LaunchConfiguration('fault_definitions')]),
+        eclss,
+    ])

--- a/ssos_eclss/launch/ogs_only.launch.py
+++ b/ssos_eclss/launch/ogs_only.launch.py
@@ -1,0 +1,37 @@
+"""Launch just the OGS lifecycle node, auto-configured and activated."""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import EmitEvent, RegisterEventHandler, LogInfo
+from launch.event_handlers import OnProcessStart
+from launch_ros.event_handlers import OnStateTransition
+from launch_ros.actions import LifecycleNode
+from launch_ros.events.lifecycle import ChangeState
+import lifecycle_msgs.msg
+
+
+def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('ssos_eclss'), 'config', 'ogs_parameters.yaml')
+
+    ogs = LifecycleNode(
+        package='ssos_eclss', executable='ogs_node', name='ogs_node',
+        namespace='', output='screen', parameters=[config])
+
+    configure = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda node: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE))
+    activate = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda node: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE))
+
+    return LaunchDescription([
+        ogs,
+        RegisterEventHandler(OnProcessStart(
+            target_action=ogs,
+            on_start=[LogInfo(msg='ogs_node started; configuring...'), configure])),
+        RegisterEventHandler(OnStateTransition(
+            target_lifecycle_node=ogs, goal_state='inactive',
+            entities=[LogInfo(msg='ogs_node configured; activating...'), activate])),
+    ])

--- a/ssos_eclss/launch/wrs_only.launch.py
+++ b/ssos_eclss/launch/wrs_only.launch.py
@@ -1,0 +1,37 @@
+"""Launch just the WRS lifecycle node, auto-configured and activated."""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import EmitEvent, RegisterEventHandler, LogInfo
+from launch.event_handlers import OnProcessStart
+from launch_ros.event_handlers import OnStateTransition
+from launch_ros.actions import LifecycleNode
+from launch_ros.events.lifecycle import ChangeState
+import lifecycle_msgs.msg
+
+
+def generate_launch_description():
+    config = os.path.join(
+        get_package_share_directory('ssos_eclss'), 'config', 'wrs_parameters.yaml')
+
+    wrs = LifecycleNode(
+        package='ssos_eclss', executable='wrs_node', name='wrs_node',
+        namespace='', output='screen', parameters=[config])
+
+    configure = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda node: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE))
+    activate = EmitEvent(event=ChangeState(
+        lifecycle_node_matcher=lambda node: True,
+        transition_id=lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE))
+
+    return LaunchDescription([
+        wrs,
+        RegisterEventHandler(OnProcessStart(
+            target_action=wrs,
+            on_start=[LogInfo(msg='wrs_node started; configuring...'), configure])),
+        RegisterEventHandler(OnStateTransition(
+            target_lifecycle_node=wrs, goal_state='inactive',
+            entities=[LogInfo(msg='wrs_node configured; activating...'), activate])),
+    ])

--- a/ssos_eclss/package.xml
+++ b/ssos_eclss/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ssos_eclss</name>
+  <version>0.9.0</version>
+  <description>High-fidelity ECLSS physics simulation for Space Station OS</description>
+  <maintainer email="spacestationos@spacedata.co.jp">Space Station OS</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>space_station_interfaces</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>lifecycle_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ssos_eclss/src/ars/adsorption_isotherm.cpp
+++ b/ssos_eclss/src/ars/adsorption_isotherm.cpp
@@ -1,0 +1,260 @@
+#include "ssos_eclss/ars/adsorption_isotherm.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+// ===================== TothIsotherm =====================
+
+TothIsotherm::TothIsotherm(const TothParams & params) : params_(params) {}
+
+double TothIsotherm::q_max(double temperature_k) const
+{
+  return params_.q_m0 * std::exp(params_.chi * (1.0 - temperature_k / params_.T_ref));
+}
+
+double TothIsotherm::affinity(double temperature_k) const
+{
+  return params_.b0 *
+         std::exp(params_.dH / (units::R_GAS * params_.T_ref) *
+                  (params_.T_ref / temperature_k - 1.0));
+}
+
+double TothIsotherm::exponent(double temperature_k) const
+{
+  const double t = params_.t0 + params_.alpha * (1.0 - params_.T_ref / temperature_k);
+  return std::clamp(t, 1.0e-3, 1.0);
+}
+
+double TothIsotherm::loading(double partial_pressure_pa, double temperature_k) const
+{
+  if (partial_pressure_pa <= 0.0) {
+    return 0.0;
+  }
+  const double qm = q_max(temperature_k);
+  const double b = affinity(temperature_k);
+  const double t = exponent(temperature_k);
+  const double bp = b * partial_pressure_pa;
+  const double denom = std::pow(1.0 + std::pow(bp, t), 1.0 / t);
+  return qm * bp / denom;
+}
+
+double TothIsotherm::dloading_dp(double partial_pressure_pa, double temperature_k) const
+{
+  if (partial_pressure_pa <= 0.0) {
+    // Henry-law limit dq/dP -> qm * b.
+    return q_max(temperature_k) * affinity(temperature_k);
+  }
+  const double qm = q_max(temperature_k);
+  const double b = affinity(temperature_k);
+  const double t = exponent(temperature_k);
+  const double bp = b * partial_pressure_pa;
+  const double bpt = std::pow(bp, t);
+  const double base = 1.0 + bpt;
+  // q = qm*b*P / base^(1/t);  dq/dP = qm*b / base^(1/t) * [1 - bpt/base]
+  const double factor = std::pow(base, 1.0 / t);
+  return qm * b / factor * (1.0 - bpt / base);
+}
+
+double TothIsotherm::dloading_dt(double partial_pressure_pa, double temperature_k) const
+{
+  const double h = 0.05;  // K
+  const double q_plus = loading(partial_pressure_pa, temperature_k + h);
+  const double q_minus = loading(partial_pressure_pa, temperature_k - h);
+  return (q_plus - q_minus) / (2.0 * h);
+}
+
+// ===================== Competitive loading =====================
+
+CompetitiveLoading competitive_loading(const TothIsotherm & co2,
+                                       const TothIsotherm & h2o,
+                                       double pp_co2_pa, double pp_h2o_pa,
+                                       double temperature_k)
+{
+  CompetitiveLoading out{0.0, 0.0};
+
+  // Single-component loadings as the uncoupled reference.
+  const double q_co2_single = co2.loading(pp_co2_pa, temperature_k);
+  const double q_h2o_single = h2o.loading(pp_h2o_pa, temperature_k);
+
+  // Extended-Toth style coupling: each adsorbate's loading is scaled by a
+  // competition factor built from the pseudo-Langmuir fractional occupancies.
+  // Water dominates the shared sites, strongly suppressing CO2 capacity.
+  const double b_co2 = co2.affinity(temperature_k);
+  const double b_h2o = h2o.affinity(temperature_k);
+  const double theta_co2 = b_co2 * std::max(pp_co2_pa, 0.0);
+  const double theta_h2o = b_h2o * std::max(pp_h2o_pa, 0.0);
+  const double sum = 1.0 + theta_co2 + theta_h2o;
+
+  // CO2 sees suppression proportional to water occupancy.
+  out.q_co2 = q_co2_single * (1.0 + theta_co2) / sum;
+  // Water is the stronger adsorbate and is only weakly affected by CO2.
+  out.q_h2o = q_h2o_single * (1.0 + theta_h2o) / (1.0 + theta_h2o + 0.05 * theta_co2);
+
+  return out;
+}
+
+// ===================== Parameter factories =====================
+// Defaults tuned to the 4BCO2 EDU (ICES-2021-313) and the Grace 544 / RK38
+// material data in Knox & Cmarik (2019). Heats of adsorption and saturation
+// loadings follow published zeolite 13X and silica-gel values.
+
+TothParams default_co2_on_13x()
+{
+  TothParams p;
+  p.q_m0 = 4.30;       // mol/kg
+  p.chi = 2.20;        // -
+  p.b0 = 9.0e-5;       // 1/Pa
+  p.dH = 38000.0;      // J/mol
+  p.t0 = 0.42;         // -
+  p.alpha = 0.18;      // -
+  p.T_ref = 298.15;    // K
+  return p;
+}
+
+TothParams default_h2o_on_13x()
+{
+  TothParams p;
+  p.q_m0 = 17.0;       // mol/kg
+  p.chi = 1.10;
+  p.b0 = 1.2e-3;       // 1/Pa (very strong affinity)
+  p.dH = 52000.0;      // J/mol
+  p.t0 = 0.50;
+  p.alpha = 0.10;
+  p.T_ref = 298.15;
+  return p;
+}
+
+TothParams default_h2o_on_silica()
+{
+  TothParams p;
+  p.q_m0 = 11.0;       // mol/kg
+  p.chi = 0.90;
+  p.b0 = 2.5e-4;       // 1/Pa
+  p.dH = 45000.0;      // J/mol
+  p.t0 = 0.60;
+  p.alpha = 0.08;
+  p.T_ref = 298.15;
+  return p;
+}
+
+LDFParams default_desiccant_ldf()
+{
+  return LDFParams{8.0e-3, 2.0e-3};  // CO2 (unused), H2O [1/s]
+}
+
+LDFParams default_adsorbent_ldf()
+{
+  return LDFParams{1.5e-2, 3.0e-3};  // CO2, H2O [1/s]
+}
+
+BedGeometry default_desiccant_geometry()
+{
+  BedGeometry g;
+  g.length = 0.165;            // m
+  g.diameter = 0.1778;         // m (7 in)
+  g.voidage = 0.36;            // -
+  g.particle_diameter = 2.0e-3;  // m
+  g.sorbent_density = 1200.0;  // kg/m^3
+  g.n_cells = 50;
+  return g;
+}
+
+BedGeometry default_adsorbent_geometry()
+{
+  BedGeometry g;
+  g.length = 0.2667;           // m
+  g.diameter = 0.1778;         // m (7 in)
+  g.voidage = 0.36;            // -
+  g.particle_diameter = 2.0e-3;  // m
+  g.sorbent_density = 1100.0;  // kg/m^3
+  g.n_cells = 50;
+  return g;
+}
+
+BedThermal default_desiccant_thermal()
+{
+  BedThermal t;
+  t.sorbent_cp = 920.0;
+  t.wall_htc = 5.0;
+  t.wall_area_per_vol = 4.0 / 0.1778;  // ~ 4/diameter for a cylinder
+  t.wall_temp = 295.0;
+  t.axial_thermal_cond = 0.5;
+  t.gas_thermal_cond = 0.026;
+  return t;
+}
+
+BedThermal default_adsorbent_thermal()
+{
+  BedThermal t = default_desiccant_thermal();
+  t.sorbent_cp = 920.0;
+  return t;
+}
+
+HeaterParams default_heater()
+{
+  HeaterParams h;
+  h.total_power_w = 700.0;            // all 19 elements
+  h.central_power_w = 700.0 * 7.0 / 19.0;  // central 7 elements during air-save
+  h.max_temp_k = units::fahrenheit_to_kelvin(400.0);  // ~477.6 K
+  return h;
+}
+
+CycleTiming default_cycle_timing()
+{
+  CycleTiming c;
+  c.air_save_s = 10.0 * units::SECONDS_PER_MINUTE;  // 600 s
+  c.adsorb_s = 60.0 * units::SECONDS_PER_MINUTE;    // 3600 s
+  c.vacuum_s = 10.0 * units::SECONDS_PER_MINUTE;    // 600 s
+  return c;
+}
+
+OperatingConditions default_operating_conditions()
+{
+  OperatingConditions o;
+  o.inlet_flow_scfm = 26.0;
+  o.inlet_ppco2_torr = 2.0;
+  o.inlet_dewpoint_k = units::celsius_to_kelvin(4.0);
+  o.cabin_temp_k = units::celsius_to_kelvin(22.0);
+  o.cabin_pressure_pa = units::torr_to_pa(760.0);
+  o.ltl_inlet_temp_k = units::celsius_to_kelvin(7.0);
+  o.ltl_flow_gpm = 0.42;
+  o.vacuum_pressure_pa = units::torr_to_pa(2.0);
+  return o;
+}
+
+SystemEfficiency default_system_efficiency()
+{
+  SystemEfficiency e;
+  e.capture_efficiency = 0.84;  // net/gross (paper 0.82-0.84)
+  e.holdup_loss = 0.10;         // 8-12% cabin air lost to vacuum
+  return e;
+}
+
+ArsParameters default_ars_parameters()
+{
+  ArsParameters p;
+  p.desiccant_bed = default_desiccant_geometry();
+  p.adsorbent_bed = default_adsorbent_geometry();
+  p.desiccant_thermal = default_desiccant_thermal();
+  p.adsorbent_thermal = default_adsorbent_thermal();
+  p.co2_on_13x = default_co2_on_13x();
+  p.h2o_on_13x = default_h2o_on_13x();
+  p.h2o_on_silica = default_h2o_on_silica();
+  p.desiccant_ldf = default_desiccant_ldf();
+  p.adsorbent_ldf = default_adsorbent_ldf();
+  p.heater = default_heater();
+  p.cycle = default_cycle_timing();
+  p.operating = default_operating_conditions();
+  p.efficiency = default_system_efficiency();
+  return p;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/adsorption_isotherm.cpp
+++ b/ssos_eclss/src/ars/adsorption_isotherm.cpp
@@ -110,7 +110,9 @@ TothParams default_co2_on_13x()
   TothParams p;
   p.q_m0 = 4.30;       // mol/kg
   p.chi = 2.20;        // -
-  p.b0 = 9.0e-5;       // 1/Pa
+  // Affinity calibrated so equilibrium loading at ISS ppCO2 (~2-3 torr, 22 C)
+  // is ~2 mol/kg, giving the ~140 min breakthrough onset reported in the paper.
+  p.b0 = 1.4e-3;       // 1/Pa
   p.dH = 38000.0;      // J/mol
   p.t0 = 0.42;         // -
   p.alpha = 0.18;      // -

--- a/ssos_eclss/src/ars/air_save_pump_model.cpp
+++ b/ssos_eclss/src/ars/air_save_pump_model.cpp
@@ -1,0 +1,41 @@
+#include "ssos_eclss/ars/air_save_pump_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+AirSavePumpModel::AirSavePumpModel(const AirSavePumpParams & params) : params_(params)
+{}
+
+AirSaveResult AirSavePumpModel::pump(double dt, double bed_pressure_pa,
+                                     double temperature_k) const
+{
+  AirSaveResult r{};
+
+  // Volumetric pump on a fixed volume: P decays exponentially toward the
+  // ultimate pressure with time constant tau = V / S.
+  const double tau = params_.void_volume_m3 / std::max(params_.displacement_m3s, 1.0e-9);
+  const double p0 = bed_pressure_pa;
+  const double p_ult = params_.ultimate_pressure_pa;
+  const double p_new = p_ult + (p0 - p_ult) * std::exp(-dt / tau);
+
+  // Moles removed from the void = V/(RT) * (P0 - P_new). These are recovered to
+  // the cabin (air-save), only the residual below ultimate pressure is lost.
+  const double dn = params_.void_volume_m3 / (units::R_GAS * temperature_k) *
+                    std::max(p0 - p_new, 0.0);
+  const double n_initial = params_.void_volume_m3 / (units::R_GAS * temperature_k) * p0;
+
+  r.bed_pressure_pa = p_new;
+  r.air_recovered_mol = dn;
+  r.recovery_fraction = (n_initial > 0.0) ? dn / n_initial : 0.0;
+  return r;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/bed_model.cpp
+++ b/ssos_eclss/src/ars/bed_model.cpp
@@ -18,7 +18,6 @@ namespace
 {
 constexpr double kGasCp = 1010.0;        // process-gas cp [J/(kg*K)] (~air)
 constexpr double kAxialDispersion = 1.0e-4;  // mass axial dispersion [m^2/s]
-constexpr double kPumpRate = 0.20;       // vacuum pumping relaxation rate [1/s]
 constexpr double kHeaterMaxTempK = 533.0;  // heater cutoff (~500 F) [K]
 constexpr std::size_t kMaxSubsteps = 4000;
 }  // namespace
@@ -166,10 +165,6 @@ void BedModel::integrate_substep(double h, const BedInlet & inlet, BedMode mode,
                    rho_bulk_ * dqco2;
     double dch2o = upwind(c_h2o_old, inlet.c_h2o) + diffuse(c_h2o_old) -
                    rho_bulk_ * dqh2o;
-    if (pumping) {
-      dcco2 += -kPumpRate * (c_co2_old[i] - c_vac) * eps;
-      dch2o += -kPumpRate * (c_h2o_old[i] - c_vac) * eps;
-    }
 
     // ---- Solid energy balance (explicit; large heat capacity) ----
     const double heat_ads = rho_bulk_ *
@@ -203,8 +198,15 @@ void BedModel::integrate_substep(double h, const BedInlet & inlet, BedMode mode,
     const double tg_new = rhs / denom;
 
     // ---- Commit ----
-    c_co2_[i] = std::max(0.0, c_co2_old[i] + h * dcco2 / eps);
-    c_h2o_[i] = std::max(0.0, c_h2o_old[i] + h * dch2o / eps);
+    if (pumping) {
+      // The vacuum holds the void gas at the vacuum partial pressure; desorbed
+      // gas is swept out by the pump rather than accumulating and re-adsorbing.
+      c_co2_[i] = c_vac;
+      c_h2o_[i] = c_vac;
+    } else {
+      c_co2_[i] = std::max(0.0, c_co2_old[i] + h * dcco2 / eps);
+      c_h2o_[i] = std::max(0.0, c_h2o_old[i] + h * dch2o / eps);
+    }
     q_co2_[i] = std::max(0.0, q_co2_[i] + h * dqco2);
     q_h2o_[i] = std::max(0.0, q_h2o_[i] + h * dqh2o);
     ts_[i] = ts_new;

--- a/ssos_eclss/src/ars/bed_model.cpp
+++ b/ssos_eclss/src/ars/bed_model.cpp
@@ -1,0 +1,252 @@
+#include "ssos_eclss/ars/bed_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ssos_eclss/common/fluid_dynamics.hpp"
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/heat_transfer.hpp"
+#include "ssos_eclss/common/numerical/cfl_control.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+namespace
+{
+constexpr double kGasCp = 1010.0;        // process-gas cp [J/(kg*K)] (~air)
+constexpr double kAxialDispersion = 1.0e-4;  // mass axial dispersion [m^2/s]
+constexpr double kPumpRate = 0.20;       // vacuum pumping relaxation rate [1/s]
+constexpr double kHeaterMaxTempK = 533.0;  // heater cutoff (~500 F) [K]
+constexpr std::size_t kMaxSubsteps = 4000;
+}  // namespace
+
+BedModel::BedModel(const BedGeometry & geom, const BedThermal & thermal,
+                   const TothIsotherm & co2, const TothIsotherm & h2o,
+                   const LDFParams & ldf, bool is_desiccant)
+: geom_(geom), thermal_(thermal), co2_iso_(co2), h2o_iso_(h2o), ldf_(ldf),
+  is_desiccant_(is_desiccant)
+{
+  n_ = std::max<std::size_t>(geom_.n_cells, 1);
+  dz_ = geom_.length / static_cast<double>(n_);
+  rho_bulk_ = (1.0 - geom_.voidage) * geom_.sorbent_density;
+  reset(295.0);
+}
+
+void BedModel::reset(double temperature_k)
+{
+  c_co2_.assign(n_, 0.0);
+  c_h2o_.assign(n_, 0.0);
+  q_co2_.assign(n_, 0.0);
+  q_h2o_.assign(n_, 0.0);
+  tg_.assign(n_, temperature_k);
+  ts_.assign(n_, temperature_k);
+}
+
+void BedModel::equilibrate(double pp_co2_pa, double pp_h2o_pa, double temperature_k)
+{
+  for (std::size_t i = 0; i < n_; ++i) {
+    tg_[i] = temperature_k;
+    ts_[i] = temperature_k;
+    c_co2_[i] = gas::concentration_from_pp(pp_co2_pa, temperature_k);
+    c_h2o_[i] = gas::concentration_from_pp(pp_h2o_pa, temperature_k);
+    const auto eq = competitive_loading(co2_iso_, h2o_iso_, pp_co2_pa, pp_h2o_pa,
+                                        temperature_k);
+    q_co2_[i] = is_desiccant_ ? 0.0 : eq.q_co2;
+    q_h2o_[i] = eq.q_h2o;
+  }
+}
+
+double BedModel::total_co2_loading_mol() const
+{
+  const double mass_per_cell = rho_bulk_ * geom_.cross_area() * dz_;
+  double total = 0.0;
+  for (double q : q_co2_) {
+    total += q * mass_per_cell;
+  }
+  return total;
+}
+
+double BedModel::total_h2o_loading_mol() const
+{
+  const double mass_per_cell = rho_bulk_ * geom_.cross_area() * dz_;
+  double total = 0.0;
+  for (double q : q_h2o_) {
+    total += q * mass_per_cell;
+  }
+  return total;
+}
+
+double BedModel::mean_solid_temperature() const
+{
+  double s = 0.0;
+  for (double t : ts_) {
+    s += t;
+  }
+  return s / static_cast<double>(n_);
+}
+
+double BedModel::max_solid_temperature() const
+{
+  return *std::max_element(ts_.begin(), ts_.end());
+}
+
+double BedModel::bed_pressure_drop(const BedInlet & inlet) const
+{
+  const double rho = gas::gas_density(inlet.pressure_pa, inlet.temperature_k,
+                                      units::M_AIR);
+  const double mu = gas::sutherland_viscosity(inlet.temperature_k);
+  return fluid::ergun_pressure_drop(std::abs(inlet.velocity_superficial),
+                                    geom_.voidage, geom_.particle_diameter, rho, mu,
+                                    geom_.length);
+}
+
+void BedModel::integrate_substep(double h, const BedInlet & inlet, BedMode mode,
+                                 double heater_power_w)
+{
+  const double eps = geom_.voidage;
+  const double v = inlet.velocity_superficial;  // superficial [m/s]
+  const bool flowing = (mode == BedMode::ADSORBING || mode == BedMode::AIR_SAVE ||
+                        mode == BedMode::REPRESSURIZING);
+  const bool pumping = (mode == BedMode::DESORBING || mode == BedMode::VACUUM);
+
+  // Gas / transport coefficients (evaluated once per substep at inlet state).
+  const double rho_g = gas::gas_density(inlet.pressure_pa, inlet.temperature_k,
+                                        units::M_AIR);
+  const double mu = gas::sutherland_viscosity(inlet.temperature_k);
+  const double re = fluid::reynolds_number(rho_g, v, geom_.particle_diameter, mu);
+  const double pr = heat::prandtl_number(kGasCp, mu, thermal_.gas_thermal_cond);
+  const double nu = heat::nusselt_wakao_kaguei(re, pr);
+  const double h_gs = heat::gas_solid_htc(nu, thermal_.gas_thermal_cond,
+                                          geom_.particle_diameter);
+  const double a_v = heat::specific_surface_area(eps, geom_.particle_diameter);
+  const double exch = h_gs * a_v;  // volumetric gas-solid exchange [W/(m^3*K)]
+  const double u_wall = thermal_.wall_htc * thermal_.wall_area_per_vol;
+  const double cap_g = std::max(eps * rho_g * kGasCp, 1.0e-9);
+  const double cap_s = std::max((1.0 - eps) * geom_.sorbent_density *
+                                thermal_.sorbent_cp, 1.0e-9);
+
+  const double c_vac = pumping
+      ? gas::concentration_from_pp(2.0 * units::TORR_TO_PA,
+                                   std::max(ts_.front(), 200.0))
+      : 0.0;
+
+  // Snapshots of the old fields (advection/conduction use old neighbour values).
+  const std::vector<double> c_co2_old = c_co2_;
+  const std::vector<double> c_h2o_old = c_h2o_;
+  const std::vector<double> tg_old = tg_;
+  const std::vector<double> ts_old = ts_;
+
+  for (std::size_t i = 0; i < n_; ++i) {
+    // ---- Equilibrium loading + LDF sorption rate ----
+    const double pp_co2 = gas::partial_pressure(std::max(c_co2_old[i], 0.0), ts_old[i]);
+    const double pp_h2o = gas::partial_pressure(std::max(c_h2o_old[i], 0.0), ts_old[i]);
+    const auto eq = competitive_loading(co2_iso_, h2o_iso_, pp_co2, pp_h2o, ts_old[i]);
+    const double q_co2_star = is_desiccant_ ? 0.0 : eq.q_co2;
+    const double q_h2o_star = eq.q_h2o;
+    const double dqco2 = is_desiccant_ ? 0.0 : ldf_.k_co2 * (q_co2_star - q_co2_[i]);
+    const double dqh2o = ldf_.k_h2o * (q_h2o_star - q_h2o_[i]);
+
+    // ---- Gas-phase mass balance (explicit) ----
+    auto upwind = [&](const std::vector<double> & c, double c_in) {
+      if (!flowing || v <= 0.0) {
+        return 0.0;
+      }
+      const double up = (i == 0) ? c_in : c[i - 1];
+      return -v * (c[i] - up) / dz_;
+    };
+    auto diffuse = [&](const std::vector<double> & c) {
+      const double left = (i == 0) ? c[i] : c[i - 1];
+      const double right = (i + 1 < n_) ? c[i + 1] : c[i];
+      return eps * kAxialDispersion * (left - 2.0 * c[i] + right) / (dz_ * dz_);
+    };
+    double dcco2 = upwind(c_co2_old, inlet.c_co2) + diffuse(c_co2_old) -
+                   rho_bulk_ * dqco2;
+    double dch2o = upwind(c_h2o_old, inlet.c_h2o) + diffuse(c_h2o_old) -
+                   rho_bulk_ * dqh2o;
+    if (pumping) {
+      dcco2 += -kPumpRate * (c_co2_old[i] - c_vac) * eps;
+      dch2o += -kPumpRate * (c_h2o_old[i] - c_vac) * eps;
+    }
+
+    // ---- Solid energy balance (explicit; large heat capacity) ----
+    const double heat_ads = rho_bulk_ *
+        (co2_iso_.heat_of_adsorption() * dqco2 + h2o_iso_.heat_of_adsorption() * dqh2o);
+    double q_heater_vol = 0.0;
+    if ((mode == BedMode::DESORBING || mode == BedMode::AIR_SAVE) &&
+        heater_power_w > 0.0 && ts_old[i] < kHeaterMaxTempK) {
+      q_heater_vol = heater_power_w / geom_.volume();
+    }
+    const double dts = (exch * (tg_old[i] - ts_old[i]) + heat_ads + q_heater_vol) /
+                       cap_s;
+
+    // ---- Gas energy balance (semi-implicit in Tg for stiff exchange) ----
+    // Explicit advection + axial conduction:
+    double adv_t = 0.0;
+    if (flowing && v > 0.0) {
+      const double tg_up = (i == 0) ? inlet.temperature_k : tg_old[i - 1];
+      adv_t = -rho_g * kGasCp * v * (tg_old[i] - tg_up) / dz_;
+    }
+    const double tg_left = (i == 0) ? tg_old[i] : tg_old[i - 1];
+    const double tg_right = (i + 1 < n_) ? tg_old[i + 1] : tg_old[i];
+    const double cond_t = thermal_.axial_thermal_cond *
+                          (tg_left - 2.0 * tg_old[i] + tg_right) / (dz_ * dz_);
+    // Implicit treatment of exch*(Ts-Tg) and wall*(Tg-Twall):
+    //   cap_g (Tg_new - Tg)/h = adv + cond + exch (Ts_new - Tg_new)
+    //                           - u_wall (Tg_new - Twall)
+    const double ts_new = ts_old[i] + h * dts;
+    const double rhs = cap_g / h * tg_old[i] + adv_t + cond_t +
+                       exch * ts_new + u_wall * thermal_.wall_temp;
+    const double denom = cap_g / h + exch + u_wall;
+    const double tg_new = rhs / denom;
+
+    // ---- Commit ----
+    c_co2_[i] = std::max(0.0, c_co2_old[i] + h * dcco2 / eps);
+    c_h2o_[i] = std::max(0.0, c_h2o_old[i] + h * dch2o / eps);
+    q_co2_[i] = std::max(0.0, q_co2_[i] + h * dqco2);
+    q_h2o_[i] = std::max(0.0, q_h2o_[i] + h * dqh2o);
+    ts_[i] = ts_new;
+    tg_[i] = tg_new;
+  }
+}
+
+BedOutputs BedModel::step(double dt, const BedInlet & inlet, BedMode mode,
+                          double heater_power_w)
+{
+  // Choose a stable substep count from the advection CFL and diffusion limits.
+  // The stiff gas-solid energy exchange is handled implicitly, so it does not
+  // constrain the substep size.
+  const double v_transport = std::abs(inlet.velocity_superficial) / geom_.voidage;
+  std::size_t n_sub = numerical::stable_substeps(dt, v_transport, dz_,
+                                                 kAxialDispersion, 0.4, 0.4);
+  n_sub = std::min(n_sub, kMaxSubsteps);
+  const double h = dt / static_cast<double>(n_sub);
+
+  for (std::size_t s = 0; s < n_sub; ++s) {
+    integrate_substep(h, inlet, mode, heater_power_w);
+  }
+  return snapshot(inlet);
+}
+
+BedOutputs BedModel::snapshot(const BedInlet & inlet) const
+{
+  BedOutputs out{};
+  out.outlet_c_co2 = c_co2_.back();
+  out.outlet_c_h2o = c_h2o_.back();
+  out.outlet_temperature = tg_.back();
+  out.max_solid_temp = max_solid_temperature();
+  out.mean_solid_temp = mean_solid_temperature();
+  out.co2_loading_mol = total_co2_loading_mol();
+  out.h2o_loading_mol = total_h2o_loading_mol();
+  out.pressure_drop_pa = bed_pressure_drop(inlet);
+  // Instantaneous CO2 captured = inlet flux - outlet flux over the cross-section.
+  const double area = geom_.cross_area();
+  const double v = inlet.velocity_superficial;
+  out.co2_capture_rate = std::max(0.0, v * area * (inlet.c_co2 - c_co2_.back()));
+  return out;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/blower_model.cpp
+++ b/ssos_eclss/src/ars/blower_model.cpp
@@ -1,0 +1,53 @@
+#include "ssos_eclss/ars/blower_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+BlowerModel::BlowerModel(const BlowerParams & params) : params_(params) {}
+
+double BlowerModel::fan_head(double rpm, double flow_m3s) const
+{
+  const double speed_ratio = rpm / params_.rated_rpm;
+  const double head = params_.shutoff_dp * speed_ratio * speed_ratio -
+                      params_.curve_quad * flow_m3s * flow_m3s;
+  return std::max(head, 0.0);
+}
+
+BlowerResult BlowerModel::solve(double system_resistance, BlowerControl control,
+                                double setpoint) const
+{
+  BlowerResult r{};
+
+  if (control == BlowerControl::CONSTANT_FLOW) {
+    r.flow_m3s = std::max(setpoint, 0.0);
+    r.delta_p = system_resistance * r.flow_m3s * r.flow_m3s;
+    // Invert fan curve for the rpm that delivers this flow at this head.
+    const double needed = (r.delta_p + params_.curve_quad * r.flow_m3s * r.flow_m3s) /
+                          params_.shutoff_dp;
+    r.rpm = params_.rated_rpm * std::sqrt(std::max(needed, 0.0));
+    r.rpm = std::min(r.rpm, params_.max_rpm);
+  } else {
+    // CONSTANT_RPM: intersect fan curve with system curve.
+    // shutoff*s^2 - a2*Q^2 = R*Q^2  ->  Q^2 = shutoff*s^2 / (a2 + R)
+    const double rpm = std::min(setpoint, params_.max_rpm);
+    const double s = rpm / params_.rated_rpm;
+    const double q2 = params_.shutoff_dp * s * s /
+                      (params_.curve_quad + system_resistance);
+    r.flow_m3s = std::sqrt(std::max(q2, 0.0));
+    r.delta_p = system_resistance * q2;
+    r.rpm = rpm;
+  }
+
+  // Shaft power estimate: P = dP * Q / efficiency (assume 0.55 blower efficiency).
+  const double eff = 0.55;
+  r.power_w = r.delta_p * r.flow_m3s / eff;
+  return r;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/cycle_state_machine.cpp
+++ b/ssos_eclss/src/ars/cycle_state_machine.cpp
@@ -1,0 +1,84 @@
+#include "ssos_eclss/ars/cycle_state_machine.hpp"
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+CycleStateMachine::CycleStateMachine(const CycleTiming & timing,
+                                     const HeaterParams & heater)
+: timing_(timing), heater_(heater)
+{
+  reset();
+}
+
+void CycleStateMachine::reset()
+{
+  t_half_ = 0.0;
+  adsorbing_train_ = 0;
+  half_cycle_count_ = 0;
+}
+
+void CycleStateMachine::update(double dt)
+{
+  t_half_ += dt;
+  const double half = timing_.half_cycle_s();
+  while (t_half_ >= half) {
+    t_half_ -= half;
+    adsorbing_train_ = 1 - adsorbing_train_;
+    ++half_cycle_count_;
+  }
+}
+
+RegenPhase CycleStateMachine::regen_phase() const
+{
+  if (t_half_ < timing_.air_save_s) {
+    return RegenPhase::AIR_SAVE;
+  }
+  if (t_half_ < timing_.air_save_s + timing_.adsorb_s) {
+    return RegenPhase::DESORB;
+  }
+  return RegenPhase::VACUUM;
+}
+
+TrainCommand CycleStateMachine::command_for_train(int train) const
+{
+  TrainCommand cmd{};
+  if (train == adsorbing_train_) {
+    // Adsorbing train: process flow through both beds, no heat.
+    cmd.desiccant_mode = BedMode::ADSORBING;
+    cmd.adsorbent_mode = BedMode::ADSORBING;
+    cmd.desiccant_heater_w = 0.0;
+    cmd.adsorbent_heater_w = 0.0;
+    return cmd;
+  }
+
+  // Regenerating train: phase-dependent.
+  switch (regen_phase()) {
+    case RegenPhase::AIR_SAVE:
+      cmd.desiccant_mode = BedMode::AIR_SAVE;
+      cmd.adsorbent_mode = BedMode::AIR_SAVE;
+      // Central 7 of 19 elements energised during air-save.
+      cmd.adsorbent_heater_w = heater_.central_power_w;
+      cmd.desiccant_heater_w = 0.0;
+      break;
+    case RegenPhase::DESORB:
+      cmd.desiccant_mode = BedMode::DESORBING;
+      cmd.adsorbent_mode = BedMode::DESORBING;
+      // All 19 elements during desorption.
+      cmd.adsorbent_heater_w = heater_.total_power_w;
+      // Desiccant beds are regenerated largely by the warm purge; modest heat.
+      cmd.desiccant_heater_w = 0.0;
+      break;
+    case RegenPhase::VACUUM:
+      cmd.desiccant_mode = BedMode::VACUUM;
+      cmd.adsorbent_mode = BedMode::VACUUM;
+      cmd.adsorbent_heater_w = 0.0;
+      cmd.desiccant_heater_w = 0.0;
+      break;
+  }
+  return cmd;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/four_bed_system.cpp
+++ b/ssos_eclss/src/ars/four_bed_system.cpp
@@ -1,0 +1,243 @@
+#include "ssos_eclss/ars/four_bed_system.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ssos_eclss/common/fluid_dynamics.hpp"
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/thermodynamics.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+FourBedSystem::FourBedSystem(const ArsParameters & params)
+: params_(params),
+  co2_iso_(params.co2_on_13x),
+  h2o_iso_(params.h2o_on_13x),
+  h2o_silica_iso_(params.h2o_on_silica)
+{
+  reconstruct();
+}
+
+void FourBedSystem::reconstruct()
+{
+  co2_iso_ = TothIsotherm(params_.co2_on_13x);
+  h2o_iso_ = TothIsotherm(params_.h2o_on_13x);
+  h2o_silica_iso_ = TothIsotherm(params_.h2o_on_silica);
+
+  // A zero-capacity CO2 isotherm for desiccant beds (water only).
+  TothParams no_co2 = params_.co2_on_13x;
+  no_co2.q_m0 = 0.0;
+  TothIsotherm desiccant_co2(no_co2);
+
+  for (int i = 0; i < 2; ++i) {
+    desiccant_[i] = std::make_unique<BedModel>(
+      params_.desiccant_bed, params_.desiccant_thermal, desiccant_co2,
+      h2o_silica_iso_, params_.desiccant_ldf, /*is_desiccant=*/true);
+    adsorbent_[i] = std::make_unique<BedModel>(
+      params_.adsorbent_bed, params_.adsorbent_thermal, co2_iso_, h2o_iso_,
+      params_.adsorbent_ldf, /*is_desiccant=*/false);
+  }
+
+  // Precooler sized to the design air/coolant flows.
+  PrecoolerParams pc{};
+  const double rho_air = gas::gas_density(params_.operating.cabin_pressure_pa,
+                                          params_.operating.cabin_temp_k, units::M_AIR);
+  const double q_air = units::scfm_to_m3s(params_.operating.inlet_flow_scfm);
+  pc.air_mass_flow = rho_air * q_air;
+  pc.coolant_mass_flow = 1000.0 * units::gpm_to_m3s(params_.operating.ltl_flow_gpm);
+  pc.air_cp = thermo::cp_mass(thermo::Species::AIR, params_.operating.cabin_temp_k);
+  pc.coolant_cp = thermo::cp_liquid_water(params_.operating.ltl_inlet_temp_k);
+  // Size UA for a high-effectiveness exchanger (exit within a few K of coolant).
+  pc.ua = 3.0 * std::min(pc.air_mass_flow * pc.air_cp,
+                         pc.coolant_mass_flow * pc.coolant_cp);
+  precooler_ = std::make_unique<PrecoolerModel>(pc);
+
+  // Blower curve targeting ~26 SCFM at ~37-40 in-H2O.
+  BlowerParams bp{};
+  bp.rated_rpm = 12000.0;
+  bp.shutoff_dp = 2.0 * units::in_h2o_to_pa(40.0);
+  bp.max_rpm = 18000.0;
+  // Choose curve so design flow yields design head.
+  bp.curve_quad = units::in_h2o_to_pa(40.0) / (q_air * q_air);
+  blower_ = std::make_unique<BlowerModel>(bp);
+
+  // Air-save scroll pump.
+  AirSavePumpParams asp{};
+  asp.void_volume_m3 = params_.adsorbent_bed.volume() * params_.adsorbent_bed.voidage;
+  asp.displacement_m3s = asp.void_volume_m3 / 120.0;  // empties void in ~2 min
+  asp.ultimate_pressure_pa = units::torr_to_pa(20.0);
+  air_save_pump_ = std::make_unique<AirSavePumpModel>(asp);
+
+  // Selector / repressurisation valve (0->800 torr in ~15 s).
+  ValveParams vp{};
+  vp.cv = 1.0e-4;
+  vp.stroke_time_s = 2.0;
+  vp.repress_time_s = 15.0 / 3.0;  // ~3 time constants to fill
+  valve_ = std::make_unique<ValveModel>(vp);
+
+  cycle_ = std::make_unique<CycleStateMachine>(params_.cycle, params_.heater);
+
+  // System resistance from Ergun across the desiccant + adsorbent beds at the
+  // design velocity: dP = R * Q^2.
+  const double area = params_.adsorbent_bed.cross_area();
+  const double v = fluid::superficial_velocity(q_air, area);
+  const double mu = gas::sutherland_viscosity(params_.operating.cabin_temp_k);
+  const double dp = fluid::ergun_pressure_drop(v, params_.adsorbent_bed.voidage,
+                                               params_.adsorbent_bed.particle_diameter,
+                                               rho_air, mu,
+                                               params_.adsorbent_bed.length +
+                                               params_.desiccant_bed.length);
+  system_resistance_ = (q_air > 0.0) ? dp / (q_air * q_air) : 0.0;
+
+  reset(params_.operating.cabin_temp_k);
+}
+
+void FourBedSystem::reset(double temperature_k)
+{
+  for (int i = 0; i < 2; ++i) {
+    desiccant_[i]->reset(temperature_k);
+    adsorbent_[i]->reset(temperature_k);
+  }
+  if (cycle_) {
+    cycle_->reset();
+  }
+}
+
+void FourBedSystem::set_parameters(const ArsParameters & params)
+{
+  params_ = params;
+  // Tunable (non-geometry) updates that don't require a rebuild.
+  if (cycle_) {
+    cycle_->set_timing(params_.cycle);
+    cycle_->set_heater(params_.heater);
+  }
+}
+
+double FourBedSystem::inlet_co2_mass_rate(const CabinConditions & cabin,
+                                          double flow_m3s) const
+{
+  // Molar flow of CO2 = (ppCO2/Ptot) * (Ptot*Q)/(R*T) = ppCO2 * Q / (R*T).
+  const double n_co2 = cabin.co2_partial_pressure_pa * flow_m3s /
+                       (units::R_GAS * cabin.temperature_k);
+  return n_co2 * units::M_CO2;  // kg/s
+}
+
+double FourBedSystem::design_co2_removal_kg_day() const
+{
+  CabinConditions cabin{};
+  cabin.co2_partial_pressure_pa = units::torr_to_pa(params_.operating.inlet_ppco2_torr);
+  cabin.temperature_k = params_.operating.cabin_temp_k;
+  cabin.total_pressure_pa = params_.operating.cabin_pressure_pa;
+  const double q_air = units::scfm_to_m3s(params_.operating.inlet_flow_scfm);
+  const double gross = inlet_co2_mass_rate(cabin, q_air);
+  return gross * params_.efficiency.capture_efficiency * units::SECONDS_PER_DAY;
+}
+
+ArsResult FourBedSystem::step(double dt, const CabinConditions & cabin)
+{
+  ArsResult res{};
+
+  // ---- Blower / flow ----
+  const BlowerResult blower = blower_->solve(
+    system_resistance_, BlowerControl::CONSTANT_FLOW,
+    units::scfm_to_m3s(params_.operating.inlet_flow_scfm));
+  const double q_air = blower.flow_m3s;
+  const double area = params_.adsorbent_bed.cross_area();
+  const double v_super = fluid::superficial_velocity(q_air, area);
+
+  // ---- Precooler ----
+  const PrecoolerResult pc = precooler_->solve(cabin.temperature_k,
+                                               params_.operating.ltl_inlet_temp_k);
+
+  // ---- Cycle commands ----
+  const int ads_train = cycle_->adsorbing_train();
+  const int regen_train = cycle_->regenerating_train();
+  const TrainCommand ads_cmd = cycle_->command_for_train(ads_train);
+  const TrainCommand regen_cmd = cycle_->command_for_train(regen_train);
+
+  // ---- Adsorbing train: cabin -> desiccant -> adsorbent ----
+  BedInlet des_in{};
+  des_in.velocity_superficial = v_super;
+  des_in.c_co2 = gas::concentration_from_pp(cabin.co2_partial_pressure_pa, pc.air_outlet_temp);
+  des_in.c_h2o = gas::concentration_from_pp(cabin.h2o_partial_pressure_pa, pc.air_outlet_temp);
+  des_in.temperature_k = pc.air_outlet_temp;
+  des_in.pressure_pa = cabin.total_pressure_pa;
+
+  BedOutputs des_out = desiccant_[ads_train]->step(dt, des_in, ads_cmd.desiccant_mode,
+                                                   ads_cmd.desiccant_heater_w);
+
+  BedInlet ads_in{};
+  ads_in.velocity_superficial = v_super;
+  ads_in.c_co2 = des_out.outlet_c_co2;
+  ads_in.c_h2o = des_out.outlet_c_h2o;
+  ads_in.temperature_k = des_out.outlet_temperature;
+  ads_in.pressure_pa = cabin.total_pressure_pa;
+
+  BedOutputs ads_out = adsorbent_[ads_train]->step(dt, ads_in, ads_cmd.adsorbent_mode,
+                                                   ads_cmd.adsorbent_heater_w);
+
+  // ---- Regenerating train: desorb under vacuum with heat ----
+  BedInlet regen_in{};
+  regen_in.velocity_superficial = 0.0;
+  regen_in.c_co2 = 0.0;
+  regen_in.c_h2o = 0.0;
+  regen_in.temperature_k = params_.operating.cabin_temp_k;
+  regen_in.pressure_pa = params_.operating.vacuum_pressure_pa;
+
+  const double regen_co2_before = adsorbent_[regen_train]->total_co2_loading_mol();
+  adsorbent_[regen_train]->step(dt, regen_in, regen_cmd.adsorbent_mode,
+                                regen_cmd.adsorbent_heater_w);
+  desiccant_[regen_train]->step(dt, regen_in, regen_cmd.desiccant_mode,
+                                regen_cmd.desiccant_heater_w);
+  const double regen_co2_after = adsorbent_[regen_train]->total_co2_loading_mol();
+  const double desorbed_mol = std::max(0.0, regen_co2_before - regen_co2_after);
+
+  // ---- Air-save pump (during AIR_SAVE phase only) ----
+  double air_saved_rate = 0.0;
+  if (cycle_->regen_phase() == RegenPhase::AIR_SAVE) {
+    const AirSaveResult as = air_save_pump_->pump(dt, cabin.total_pressure_pa,
+                                                  params_.operating.cabin_temp_k);
+    air_saved_rate = as.air_recovered_mol * units::M_AIR / dt;
+  }
+
+  // ---- Valve actuation toward the active configuration ----
+  valve_->command(1.0);
+  valve_->update(dt);
+
+  // ---- Net CO2 removal: gross bed capture limited by inlet, scaled by the
+  //      system net-capture efficiency (air-save + holdup losses). ----
+  const double gross_capture_kg_s = ads_out.co2_capture_rate * units::M_CO2;
+  const double inlet_co2_kg_s = inlet_co2_mass_rate(cabin, q_air);
+  const double bounded = std::clamp(gross_capture_kg_s, 0.0, inlet_co2_kg_s);
+  res.co2_removal_rate_kg_s = bounded * params_.efficiency.capture_efficiency;
+  res.co2_removal_rate_kg_day = res.co2_removal_rate_kg_s * units::SECONDS_PER_DAY;
+
+  // ---- Advance cycle ----
+  cycle_->update(dt);
+
+  // ---- Fill out result ----
+  res.scrubbed_co2_pp_pa = gas::partial_pressure(ads_out.outlet_c_co2,
+                                                 ads_out.outlet_temperature);
+  res.scrubbed_h2o_pp_pa = gas::partial_pressure(ads_out.outlet_c_h2o,
+                                                 ads_out.outlet_temperature);
+  res.return_air_temp_k = ads_out.outlet_temperature;
+  res.system_pressure_drop_pa = des_out.pressure_drop_pa + ads_out.pressure_drop_pa;
+  res.blower_flow_scfm = units::m3s_to_scfm(q_air);
+  res.blower_power_w = blower.power_w;
+  res.precooler_exit_temp_k = pc.air_outlet_temp;
+  res.max_bed_temp_k = std::max({desiccant_[0]->max_solid_temperature(),
+                                 desiccant_[1]->max_solid_temperature(),
+                                 adsorbent_[0]->max_solid_temperature(),
+                                 adsorbent_[1]->max_solid_temperature()});
+  res.co2_desorbed_rate_kg_s = desorbed_mol * units::M_CO2 / dt;
+  res.air_saved_rate_kg_s = air_saved_rate;
+  res.adsorbing_train = ads_train;
+  return res;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/four_bed_system.cpp
+++ b/ssos_eclss/src/ars/four_bed_system.cpp
@@ -109,8 +109,14 @@ void FourBedSystem::reset(double temperature_k)
 
 void FourBedSystem::set_parameters(const ArsParameters & params)
 {
+  // Preserve geometry/isotherm fields that require a rebuild; apply the rest.
+  const BedGeometry des_geom = params_.desiccant_bed;
+  const BedGeometry ads_geom = params_.adsorbent_bed;
   params_ = params;
-  // Tunable (non-geometry) updates that don't require a rebuild.
+  params_.desiccant_bed = des_geom;
+  params_.adsorbent_bed = ads_geom;
+  // Tunable (non-geometry) updates that don't require a rebuild: cycle, heater,
+  // operating set-points and the net-capture efficiency are used directly.
   if (cycle_) {
     cycle_->set_timing(params_.cycle);
     cycle_->set_heater(params_.heater);

--- a/ssos_eclss/src/ars/precooler_model.cpp
+++ b/ssos_eclss/src/ars/precooler_model.cpp
@@ -1,0 +1,46 @@
+#include "ssos_eclss/ars/precooler_model.hpp"
+
+#include <algorithm>
+
+#include "ssos_eclss/common/heat_transfer.hpp"
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+PrecoolerModel::PrecoolerModel(const PrecoolerParams & params) : params_(params) {}
+
+PrecoolerResult PrecoolerModel::solve(double air_inlet_temp,
+                                      double coolant_inlet_temp) const
+{
+  PrecoolerResult r{};
+  const double c_air = params_.air_mass_flow * params_.air_cp;
+  const double c_cool = params_.coolant_mass_flow * params_.coolant_cp;
+  const double c_min = std::min(c_air, c_cool);
+  const double c_max = std::max(c_air, c_cool);
+
+  if (c_min <= 0.0) {
+    r.air_outlet_temp = air_inlet_temp;
+    r.coolant_outlet_temp = coolant_inlet_temp;
+    r.heat_duty = 0.0;
+    r.effectiveness = 0.0;
+    return r;
+  }
+
+  const double cr = c_min / c_max;
+  const double ntu = heat::ntu(params_.ua, c_min);
+  const double eps = heat::effectiveness_counterflow(ntu, cr);
+
+  // Air is the hot stream (gets cooled).
+  const double q = heat::hx_heat_duty(eps, c_min, air_inlet_temp, coolant_inlet_temp);
+
+  r.effectiveness = eps;
+  r.heat_duty = q;
+  r.air_outlet_temp = air_inlet_temp - q / c_air;
+  r.coolant_outlet_temp = coolant_inlet_temp + q / c_cool;
+  return r;
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ars/valve_model.cpp
+++ b/ssos_eclss/src/ars/valve_model.cpp
@@ -1,0 +1,47 @@
+#include "ssos_eclss/ars/valve_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ssos_eclss
+{
+namespace ars
+{
+
+ValveModel::ValveModel(const ValveParams & params) : params_(params) {}
+
+void ValveModel::update(double dt)
+{
+  if (params_.stroke_time_s <= 0.0) {
+    position_ = target_;
+    return;
+  }
+  const double max_step = dt / params_.stroke_time_s;  // fraction per dt
+  const double err = target_ - position_;
+  if (std::abs(err) <= max_step) {
+    position_ = target_;
+  } else {
+    position_ += std::copysign(max_step, err);
+  }
+  position_ = clamp01(position_);
+}
+
+double ValveModel::flow(double delta_p_pa) const
+{
+  const double sign = (delta_p_pa >= 0.0) ? 1.0 : -1.0;
+  return position_ * params_.cv * sign * std::sqrt(std::abs(delta_p_pa));
+}
+
+double ValveModel::repressurize(double dt, double current_pressure,
+                                double target_pressure) const
+{
+  if (params_.repress_time_s <= 0.0) {
+    return target_pressure;
+  }
+  // First-order approach: matches the ~15 s 0->800 torr fill of the EDU.
+  const double alpha = 1.0 - std::exp(-dt / params_.repress_time_s);
+  return current_pressure + alpha * (target_pressure - current_pressure);
+}
+
+}  // namespace ars
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/cabin/cabin_atmosphere.cpp
+++ b/ssos_eclss/src/cabin/cabin_atmosphere.cpp
@@ -1,0 +1,123 @@
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+
+#include <algorithm>
+
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace cabin
+{
+
+CabinAtmosphere::CabinAtmosphere(const CabinParams & params) : params_(params)
+{
+  initialize_nominal();
+}
+
+void CabinAtmosphere::initialize_nominal(double co2_ppm, double relative_humidity)
+{
+  const double t = params_.temperature_k;
+  const double v = params_.volume_m3;
+  const double total_p = units::STD_PRESSURE_PA;
+
+  // Water vapour from RH.
+  const double pp_h2o = gas::water_pp_from_rh(relative_humidity, t);
+  // CO2 from ppm of total pressure.
+  const double pp_co2 = units::ppm_to_fraction(co2_ppm) * total_p;
+  // O2 at ~21% of the dry-gas pressure.
+  const double dry_p = total_p - pp_h2o - pp_co2;
+  const double pp_o2 = 0.21 * dry_p;
+  const double pp_n2 = dry_p - pp_o2;
+
+  auto moles_for = [&](double pp) { return pp * v / (units::R_GAS * t); };
+  n_o2_ = moles_for(pp_o2);
+  n_co2_ = moles_for(pp_co2);
+  n_n2_ = moles_for(pp_n2);
+  n_h2o_ = moles_for(pp_h2o);
+}
+
+double & CabinAtmosphere::ref(Gas species)
+{
+  switch (species) {
+    case Gas::O2: return n_o2_;
+    case Gas::CO2: return n_co2_;
+    case Gas::N2: return n_n2_;
+    case Gas::H2O: return n_h2o_;
+  }
+  return n_n2_;
+}
+
+double CabinAtmosphere::get(Gas species) const
+{
+  switch (species) {
+    case Gas::O2: return n_o2_;
+    case Gas::CO2: return n_co2_;
+    case Gas::N2: return n_n2_;
+    case Gas::H2O: return n_h2o_;
+  }
+  return 0.0;
+}
+
+void CabinAtmosphere::apply_flows(double dt, const GasFlows & flows)
+{
+  n_o2_ = std::max(0.0, n_o2_ + flows.o2 * dt);
+  n_co2_ = std::max(0.0, n_co2_ + flows.co2 * dt);
+  n_n2_ = std::max(0.0, n_n2_ + flows.n2 * dt);
+  n_h2o_ = std::max(0.0, n_h2o_ + flows.h2o * dt);
+}
+
+void CabinAtmosphere::add_moles(Gas species, double moles)
+{
+  double & r = ref(species);
+  r = std::max(0.0, r + moles);
+}
+
+double CabinAtmosphere::total_moles() const
+{
+  return n_o2_ + n_co2_ + n_n2_ + n_h2o_;
+}
+
+double CabinAtmosphere::moles(Gas species) const { return get(species); }
+
+double CabinAtmosphere::total_pressure_pa() const
+{
+  return total_moles() * units::R_GAS * params_.temperature_k / params_.volume_m3;
+}
+
+double CabinAtmosphere::partial_pressure_pa(Gas species) const
+{
+  return get(species) * units::R_GAS * params_.temperature_k / params_.volume_m3;
+}
+
+double CabinAtmosphere::mole_fraction(Gas species) const
+{
+  const double tot = total_moles();
+  return (tot > 0.0) ? get(species) / tot : 0.0;
+}
+
+double CabinAtmosphere::co2_ppm() const
+{
+  return units::fraction_to_ppm(mole_fraction(Gas::CO2));
+}
+
+double CabinAtmosphere::o2_fraction() const { return mole_fraction(Gas::O2); }
+
+double CabinAtmosphere::relative_humidity() const
+{
+  return gas::relative_humidity(partial_pressure_pa(Gas::H2O), params_.temperature_k);
+}
+
+double CabinAtmosphere::dew_point_k() const
+{
+  return gas::dew_point_from_pp(partial_pressure_pa(Gas::H2O));
+}
+
+double CabinAtmosphere::total_gas_mass_kg() const
+{
+  return n_o2_ * units::M_O2 + n_co2_ * units::M_CO2 + n_n2_ * units::M_N2 +
+         n_h2o_ * units::M_H2O;
+}
+
+}  // namespace cabin
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/cabin/crew_metabolic_model.cpp
+++ b/ssos_eclss/src/cabin/crew_metabolic_model.cpp
@@ -1,0 +1,45 @@
+#include "ssos_eclss/cabin/crew_metabolic_model.hpp"
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace cabin
+{
+
+CrewMetabolicModel::CrewMetabolicModel(int crew_size, const CrewProfile & profile)
+: crew_size_(crew_size), profile_(profile)
+{}
+
+MetabolicLoads CrewMetabolicModel::loads(double activity_factor) const
+{
+  MetabolicLoads out{};
+  const double n = static_cast<double>(crew_size_) * activity_factor;
+
+  // Convert per-day mass rates to per-second molar rates.
+  const double co2_kg_s = units::kg_per_day_to_kg_per_s(profile_.co2_kg_day) * n;
+  const double o2_kg_s = units::kg_per_day_to_kg_per_s(profile_.o2_kg_day) * n;
+  const double h2o_kg_s = units::kg_per_day_to_kg_per_s(profile_.water_kg_day) * n;
+
+  out.flows.co2 = co2_kg_s / units::M_CO2;     // produced (+)
+  out.flows.o2 = -o2_kg_s / units::M_O2;       // consumed (-)
+  out.flows.h2o = h2o_kg_s / units::M_H2O;     // produced (+)
+  out.flows.n2 = 0.0;
+
+  out.heat_w = profile_.heat_w * n;
+  out.water_kg_s = h2o_kg_s;
+  return out;
+}
+
+CrewProfile default_crew_profile()
+{
+  CrewProfile p;
+  p.co2_kg_day = 1.04;    // kg/day CO2
+  p.o2_kg_day = 0.84;     // kg/day O2
+  p.water_kg_day = 2.28;  // kg/day respiration + perspiration vapour
+  p.heat_w = 117.0;       // W average metabolic heat
+  return p;
+}
+
+}  // namespace cabin
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/cabin/leak_model.cpp
+++ b/ssos_eclss/src/cabin/leak_model.cpp
@@ -1,0 +1,62 @@
+#include "ssos_eclss/cabin/leak_model.hpp"
+
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace cabin
+{
+
+LeakModel::LeakModel(const LeakParams & params) : params_(params) {}
+
+double LeakModel::mass_leak_rate(const CabinAtmosphere & atm) const
+{
+  const double p0 = atm.total_pressure_pa();
+  const double t0 = atm.temperature_k();
+  if (p0 <= 0.0 || t0 <= 0.0) {
+    return 0.0;
+  }
+  // Mixture molar mass from composition.
+  const double m_mix =
+      atm.mole_fraction(Gas::O2) * units::M_O2 +
+      atm.mole_fraction(Gas::CO2) * units::M_CO2 +
+      atm.mole_fraction(Gas::N2) * units::M_N2 +
+      atm.mole_fraction(Gas::H2O) * units::M_H2O;
+  const double r_specific = units::R_GAS / std::max(m_mix, 1.0e-6);
+
+  // Choked (sonic) orifice flow to vacuum, gamma ~ 1.4:
+  //   m_dot = Cd * A * sqrt(gamma * rho0 * P0) * (2/(gamma+1))^((gamma+1)/(2(gamma-1)))
+  const double gamma = 1.4;
+  const double rho0 = p0 / (r_specific * t0);
+  const double choke =
+      std::pow(2.0 / (gamma + 1.0), (gamma + 1.0) / (2.0 * (gamma - 1.0)));
+  return params_.discharge_coeff * effective_area() * std::sqrt(gamma * rho0 * p0) *
+         choke;
+}
+
+GasFlows LeakModel::leak_flows(const CabinAtmosphere & atm) const
+{
+  const double m_dot = mass_leak_rate(atm);  // kg/s
+  GasFlows f{};
+  if (m_dot <= 0.0) {
+    return f;
+  }
+  // Distribute by mole fraction: outflow is well-mixed gas.
+  const double m_mix =
+      atm.mole_fraction(Gas::O2) * units::M_O2 +
+      atm.mole_fraction(Gas::CO2) * units::M_CO2 +
+      atm.mole_fraction(Gas::N2) * units::M_N2 +
+      atm.mole_fraction(Gas::H2O) * units::M_H2O;
+  const double n_dot_total = m_dot / std::max(m_mix, 1.0e-6);  // mol/s
+
+  f.o2 = -atm.mole_fraction(Gas::O2) * n_dot_total;
+  f.co2 = -atm.mole_fraction(Gas::CO2) * n_dot_total;
+  f.n2 = -atm.mole_fraction(Gas::N2) * n_dot_total;
+  f.h2o = -atm.mole_fraction(Gas::H2O) * n_dot_total;
+  return f;
+}
+
+}  // namespace cabin
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/common/fluid_dynamics.cpp
+++ b/ssos_eclss/src/common/fluid_dynamics.cpp
@@ -1,0 +1,74 @@
+#include "ssos_eclss/common/fluid_dynamics.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ssos_eclss
+{
+namespace fluid
+{
+
+double reynolds_number(double density, double velocity, double particle_d,
+                       double viscosity)
+{
+  if (viscosity <= 0.0) {
+    return 0.0;
+  }
+  return density * std::abs(velocity) * particle_d / viscosity;
+}
+
+double ergun_pressure_gradient(double velocity, double voidage, double particle_d,
+                               double density, double viscosity)
+{
+  const double e = std::clamp(voidage, 1.0e-3, 0.999);
+  const double e3 = e * e * e;
+  const double one_minus_e = 1.0 - e;
+  const double dp = particle_d;
+  const double dp2 = dp * dp;
+
+  // Viscous (Blake-Kozeny) term, linear in velocity.
+  const double viscous = 150.0 * one_minus_e * one_minus_e / e3 *
+                         viscosity * velocity / dp2;
+  // Inertial (Burke-Plummer) term, quadratic; preserve sign of velocity.
+  const double inertial = 1.75 * one_minus_e / e3 *
+                          density * std::abs(velocity) * velocity / dp;
+  return viscous + inertial;
+}
+
+double ergun_pressure_drop(double velocity, double voidage, double particle_d,
+                           double density, double viscosity, double bed_length)
+{
+  return ergun_pressure_gradient(velocity, voidage, particle_d, density, viscosity) *
+         bed_length;
+}
+
+double darcy_friction_factor(double reynolds, double relative_rough)
+{
+  if (reynolds <= 0.0) {
+    return 0.0;
+  }
+  if (reynolds < 2300.0) {
+    return 64.0 / reynolds;
+  }
+  // Haaland explicit approximation to Colebrook.
+  const double term = std::pow(relative_rough / 3.7, 1.11) + 6.9 / reynolds;
+  const double inv_sqrt_f = -1.8 * std::log10(term);
+  return 1.0 / (inv_sqrt_f * inv_sqrt_f);
+}
+
+double superficial_velocity(double volumetric_flow_m3s, double cross_area_m2)
+{
+  if (cross_area_m2 <= 0.0) {
+    return 0.0;
+  }
+  return volumetric_flow_m3s / cross_area_m2;
+}
+
+double interstitial_velocity(double superficial_v, double voidage)
+{
+  const double e = std::clamp(voidage, 1.0e-3, 0.999);
+  return superficial_v / e;
+}
+
+}  // namespace fluid
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/common/gas_properties.cpp
+++ b/ssos_eclss/src/common/gas_properties.cpp
@@ -1,0 +1,118 @@
+#include "ssos_eclss/common/gas_properties.hpp"
+
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace gas
+{
+
+double gas_density(double pressure_pa, double temperature_k, double molar_mass)
+{
+  return pressure_pa * molar_mass / (units::R_GAS * temperature_k);
+}
+
+double concentration_from_pp(double partial_pressure_pa, double temperature_k)
+{
+  return partial_pressure_pa / (units::R_GAS * temperature_k);
+}
+
+double partial_pressure(double concentration_mol_m3, double temperature_k)
+{
+  return concentration_mol_m3 * units::R_GAS * temperature_k;
+}
+
+double water_saturation_pressure(double temperature_k)
+{
+  // Magnus/Tetens: Psat[Pa] = 610.94 * exp(17.625 * Tc / (Tc + 243.04))
+  const double tc = units::kelvin_to_celsius(temperature_k);
+  return 610.94 * std::exp(17.625 * tc / (tc + 243.04));
+}
+
+double dew_point_from_pp(double water_pp_pa)
+{
+  // Invert Magnus. Guard against non-positive pressure.
+  if (water_pp_pa <= 0.0) {
+    return 0.0;  // 0 K sentinel; caller treats as "bone dry"
+  }
+  const double ln_ratio = std::log(water_pp_pa / 610.94);
+  const double tc = 243.04 * ln_ratio / (17.625 - ln_ratio);
+  return units::celsius_to_kelvin(tc);
+}
+
+double relative_humidity(double water_pp_pa, double temperature_k)
+{
+  const double psat = water_saturation_pressure(temperature_k);
+  if (psat <= 0.0) {
+    return 0.0;
+  }
+  return water_pp_pa / psat;
+}
+
+double water_pp_from_rh(double relative_humidity, double temperature_k)
+{
+  return relative_humidity * water_saturation_pressure(temperature_k);
+}
+
+double humidity_ratio(double water_pp_pa, double total_pressure_pa)
+{
+  const double dry_pp = total_pressure_pa - water_pp_pa;
+  if (dry_pp <= 0.0) {
+    return 0.0;
+  }
+  // w = (M_w / M_air) * Pw / (Ptot - Pw)
+  return (units::M_H2O / units::M_AIR) * water_pp_pa / dry_pp;
+}
+
+double sutherland_viscosity(double temperature_k, double mu_ref, double t_ref,
+                            double sutherland_c)
+{
+  const double ratio = temperature_k / t_ref;
+  return mu_ref * std::pow(ratio, 1.5) * (t_ref + sutherland_c) /
+         (temperature_k + sutherland_c);
+}
+
+double mixture_viscosity(const std::vector<MixtureComponent> & components)
+{
+  // Wilke's semi-empirical mixing rule.
+  const std::size_t n = components.size();
+  if (n == 0) {
+    return 0.0;
+  }
+  double mu_mix = 0.0;
+  for (std::size_t i = 0; i < n; ++i) {
+    double denom = 0.0;
+    for (std::size_t j = 0; j < n; ++j) {
+      const double mu_ratio = components[i].viscosity / components[j].viscosity;
+      const double m_ratio = components[j].molar_mass / components[i].molar_mass;
+      const double num = 1.0 + std::sqrt(mu_ratio) * std::pow(m_ratio, 0.25);
+      const double phi = num * num /
+                         std::sqrt(8.0 * (1.0 + components[i].molar_mass /
+                                          components[j].molar_mass));
+      denom += components[j].mole_fraction * phi;
+    }
+    if (denom > 0.0) {
+      mu_mix += components[i].mole_fraction * components[i].viscosity / denom;
+    }
+  }
+  return mu_mix;
+}
+
+double mixture_molar_mass(const std::vector<MixtureComponent> & components)
+{
+  double m = 0.0;
+  double total_fraction = 0.0;
+  for (const auto & c : components) {
+    m += c.mole_fraction * c.molar_mass;
+    total_fraction += c.mole_fraction;
+  }
+  if (total_fraction > 0.0) {
+    m /= total_fraction;  // normalise in case fractions don't sum to 1
+  }
+  return m;
+}
+
+}  // namespace gas
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/common/heat_transfer.cpp
+++ b/ssos_eclss/src/common/heat_transfer.cpp
@@ -1,0 +1,89 @@
+#include "ssos_eclss/common/heat_transfer.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ssos_eclss
+{
+namespace heat
+{
+
+double prandtl_number(double cp, double viscosity, double thermal_cond)
+{
+  if (thermal_cond <= 0.0) {
+    return 0.0;
+  }
+  return cp * viscosity / thermal_cond;
+}
+
+double nusselt_wakao_kaguei(double reynolds, double prandtl)
+{
+  return 2.0 + 1.1 * std::pow(std::max(reynolds, 0.0), 0.6) *
+                  std::cbrt(std::max(prandtl, 0.0));
+}
+
+double gas_solid_htc(double nusselt, double thermal_cond, double particle_d)
+{
+  if (particle_d <= 0.0) {
+    return 0.0;
+  }
+  return nusselt * thermal_cond / particle_d;
+}
+
+double specific_surface_area(double voidage, double particle_d)
+{
+  const double e = std::clamp(voidage, 0.0, 0.999);
+  if (particle_d <= 0.0) {
+    return 0.0;
+  }
+  return 6.0 * (1.0 - e) / particle_d;
+}
+
+double ntu(double ua, double c_min)
+{
+  if (c_min <= 0.0) {
+    return 0.0;
+  }
+  return ua / c_min;
+}
+
+double effectiveness_counterflow(double ntu_val, double cr)
+{
+  cr = std::clamp(cr, 0.0, 1.0);
+  if (ntu_val <= 0.0) {
+    return 0.0;
+  }
+  if (cr < 1.0e-6) {
+    // Cr -> 0 (e.g. condensing/evaporating stream).
+    return 1.0 - std::exp(-ntu_val);
+  }
+  if (std::abs(cr - 1.0) < 1.0e-6) {
+    return ntu_val / (1.0 + ntu_val);
+  }
+  const double e = std::exp(-ntu_val * (1.0 - cr));
+  return (1.0 - e) / (1.0 - cr * e);
+}
+
+double effectiveness_crossflow(double ntu_val, double cr)
+{
+  cr = std::clamp(cr, 0.0, 1.0);
+  if (ntu_val <= 0.0) {
+    return 0.0;
+  }
+  if (cr < 1.0e-6) {
+    return 1.0 - std::exp(-ntu_val);
+  }
+  // Both fluids unmixed (approximate closed form).
+  const double term = std::pow(ntu_val, 0.22) / cr *
+                      (std::exp(-cr * std::pow(ntu_val, 0.78)) - 1.0);
+  return 1.0 - std::exp(term);
+}
+
+double hx_heat_duty(double effectiveness, double c_min, double t_hot_in,
+                    double t_cold_in)
+{
+  return effectiveness * c_min * (t_hot_in - t_cold_in);
+}
+
+}  // namespace heat
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/common/thermodynamics.cpp
+++ b/ssos_eclss/src/common/thermodynamics.cpp
@@ -1,0 +1,103 @@
+#include "ssos_eclss/common/thermodynamics.hpp"
+
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace thermo
+{
+
+namespace
+{
+// Quadratic mass-specific cp fits cp(T) = a + b*T + c*T^2 [J/(kg*K)].
+// Coefficients fitted to NIST/NASA data over ~250..600 K for ECLSS use.
+struct CpFit
+{
+  double a;
+  double b;
+  double c;
+  double molar_mass;
+};
+
+CpFit fit_for(Species s)
+{
+  switch (s) {
+    case Species::AIR:       return {950.0, 0.16, 0.0, units::M_AIR};
+    case Species::CO2:       return {600.0, 0.95, -3.0e-4, units::M_CO2};
+    case Species::H2O_VAPOR: return {1820.0, 0.30, 0.0, units::M_H2O};
+    case Species::O2:        return {880.0, 0.12, 0.0, units::M_O2};
+    case Species::H2:        return {14200.0, 0.5, 0.0, units::M_H2};
+    case Species::N2:        return {1010.0, 0.07, 0.0, units::M_N2};
+    case Species::CH4:       return {1700.0, 3.0, 0.0, units::M_CH4};
+  }
+  return {1005.0, 0.0, 0.0, units::M_AIR};
+}
+}  // namespace
+
+double cp_mass(Species species, double temperature_k)
+{
+  const CpFit f = fit_for(species);
+  return f.a + f.b * temperature_k + f.c * temperature_k * temperature_k;
+}
+
+double cp_molar(Species species, double temperature_k)
+{
+  const CpFit f = fit_for(species);
+  return cp_mass(species, temperature_k) * f.molar_mass;
+}
+
+double cv_mass(Species species, double temperature_k)
+{
+  const CpFit f = fit_for(species);
+  const double r_specific = units::R_GAS / f.molar_mass;
+  return cp_mass(species, temperature_k) - r_specific;
+}
+
+double gamma_ratio(Species species, double temperature_k)
+{
+  const double cp = cp_mass(species, temperature_k);
+  const double cv = cv_mass(species, temperature_k);
+  return (cv > 0.0) ? cp / cv : 1.4;
+}
+
+double sensible_enthalpy(Species species, double temperature_k, double reference_k)
+{
+  const CpFit f = fit_for(species);
+  // Integral of (a + b*T + c*T^2) dT from reference_k to temperature_k.
+  auto integral = [&](double t) {
+    return f.a * t + 0.5 * f.b * t * t + (1.0 / 3.0) * f.c * t * t * t;
+  };
+  return integral(temperature_k) - integral(reference_k);
+}
+
+double latent_heat_water(double temperature_k)
+{
+  // Watson correlation referenced to L0 = 2.501e6 J/kg at 273.15 K,
+  // critical temperature Tc = 647.096 K, exponent 0.38.
+  const double tc = 647.096;
+  const double l0 = 2.501e6;
+  const double t_ref = 273.15;
+  if (temperature_k >= tc) {
+    return 0.0;
+  }
+  const double ratio = (tc - temperature_k) / (tc - t_ref);
+  return l0 * std::pow(ratio, 0.38);
+}
+
+double cp_liquid_water(double temperature_k)
+{
+  // Mild curvature; minimum near 308 K. Stay close to 4180..4220.
+  const double dt = temperature_k - 308.0;
+  return 4180.0 + 4.0e-3 * dt * dt;
+}
+
+double cp_sorbent_solid(double /*temperature_k*/)
+{
+  // Representative zeolite/silica specific heat [J/(kg*K)].
+  return 920.0;
+}
+
+}  // namespace thermo
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/faults/actuator_fault.cpp
+++ b/ssos_eclss/src/faults/actuator_fault.cpp
@@ -1,0 +1,40 @@
+#include "ssos_eclss/faults/actuator_fault.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+ActuatorFault::ActuatorFault(const FaultDefinition & def) : def_(def) {}
+
+ActuatorEffect ActuatorFault::effect() const
+{
+  ActuatorEffect e{};
+  switch (def_.type) {
+    case FaultType::VALVE_STUCK_OPEN:
+      e.override_position = true;
+      e.forced_position = 1.0;
+      break;
+    case FaultType::VALVE_STUCK_CLOSED:
+      e.override_position = true;
+      e.forced_position = 0.0;
+      e.effectiveness = 0.0;
+      break;
+    case FaultType::BLOWER_DEGRADED:
+      // magnitude is the residual effectiveness fraction (e.g. 0.6).
+      e.effectiveness = std::clamp(def_.magnitude, 0.0, 1.0);
+      break;
+    case FaultType::BLOWER_FAILED:
+    case FaultType::PUMP_FAILED:
+      e.effectiveness = 0.0;
+      break;
+    default:
+      break;
+  }
+  return e;
+}
+
+}  // namespace faults
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/faults/fault_injector.cpp
+++ b/ssos_eclss/src/faults/fault_injector.cpp
@@ -1,0 +1,125 @@
+#include "ssos_eclss/faults/fault_injector.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+void FaultInjector::register_fault(const FaultDefinition & def, unsigned seed)
+{
+  Entry e;
+  e.def = def;
+  e.active = false;
+  if (is_sensor_fault(def.type)) {
+    e.sensor = std::make_unique<SensorFault>(def, seed);
+  }
+  entries_.push_back(std::move(e));
+}
+
+void FaultInjector::clear()
+{
+  entries_.clear();
+}
+
+bool FaultInjector::is_active_at(const FaultDefinition & def, double t) const
+{
+  if (t < def.start_time_s) {
+    return false;
+  }
+  if (def.duration_s < 0.0) {
+    return true;  // permanent
+  }
+  return t <= def.start_time_s + def.duration_s;
+}
+
+void FaultInjector::update(double sim_time_s)
+{
+  current_time_s_ = sim_time_s;
+  for (auto & e : entries_) {
+    e.active = is_active_at(e.def, sim_time_s);
+  }
+}
+
+bool FaultInjector::any_active() const
+{
+  for (const auto & e : entries_) {
+    if (e.active) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<FaultDefinition> FaultInjector::active_faults() const
+{
+  std::vector<FaultDefinition> out;
+  for (const auto & e : entries_) {
+    if (e.active) {
+      out.push_back(e.def);
+    }
+  }
+  return out;
+}
+
+ActuatorEffect FaultInjector::actuator_effect(const std::string & target) const
+{
+  ActuatorEffect agg{};
+  for (const auto & e : entries_) {
+    if (!e.active || e.def.target != target) {
+      continue;
+    }
+    ActuatorFault f(e.def);
+    const ActuatorEffect eff = f.effect();
+    if (eff.override_position) {
+      agg.override_position = true;
+      agg.forced_position = eff.forced_position;
+    }
+    // The most severe (lowest) effectiveness dominates.
+    agg.effectiveness = std::min(agg.effectiveness, eff.effectiveness);
+  }
+  return agg;
+}
+
+ThermalEffect FaultInjector::thermal_effect(const std::string & target) const
+{
+  ThermalEffect agg{};
+  for (const auto & e : entries_) {
+    if (!e.active || e.def.target != target) {
+      continue;
+    }
+    ThermalFault f(e.def);
+    const ThermalEffect eff = f.effect();
+    agg.heater_power_factor = std::min(agg.heater_power_factor, eff.heater_power_factor);
+    agg.precooler_ua_factor = std::min(agg.precooler_ua_factor, eff.precooler_ua_factor);
+    agg.wall_htc_factor = std::max(agg.wall_htc_factor, eff.wall_htc_factor);
+  }
+  return agg;
+}
+
+double FaultInjector::apply_sensor(const std::string & sensor, double true_value)
+{
+  double value = true_value;
+  for (auto & e : entries_) {
+    if (!e.active || !e.sensor || e.def.target != sensor) {
+      continue;
+    }
+    value = e.sensor->apply(value, current_time_s_ - e.def.start_time_s);
+  }
+  return value;
+}
+
+double FaultInjector::leak_fault_area(const std::string & target) const
+{
+  double area = 0.0;
+  for (const auto & e : entries_) {
+    if (e.active && e.def.type == FaultType::CABIN_LEAK && e.def.target == target) {
+      area += e.def.magnitude;  // magnitude is the leak area [m^2]
+    }
+  }
+  return area;
+}
+
+}  // namespace faults
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/faults/fault_types.cpp
+++ b/ssos_eclss/src/faults/fault_types.cpp
@@ -1,0 +1,51 @@
+#include "ssos_eclss/faults/fault_types.hpp"
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+std::string to_string(FaultType type)
+{
+  switch (type) {
+    case FaultType::NONE: return "none";
+    case FaultType::SENSOR_STUCK: return "sensor_stuck";
+    case FaultType::SENSOR_DRIFT: return "sensor_drift";
+    case FaultType::SENSOR_BIAS: return "sensor_bias";
+    case FaultType::SENSOR_NOISE: return "sensor_noise";
+    case FaultType::SENSOR_SCALE: return "sensor_scale";
+    case FaultType::VALVE_STUCK_OPEN: return "valve_stuck_open";
+    case FaultType::VALVE_STUCK_CLOSED: return "valve_stuck_closed";
+    case FaultType::BLOWER_DEGRADED: return "blower_degraded";
+    case FaultType::BLOWER_FAILED: return "blower_failed";
+    case FaultType::PUMP_FAILED: return "pump_failed";
+    case FaultType::HEATER_PARTIAL: return "heater_partial";
+    case FaultType::HEATER_FAILED: return "heater_failed";
+    case FaultType::PRECOOLER_DEGRADED: return "precooler_degraded";
+    case FaultType::INSULATION_LOSS: return "insulation_loss";
+    case FaultType::CABIN_LEAK: return "cabin_leak";
+  }
+  return "unknown";
+}
+
+bool is_sensor_fault(FaultType type)
+{
+  switch (type) {
+    case FaultType::SENSOR_STUCK:
+    case FaultType::SENSOR_DRIFT:
+    case FaultType::SENSOR_BIAS:
+    case FaultType::SENSOR_NOISE:
+    case FaultType::SENSOR_SCALE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool is_physics_fault(FaultType type)
+{
+  return type != FaultType::NONE && !is_sensor_fault(type);
+}
+
+}  // namespace faults
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/faults/sensor_fault.cpp
+++ b/ssos_eclss/src/faults/sensor_fault.cpp
@@ -1,0 +1,45 @@
+#include "ssos_eclss/faults/sensor_fault.hpp"
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+SensorFault::SensorFault(const FaultDefinition & def, unsigned seed)
+: def_(def), rng_(seed)
+{}
+
+double SensorFault::apply(double true_value, double fault_elapsed_s)
+{
+  switch (def_.type) {
+    case FaultType::SENSOR_STUCK:
+      // Latch the first observed value (or the configured magnitude if nonzero).
+      if (!latched_) {
+        latched_ = true;
+        latched_value_ = (def_.magnitude != 0.0) ? def_.magnitude : true_value;
+      }
+      return latched_value_;
+
+    case FaultType::SENSOR_DRIFT:
+      // Linear drift: magnitude is the drift rate [units/s].
+      return true_value + def_.magnitude * fault_elapsed_s;
+
+    case FaultType::SENSOR_BIAS:
+      // Constant additive offset.
+      return true_value + def_.magnitude;
+
+    case FaultType::SENSOR_NOISE:
+      // Additive Gaussian noise with std-dev = magnitude.
+      return true_value + def_.magnitude * noise_(rng_);
+
+    case FaultType::SENSOR_SCALE:
+      // Multiplicative scale error.
+      return true_value * def_.magnitude;
+
+    default:
+      return true_value;
+  }
+}
+
+}  // namespace faults
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/faults/thermal_fault.cpp
+++ b/ssos_eclss/src/faults/thermal_fault.cpp
@@ -1,0 +1,38 @@
+#include "ssos_eclss/faults/thermal_fault.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace faults
+{
+
+ThermalFault::ThermalFault(const FaultDefinition & def) : def_(def) {}
+
+ThermalEffect ThermalFault::effect() const
+{
+  ThermalEffect e{};
+  switch (def_.type) {
+    case FaultType::HEATER_PARTIAL:
+      // magnitude is the surviving power fraction (e.g. 7/19 elements).
+      e.heater_power_factor = std::clamp(def_.magnitude, 0.0, 1.0);
+      break;
+    case FaultType::HEATER_FAILED:
+      e.heater_power_factor = 0.0;
+      break;
+    case FaultType::PRECOOLER_DEGRADED:
+      // magnitude is the residual UA fraction.
+      e.precooler_ua_factor = std::clamp(def_.magnitude, 0.0, 1.0);
+      break;
+    case FaultType::INSULATION_LOSS:
+      // magnitude is the wall-loss amplification (>= 1).
+      e.wall_htc_factor = std::max(1.0, def_.magnitude);
+      break;
+    default:
+      break;
+  }
+  return e;
+}
+
+}  // namespace faults
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/main/ars_main.cpp
+++ b/ssos_eclss/src/main/ars_main.cpp
@@ -1,0 +1,15 @@
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "ssos_eclss/nodes/ars_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ssos_eclss::nodes::ArsNode>();
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node->get_node_base_interface());
+  exec.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ssos_eclss/src/main/cabin_main.cpp
+++ b/ssos_eclss/src/main/cabin_main.cpp
@@ -1,0 +1,15 @@
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "ssos_eclss/nodes/cabin_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ssos_eclss::nodes::CabinNode>();
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node->get_node_base_interface());
+  exec.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ssos_eclss/src/main/ogs_main.cpp
+++ b/ssos_eclss/src/main/ogs_main.cpp
@@ -1,0 +1,15 @@
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "ssos_eclss/nodes/ogs_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ssos_eclss::nodes::OgsNode>();
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node->get_node_base_interface());
+  exec.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ssos_eclss/src/main/wrs_main.cpp
+++ b/ssos_eclss/src/main/wrs_main.cpp
@@ -1,0 +1,15 @@
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "ssos_eclss/nodes/wrs_node.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ssos_eclss::nodes::WrsNode>();
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node->get_node_base_interface());
+  exec.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ssos_eclss/src/nodes/ars_node.cpp
+++ b/ssos_eclss/src/nodes/ars_node.cpp
@@ -1,0 +1,236 @@
+#include "ssos_eclss/nodes/ars_node.hpp"
+
+#include <functional>
+#include <vector>
+
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+#include "ssos_eclss/nodes/eclss_diagnostics.hpp"
+
+using std::placeholders::_1;
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+ArsNode::ArsNode(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("ars_node", options)
+{
+  // use_sim_time defaults declared by the node; allow override.
+  if (!this->has_parameter("step_rate_hz")) {
+    this->declare_parameter("step_rate_hz", step_rate_hz_);
+  }
+  if (!this->has_parameter("co2_required_kg_day")) {
+    this->declare_parameter("co2_required_kg_day", co2_required_kg_day_);
+  }
+}
+
+CallbackReturn ArsNode::on_configure(const rclcpp_lifecycle::State &)
+{
+  step_rate_hz_ = this->get_parameter("step_rate_hz").as_double();
+  co2_required_kg_day_ = this->get_parameter("co2_required_kg_day").as_double();
+
+  bridge_ = std::make_unique<EclssParameterBridge>(this);
+  bridge_->declare_ars_parameters(ars::default_ars_parameters());
+  const ars::ArsParameters params = bridge_->read_ars_parameters();
+  ars_ = std::make_unique<ars::FourBedSystem>(params);
+
+  // Default cabin conditions until the first world-state arrives.
+  cabin_.co2_partial_pressure_pa = units::torr_to_pa(params.operating.inlet_ppco2_torr);
+  cabin_.h2o_partial_pressure_pa =
+    gas::water_pp_from_rh(0.40, params.operating.cabin_temp_k);
+  cabin_.temperature_k = params.operating.cabin_temp_k;
+  cabin_.total_pressure_pa = params.operating.cabin_pressure_pa;
+
+  // Publishers.
+  co2_removal_pub_ =
+    this->create_publisher<std_msgs::msg::Float64>("/ssos/ars/co2_removal_kg_day", 10);
+  telemetry_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+    "/ssos/ars/diagnostics", 10);
+  heartbeat_pub_ =
+    this->create_publisher<SubsystemHeartbeat>("/ssos/ars/heartbeat", 10);
+  fault_pub_ = this->create_publisher<FaultEvent>("/ssos/fault_event", 10);
+
+  // Subscriber to the simulation world state.
+  world_state_sub_ = this->create_subscription<WorldState>(
+    "/sim/world_state", 10, std::bind(&ArsNode::on_world_state, this, _1));
+
+  // Registration client.
+  register_client_ =
+    this->create_client<RegisterSubsystem>("/ssos/register_subsystem");
+
+  // Live parameter validation/apply.
+  param_cb_handle_ = this->add_on_set_parameters_callback(
+    std::bind(&ArsNode::on_set_parameters, this, _1));
+
+  RCLCPP_INFO(get_logger(), "ARS configured (design CO2 removal %.2f kg/day)",
+              ars_->design_co2_removal_kg_day());
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn ArsNode::on_activate(const rclcpp_lifecycle::State &)
+{
+  co2_removal_pub_->on_activate();
+  telemetry_pub_->on_activate();
+  heartbeat_pub_->on_activate();
+  fault_pub_->on_activate();
+
+  first_step_ = true;
+  const auto period = std::chrono::duration<double>(1.0 / std::max(step_rate_hz_, 1.0e-3));
+  step_timer_ = this->create_wall_timer(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+    std::bind(&ArsNode::step, this));
+
+  register_with_manager();
+  RCLCPP_INFO(get_logger(), "ARS activated");
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn ArsNode::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  if (step_timer_) {
+    step_timer_->cancel();
+    step_timer_.reset();
+  }
+  co2_removal_pub_->on_deactivate();
+  telemetry_pub_->on_deactivate();
+  heartbeat_pub_->on_deactivate();
+  fault_pub_->on_deactivate();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn ArsNode::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  step_timer_.reset();
+  co2_removal_pub_.reset();
+  telemetry_pub_.reset();
+  heartbeat_pub_.reset();
+  fault_pub_.reset();
+  world_state_sub_.reset();
+  register_client_.reset();
+  ars_.reset();
+  bridge_.reset();
+  return CallbackReturn::SUCCESS;
+}
+
+void ArsNode::on_world_state(const WorldState::SharedPtr msg)
+{
+  const double total_p = units::kpa_to_pa(msg->cabin_pressure_kpa);
+  cabin_.total_pressure_pa = total_p;
+  cabin_.temperature_k = units::celsius_to_kelvin(msg->cabin_temp_celsius);
+  cabin_.co2_partial_pressure_pa =
+    units::ppm_to_fraction(msg->atmospheric_co2_ppm) * total_p;
+  cabin_.h2o_partial_pressure_pa =
+    gas::water_pp_from_rh(0.40, cabin_.temperature_k);
+  have_world_state_ = true;
+}
+
+void ArsNode::step()
+{
+  const rclcpp::Time now = this->now();
+  double dt = 1.0 / std::max(step_rate_hz_, 1.0e-3);
+  if (!first_step_) {
+    const double measured = (now - last_step_time_).seconds();
+    if (measured > 0.0 && measured < 100.0) {
+      dt = measured;
+    }
+  }
+  first_step_ = false;
+  last_step_time_ = now;
+
+  // Apply any committed dynamic parameter changes before stepping.
+  if (params_dirty_) {
+    ars_->set_parameters(bridge_->read_ars_parameters());
+    params_dirty_ = false;
+  }
+
+  last_result_ = ars_->step(dt, cabin_);
+
+  // CO2 removal rate.
+  std_msgs::msg::Float64 removal;
+  removal.data = last_result_.co2_removal_rate_kg_day;
+  co2_removal_pub_->publish(removal);
+
+  // Telemetry.
+  diagnostic_msgs::msg::DiagnosticArray diag;
+  diag.header.stamp = now;
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.name = "ars";
+  status.hardware_id = "ssos_eclss/ars";
+  auto kv = [&](const std::string & k, double v) {
+    diagnostic_msgs::msg::KeyValue pair;
+    pair.key = k;
+    pair.value = std::to_string(v);
+    status.values.push_back(pair);
+  };
+  kv("co2_removal_kg_day", last_result_.co2_removal_rate_kg_day);
+  kv("scrubbed_co2_torr", units::pa_to_torr(last_result_.scrubbed_co2_pp_pa));
+  kv("system_dp_in_h2o", units::pa_to_in_h2o(last_result_.system_pressure_drop_pa));
+  kv("max_bed_temp_k", last_result_.max_bed_temp_k);
+  kv("blower_flow_scfm", last_result_.blower_flow_scfm);
+  kv("precooler_exit_k", last_result_.precooler_exit_temp_k);
+  kv("adsorbing_train", last_result_.adsorbing_train);
+  status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  status.message = "nominal";
+  diag.status.push_back(status);
+  telemetry_pub_->publish(diag);
+
+  // Fault detection.
+  bool healthy = true;
+  std::string health_msg = "nominal";
+  if (EclssDiagnostics::ars_co2_removal_low(last_result_.co2_removal_rate_kg_day,
+                                            co2_required_kg_day_)) {
+    healthy = false;
+    health_msg = "CO2 removal below requirement";
+    fault_pub_->publish(EclssDiagnostics::make_fault(
+      now, "ars", "co2_removal_below_requirement",
+      FaultEvent::SEVERITY_CRITICAL, health_msg, {"/ssos/ars/co2_removal_kg_day"}));
+  }
+
+  // Heartbeat.
+  heartbeat_pub_->publish(EclssDiagnostics::make_heartbeat(
+    now, "ars", SubsystemHeartbeat::LIFECYCLE_ACTIVE, healthy, health_msg));
+}
+
+void ArsNode::register_with_manager()
+{
+  if (!register_client_->wait_for_service(std::chrono::milliseconds(200))) {
+    RCLCPP_WARN(get_logger(),
+                "system_manager registration service unavailable; continuing");
+    return;
+  }
+  auto req = std::make_shared<RegisterSubsystem::Request>();
+  req->subsystem_name = "ars";
+  req->published_topics = {"/ssos/ars/co2_removal_kg_day", "/ssos/ars/diagnostics"};
+  req->subscribed_topics = {"/sim/world_state"};
+  req->heartbeat_topic = "/ssos/ars/heartbeat";
+  register_client_->async_send_request(req);
+}
+
+rcl_interfaces::msg::SetParametersResult ArsNode::on_set_parameters(
+  const std::vector<rclcpp::Parameter> & params)
+{
+  // Validate first; never let a bad value reach the physics.
+  rcl_interfaces::msg::SetParametersResult result = bridge_->validate(params);
+  if (!result.successful) {
+    RCLCPP_WARN(get_logger(), "Rejected parameter update: %s", result.reason.c_str());
+    return result;
+  }
+  // The callback fires before values are committed, so flag a refresh that the
+  // next step() performs after the new values take effect. Static (geometry)
+  // changes need a reconfigure cycle to rebuild the beds.
+  for (const auto & p : params) {
+    if (EclssParameterBridge::is_static_parameter(p.get_name())) {
+      RCLCPP_INFO(get_logger(),
+                  "Static parameter '%s' changed; reconfigure to apply",
+                  p.get_name().c_str());
+    } else {
+      params_dirty_ = true;
+    }
+  }
+  return result;
+}
+
+}  // namespace nodes
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/nodes/cabin_node.cpp
+++ b/ssos_eclss/src/nodes/cabin_node.cpp
@@ -1,0 +1,173 @@
+#include "ssos_eclss/nodes/cabin_node.hpp"
+
+#include <functional>
+
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+#include "ssos_eclss/common/units.hpp"
+#include "ssos_eclss/nodes/eclss_diagnostics.hpp"
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+CabinNode::CabinNode(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("cabin_node", options)
+{
+  this->declare_parameter("step_rate_hz", step_rate_hz_);
+  this->declare_parameter("crew_size", crew_size_);
+  this->declare_parameter("cabin_volume_m3", cabin_volume_m3_);
+  this->declare_parameter("cabin_temp_c", cabin_temp_c_);
+  this->declare_parameter("co2_alarm_ppm", co2_alarm_ppm_);
+}
+
+CallbackReturn CabinNode::on_configure(const rclcpp_lifecycle::State &)
+{
+  step_rate_hz_ = this->get_parameter("step_rate_hz").as_double();
+  crew_size_ = static_cast<int>(this->get_parameter("crew_size").as_int());
+  cabin_volume_m3_ = this->get_parameter("cabin_volume_m3").as_double();
+  cabin_temp_c_ = this->get_parameter("cabin_temp_c").as_double();
+  co2_alarm_ppm_ = this->get_parameter("co2_alarm_ppm").as_double();
+
+  cabin::CabinParams cp{};
+  cp.volume_m3 = cabin_volume_m3_;
+  cp.temperature_k = units::celsius_to_kelvin(cabin_temp_c_);
+  atmosphere_ = std::make_unique<cabin::CabinAtmosphere>(cp);
+  crew_ = std::make_unique<cabin::CrewMetabolicModel>(crew_size_,
+                                                      cabin::default_crew_profile());
+  cabin::LeakParams lp{};
+  lp.nominal_area_m2 = 1.0e-7;
+  lp.discharge_coeff = 0.62;
+  leak_ = std::make_unique<cabin::LeakModel>(lp);
+
+  co2_pub_ = this->create_publisher<std_msgs::msg::Float64>("/ssos/cabin/co2_ppm", 10);
+  telemetry_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+    "/ssos/cabin/diagnostics", 10);
+  heartbeat_pub_ =
+    this->create_publisher<SubsystemHeartbeat>("/ssos/cabin/heartbeat", 10);
+  fault_pub_ = this->create_publisher<FaultEvent>("/ssos/fault_event", 10);
+  register_client_ =
+    this->create_client<RegisterSubsystem>("/ssos/register_subsystem");
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn CabinNode::on_activate(const rclcpp_lifecycle::State &)
+{
+  co2_pub_->on_activate();
+  telemetry_pub_->on_activate();
+  heartbeat_pub_->on_activate();
+  fault_pub_->on_activate();
+  first_step_ = true;
+  const auto period = std::chrono::duration<double>(1.0 / std::max(step_rate_hz_, 1.0e-3));
+  step_timer_ = this->create_wall_timer(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+    std::bind(&CabinNode::step, this));
+  register_with_manager();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn CabinNode::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  if (step_timer_) {
+    step_timer_->cancel();
+    step_timer_.reset();
+  }
+  co2_pub_->on_deactivate();
+  telemetry_pub_->on_deactivate();
+  heartbeat_pub_->on_deactivate();
+  fault_pub_->on_deactivate();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn CabinNode::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  step_timer_.reset();
+  co2_pub_.reset();
+  telemetry_pub_.reset();
+  heartbeat_pub_.reset();
+  fault_pub_.reset();
+  register_client_.reset();
+  atmosphere_.reset();
+  crew_.reset();
+  leak_.reset();
+  return CallbackReturn::SUCCESS;
+}
+
+void CabinNode::step()
+{
+  const rclcpp::Time now = this->now();
+  double dt = 1.0 / std::max(step_rate_hz_, 1.0e-3);
+  if (!first_step_) {
+    const double measured = (now - last_step_time_).seconds();
+    if (measured > 0.0 && measured < 100.0) {
+      dt = measured;
+    }
+  }
+  first_step_ = false;
+  last_step_time_ = now;
+
+  // Crew loads + leakage drive the cabin atmosphere.
+  const cabin::MetabolicLoads m = crew_->loads(1.0);
+  const cabin::GasFlows lk = leak_->leak_flows(*atmosphere_);
+  cabin::GasFlows total{};
+  total.o2 = m.flows.o2 + lk.o2;
+  total.co2 = m.flows.co2 + lk.co2;
+  total.n2 = lk.n2;
+  total.h2o = m.flows.h2o + lk.h2o;
+  atmosphere_->apply_flows(dt, total);
+
+  last_co2_ppm_ = atmosphere_->co2_ppm();
+
+  std_msgs::msg::Float64 co2;
+  co2.data = last_co2_ppm_;
+  co2_pub_->publish(co2);
+
+  diagnostic_msgs::msg::DiagnosticArray diag;
+  diag.header.stamp = now;
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.name = "cabin";
+  status.hardware_id = "ssos_eclss/cabin";
+  auto kv = [&](const std::string & k, double v) {
+    diagnostic_msgs::msg::KeyValue pair;
+    pair.key = k;
+    pair.value = std::to_string(v);
+    status.values.push_back(pair);
+  };
+  kv("co2_ppm", last_co2_ppm_);
+  kv("o2_fraction", atmosphere_->o2_fraction());
+  kv("total_pressure_kpa", units::pa_to_kpa(atmosphere_->total_pressure_pa()));
+  kv("relative_humidity", atmosphere_->relative_humidity());
+  status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  status.message = "nominal";
+  diag.status.push_back(status);
+  telemetry_pub_->publish(diag);
+
+  bool healthy = true;
+  std::string msg = "nominal";
+  if (last_co2_ppm_ > co2_alarm_ppm_) {
+    healthy = false;
+    msg = "cabin CO2 above alarm threshold";
+    fault_pub_->publish(EclssDiagnostics::make_fault(
+      now, "cabin", "co2_high", FaultEvent::SEVERITY_CRITICAL, msg,
+      {"/ssos/cabin/co2_ppm"}));
+  }
+  heartbeat_pub_->publish(EclssDiagnostics::make_heartbeat(
+    now, "cabin", SubsystemHeartbeat::LIFECYCLE_ACTIVE, healthy, msg));
+}
+
+void CabinNode::register_with_manager()
+{
+  if (!register_client_->wait_for_service(std::chrono::milliseconds(200))) {
+    RCLCPP_WARN(get_logger(), "system_manager unavailable; continuing");
+    return;
+  }
+  auto req = std::make_shared<RegisterSubsystem::Request>();
+  req->subsystem_name = "cabin";
+  req->published_topics = {"/ssos/cabin/co2_ppm", "/ssos/cabin/diagnostics"};
+  req->subscribed_topics = {};
+  req->heartbeat_topic = "/ssos/cabin/heartbeat";
+  register_client_->async_send_request(req);
+}
+
+}  // namespace nodes
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/nodes/eclss_diagnostics.cpp
+++ b/ssos_eclss/src/nodes/eclss_diagnostics.cpp
@@ -1,0 +1,51 @@
+#include "ssos_eclss/nodes/eclss_diagnostics.hpp"
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+SubsystemHeartbeat EclssDiagnostics::make_heartbeat(const rclcpp::Time & stamp,
+                                                    const std::string & subsystem_name,
+                                                    uint8_t lifecycle_state,
+                                                    bool healthy,
+                                                    const std::string & status_message)
+{
+  SubsystemHeartbeat hb;
+  hb.stamp = stamp;
+  hb.subsystem_name = subsystem_name;
+  hb.lifecycle_state = lifecycle_state;
+  hb.healthy = healthy;
+  hb.status_message = status_message;
+  return hb;
+}
+
+FaultEvent EclssDiagnostics::make_fault(const rclcpp::Time & stamp,
+                                        const std::string & subsystem_name,
+                                        const std::string & fault_type,
+                                        uint8_t severity,
+                                        const std::string & description,
+                                        const std::vector<std::string> & affected)
+{
+  FaultEvent ev;
+  ev.stamp = stamp;
+  ev.subsystem_name = subsystem_name;
+  ev.fault_type = fault_type;
+  ev.severity = severity;
+  ev.description = description;
+  ev.affected_interfaces = affected;
+  return ev;
+}
+
+bool EclssDiagnostics::ars_co2_removal_low(double removal_kg_day, double required_kg_day)
+{
+  return removal_kg_day < required_kg_day;
+}
+
+bool EclssDiagnostics::bed_underheated(double max_bed_temp_k, double target_temp_k)
+{
+  return max_bed_temp_k < target_temp_k;
+}
+
+}  // namespace nodes
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/nodes/eclss_parameter_bridge.cpp
+++ b/ssos_eclss/src/nodes/eclss_parameter_bridge.cpp
@@ -1,0 +1,232 @@
+#include "ssos_eclss/nodes/eclss_parameter_bridge.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+namespace
+{
+// Helper: declare a double parameter only if not already declared.
+void declare_double(rclcpp_lifecycle::LifecycleNode * n, const std::string & name,
+                    double value)
+{
+  if (!n->has_parameter(name)) {
+    n->declare_parameter(name, value);
+  }
+}
+void declare_int(rclcpp_lifecycle::LifecycleNode * n, const std::string & name,
+                 int value)
+{
+  if (!n->has_parameter(name)) {
+    n->declare_parameter(name, value);
+  }
+}
+}  // namespace
+
+EclssParameterBridge::EclssParameterBridge(rclcpp_lifecycle::LifecycleNode * node)
+: node_(node)
+{}
+
+void EclssParameterBridge::declare_ars_parameters(const ars::ArsParameters & d)
+{
+  // ---- Bed geometry (static) ----
+  declare_double(node_, "ars.bed.desiccant.length", d.desiccant_bed.length);
+  declare_double(node_, "ars.bed.desiccant.diameter", d.desiccant_bed.diameter);
+  declare_double(node_, "ars.bed.desiccant.voidage", d.desiccant_bed.voidage);
+  declare_double(node_, "ars.bed.desiccant.particle_diameter",
+                 d.desiccant_bed.particle_diameter);
+  declare_int(node_, "ars.bed.desiccant.n_cells",
+              static_cast<int>(d.desiccant_bed.n_cells));
+  declare_double(node_, "ars.bed.adsorbent.length", d.adsorbent_bed.length);
+  declare_double(node_, "ars.bed.adsorbent.diameter", d.adsorbent_bed.diameter);
+  declare_double(node_, "ars.bed.adsorbent.voidage", d.adsorbent_bed.voidage);
+  declare_double(node_, "ars.bed.adsorbent.particle_diameter",
+                 d.adsorbent_bed.particle_diameter);
+  declare_int(node_, "ars.bed.adsorbent.n_cells",
+              static_cast<int>(d.adsorbent_bed.n_cells));
+
+  // ---- CO2-on-13X isotherm (dynamic, for what-if) ----
+  declare_double(node_, "ars.isotherm.co2_13x.q_m0", d.co2_on_13x.q_m0);
+  declare_double(node_, "ars.isotherm.co2_13x.b0", d.co2_on_13x.b0);
+  declare_double(node_, "ars.isotherm.co2_13x.dH", d.co2_on_13x.dH);
+  declare_double(node_, "ars.isotherm.co2_13x.t0", d.co2_on_13x.t0);
+
+  // ---- LDF (dynamic) ----
+  declare_double(node_, "ars.ldf.adsorbent.k_co2", d.adsorbent_ldf.k_co2);
+  declare_double(node_, "ars.ldf.adsorbent.k_h2o", d.adsorbent_ldf.k_h2o);
+
+  // ---- Heater (dynamic) ----
+  declare_double(node_, "ars.heater.total_power_w", d.heater.total_power_w);
+  declare_double(node_, "ars.heater.central_power_w", d.heater.central_power_w);
+  declare_double(node_, "ars.heater.max_temp_k", d.heater.max_temp_k);
+
+  // ---- Cycle timing (dynamic) ----
+  declare_double(node_, "ars.cycle.air_save_s", d.cycle.air_save_s);
+  declare_double(node_, "ars.cycle.adsorb_s", d.cycle.adsorb_s);
+  declare_double(node_, "ars.cycle.vacuum_s", d.cycle.vacuum_s);
+
+  // ---- Operating conditions (dynamic) ----
+  declare_double(node_, "ars.operating.inlet_flow_scfm", d.operating.inlet_flow_scfm);
+  declare_double(node_, "ars.operating.inlet_ppco2_torr",
+                 d.operating.inlet_ppco2_torr);
+  declare_double(node_, "ars.operating.ltl_inlet_temp_k", d.operating.ltl_inlet_temp_k);
+  declare_double(node_, "ars.operating.ltl_flow_gpm", d.operating.ltl_flow_gpm);
+  declare_double(node_, "ars.operating.cabin_temp_k", d.operating.cabin_temp_k);
+  declare_double(node_, "ars.operating.cabin_pressure_pa",
+                 d.operating.cabin_pressure_pa);
+  declare_double(node_, "ars.operating.vacuum_pressure_pa",
+                 d.operating.vacuum_pressure_pa);
+
+  // ---- System efficiency (dynamic) ----
+  declare_double(node_, "ars.efficiency.capture_efficiency",
+                 d.efficiency.capture_efficiency);
+  declare_double(node_, "ars.efficiency.holdup_loss", d.efficiency.holdup_loss);
+}
+
+ars::ArsParameters EclssParameterBridge::read_ars_parameters() const
+{
+  ars::ArsParameters p = ars::default_ars_parameters();
+  auto gd = [&](const std::string & n, double def) {
+    return node_->get_parameter_or(n, def);
+  };
+
+  p.desiccant_bed.length = gd("ars.bed.desiccant.length", p.desiccant_bed.length);
+  p.desiccant_bed.diameter = gd("ars.bed.desiccant.diameter", p.desiccant_bed.diameter);
+  p.desiccant_bed.voidage = gd("ars.bed.desiccant.voidage", p.desiccant_bed.voidage);
+  p.desiccant_bed.particle_diameter =
+    gd("ars.bed.desiccant.particle_diameter", p.desiccant_bed.particle_diameter);
+  p.desiccant_bed.n_cells = static_cast<std::size_t>(
+    node_->get_parameter_or("ars.bed.desiccant.n_cells",
+                            static_cast<int>(p.desiccant_bed.n_cells)));
+  p.adsorbent_bed.length = gd("ars.bed.adsorbent.length", p.adsorbent_bed.length);
+  p.adsorbent_bed.diameter = gd("ars.bed.adsorbent.diameter", p.adsorbent_bed.diameter);
+  p.adsorbent_bed.voidage = gd("ars.bed.adsorbent.voidage", p.adsorbent_bed.voidage);
+  p.adsorbent_bed.particle_diameter =
+    gd("ars.bed.adsorbent.particle_diameter", p.adsorbent_bed.particle_diameter);
+  p.adsorbent_bed.n_cells = static_cast<std::size_t>(
+    node_->get_parameter_or("ars.bed.adsorbent.n_cells",
+                            static_cast<int>(p.adsorbent_bed.n_cells)));
+
+  p.co2_on_13x.q_m0 = gd("ars.isotherm.co2_13x.q_m0", p.co2_on_13x.q_m0);
+  p.co2_on_13x.b0 = gd("ars.isotherm.co2_13x.b0", p.co2_on_13x.b0);
+  p.co2_on_13x.dH = gd("ars.isotherm.co2_13x.dH", p.co2_on_13x.dH);
+  p.co2_on_13x.t0 = gd("ars.isotherm.co2_13x.t0", p.co2_on_13x.t0);
+
+  p.adsorbent_ldf.k_co2 = gd("ars.ldf.adsorbent.k_co2", p.adsorbent_ldf.k_co2);
+  p.adsorbent_ldf.k_h2o = gd("ars.ldf.adsorbent.k_h2o", p.adsorbent_ldf.k_h2o);
+
+  p.heater.total_power_w = gd("ars.heater.total_power_w", p.heater.total_power_w);
+  p.heater.central_power_w = gd("ars.heater.central_power_w", p.heater.central_power_w);
+  p.heater.max_temp_k = gd("ars.heater.max_temp_k", p.heater.max_temp_k);
+
+  p.cycle.air_save_s = gd("ars.cycle.air_save_s", p.cycle.air_save_s);
+  p.cycle.adsorb_s = gd("ars.cycle.adsorb_s", p.cycle.adsorb_s);
+  p.cycle.vacuum_s = gd("ars.cycle.vacuum_s", p.cycle.vacuum_s);
+
+  p.operating.inlet_flow_scfm =
+    gd("ars.operating.inlet_flow_scfm", p.operating.inlet_flow_scfm);
+  p.operating.inlet_ppco2_torr =
+    gd("ars.operating.inlet_ppco2_torr", p.operating.inlet_ppco2_torr);
+  p.operating.ltl_inlet_temp_k =
+    gd("ars.operating.ltl_inlet_temp_k", p.operating.ltl_inlet_temp_k);
+  p.operating.ltl_flow_gpm = gd("ars.operating.ltl_flow_gpm", p.operating.ltl_flow_gpm);
+  p.operating.cabin_temp_k = gd("ars.operating.cabin_temp_k", p.operating.cabin_temp_k);
+  p.operating.cabin_pressure_pa =
+    gd("ars.operating.cabin_pressure_pa", p.operating.cabin_pressure_pa);
+  p.operating.vacuum_pressure_pa =
+    gd("ars.operating.vacuum_pressure_pa", p.operating.vacuum_pressure_pa);
+
+  p.efficiency.capture_efficiency =
+    gd("ars.efficiency.capture_efficiency", p.efficiency.capture_efficiency);
+  p.efficiency.holdup_loss = gd("ars.efficiency.holdup_loss", p.efficiency.holdup_loss);
+  return p;
+}
+
+rcl_interfaces::msg::SetParametersResult EclssParameterBridge::validate(
+  const std::vector<rclcpp::Parameter> & params) const
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+
+  auto reject = [&](const std::string & msg) {
+    result.successful = false;
+    result.reason = msg;
+  };
+
+  for (const auto & p : params) {
+    const std::string & name = p.get_name();
+
+    // Toth heterogeneity exponent must lie in (0, 1].
+    if (name == "ars.isotherm.co2_13x.t0") {
+      const double t = p.as_double();
+      if (!(t > 0.0 && t <= 1.0)) {
+        reject("Toth exponent t0 must be in (0, 1], got " + std::to_string(t));
+      }
+    } else if (name == "ars.isotherm.co2_13x.q_m0" ||
+               name == "ars.isotherm.co2_13x.b0" ||
+               name == "ars.isotherm.co2_13x.dH") {
+      if (p.as_double() <= 0.0) {
+        reject(name + " must be positive, got " + std::to_string(p.as_double()));
+      }
+    } else if (name == "ars.bed.desiccant.voidage" ||
+               name == "ars.bed.adsorbent.voidage") {
+      const double v = p.as_double();
+      if (!(v > 0.0 && v < 1.0)) {
+        reject(name + " (voidage) must be in (0, 1), got " + std::to_string(v));
+      }
+    } else if (name == "ars.efficiency.capture_efficiency" ||
+               name == "ars.efficiency.holdup_loss") {
+      const double v = p.as_double();
+      if (!(v >= 0.0 && v <= 1.0)) {
+        reject(name + " must be in [0, 1], got " + std::to_string(v));
+      }
+    } else if (name == "ars.operating.cabin_temp_k" ||
+               name == "ars.operating.ltl_inlet_temp_k" ||
+               name == "ars.heater.max_temp_k") {
+      if (p.as_double() <= 0.0) {
+        reject(name + " (temperature) must be > 0 K, got " +
+               std::to_string(p.as_double()));
+      }
+    } else if (name == "ars.operating.inlet_flow_scfm" ||
+               name == "ars.operating.inlet_ppco2_torr" ||
+               name == "ars.operating.ltl_flow_gpm" ||
+               name == "ars.heater.total_power_w" ||
+               name == "ars.heater.central_power_w" ||
+               name == "ars.cycle.air_save_s" || name == "ars.cycle.adsorb_s" ||
+               name == "ars.cycle.vacuum_s" || name == "ars.ldf.adsorbent.k_co2" ||
+               name == "ars.ldf.adsorbent.k_h2o" ||
+               name == "ars.bed.desiccant.length" ||
+               name == "ars.bed.adsorbent.length" ||
+               name == "ars.bed.desiccant.diameter" ||
+               name == "ars.bed.adsorbent.diameter" ||
+               name == "ars.bed.desiccant.particle_diameter" ||
+               name == "ars.bed.adsorbent.particle_diameter") {
+      if (p.as_double() < 0.0) {
+        reject(name + " must be >= 0, got " + std::to_string(p.as_double()));
+      }
+    } else if (name == "ars.bed.desiccant.n_cells" ||
+               name == "ars.bed.adsorbent.n_cells") {
+      if (p.as_int() < 1) {
+        reject(name + " must be >= 1, got " + std::to_string(p.as_int()));
+      }
+    }
+
+    if (!result.successful) {
+      break;
+    }
+  }
+  return result;
+}
+
+bool EclssParameterBridge::is_static_parameter(const std::string & name)
+{
+  // Geometry and cell count require a reconfigure cycle.
+  return name.find("ars.bed.") == 0;
+}
+
+}  // namespace nodes
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/nodes/ogs_node.cpp
+++ b/ssos_eclss/src/nodes/ogs_node.cpp
@@ -1,0 +1,149 @@
+#include "ssos_eclss/nodes/ogs_node.hpp"
+
+#include <functional>
+
+#include "ssos_eclss/nodes/eclss_diagnostics.hpp"
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+OgsNode::OgsNode(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("ogs_node", options)
+{
+  this->declare_parameter("step_rate_hz", step_rate_hz_);
+  this->declare_parameter("stack_current_a", stack_current_a_);
+  this->declare_parameter("o2_required_kg_day", o2_required_kg_day_);
+}
+
+CallbackReturn OgsNode::on_configure(const rclcpp_lifecycle::State &)
+{
+  step_rate_hz_ = this->get_parameter("step_rate_hz").as_double();
+  stack_current_a_ = this->get_parameter("stack_current_a").as_double();
+  o2_required_kg_day_ = this->get_parameter("o2_required_kg_day").as_double();
+
+  ogs::OgsParameters params = ogs::default_ogs_parameters();
+  params.operating.stack_current_a = stack_current_a_;
+  ogs_ = std::make_unique<ogs::OxygenGeneratorSystem>(params);
+
+  o2_pub_ = this->create_publisher<std_msgs::msg::Float64>("/ssos/ogs/o2_kg_day", 10);
+  telemetry_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+    "/ssos/ogs/diagnostics", 10);
+  heartbeat_pub_ =
+    this->create_publisher<SubsystemHeartbeat>("/ssos/ogs/heartbeat", 10);
+  fault_pub_ = this->create_publisher<FaultEvent>("/ssos/fault_event", 10);
+  register_client_ =
+    this->create_client<RegisterSubsystem>("/ssos/register_subsystem");
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn OgsNode::on_activate(const rclcpp_lifecycle::State &)
+{
+  o2_pub_->on_activate();
+  telemetry_pub_->on_activate();
+  heartbeat_pub_->on_activate();
+  fault_pub_->on_activate();
+  first_step_ = true;
+  const auto period = std::chrono::duration<double>(1.0 / std::max(step_rate_hz_, 1.0e-3));
+  step_timer_ = this->create_wall_timer(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+    std::bind(&OgsNode::step, this));
+  register_with_manager();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn OgsNode::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  if (step_timer_) {
+    step_timer_->cancel();
+    step_timer_.reset();
+  }
+  o2_pub_->on_deactivate();
+  telemetry_pub_->on_deactivate();
+  heartbeat_pub_->on_deactivate();
+  fault_pub_->on_deactivate();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn OgsNode::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  step_timer_.reset();
+  o2_pub_.reset();
+  telemetry_pub_.reset();
+  heartbeat_pub_.reset();
+  fault_pub_.reset();
+  register_client_.reset();
+  ogs_.reset();
+  return CallbackReturn::SUCCESS;
+}
+
+void OgsNode::step()
+{
+  const rclcpp::Time now = this->now();
+  double dt = 1.0 / std::max(step_rate_hz_, 1.0e-3);
+  if (!first_step_) {
+    const double measured = (now - last_step_time_).seconds();
+    if (measured > 0.0 && measured < 100.0) {
+      dt = measured;
+    }
+  }
+  first_step_ = false;
+  last_step_time_ = now;
+
+  last_result_ = ogs_->step(dt, stack_current_a_, 1.0e9);
+
+  std_msgs::msg::Float64 o2;
+  o2.data = last_result_.o2_production_kg_day;
+  o2_pub_->publish(o2);
+
+  diagnostic_msgs::msg::DiagnosticArray diag;
+  diag.header.stamp = now;
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.name = "ogs";
+  status.hardware_id = "ssos_eclss/ogs";
+  auto kv = [&](const std::string & k, double v) {
+    diagnostic_msgs::msg::KeyValue pair;
+    pair.key = k;
+    pair.value = std::to_string(v);
+    status.values.push_back(pair);
+  };
+  kv("o2_kg_day", last_result_.o2_production_kg_day);
+  kv("h2_mol_s", last_result_.h2_production_mol_s);
+  kv("stack_voltage", last_result_.stack_voltage);
+  kv("stack_power_w", last_result_.stack_power_w);
+  kv("stack_temp_k", last_result_.stack_temperature_k);
+  status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  status.message = "nominal";
+  diag.status.push_back(status);
+  telemetry_pub_->publish(diag);
+
+  bool healthy = true;
+  std::string msg = "nominal";
+  if (last_result_.o2_production_kg_day < o2_required_kg_day_) {
+    healthy = false;
+    msg = "O2 production below requirement";
+    fault_pub_->publish(EclssDiagnostics::make_fault(
+      now, "ogs", "o2_production_low", FaultEvent::SEVERITY_CRITICAL, msg,
+      {"/ssos/ogs/o2_kg_day"}));
+  }
+  heartbeat_pub_->publish(EclssDiagnostics::make_heartbeat(
+    now, "ogs", SubsystemHeartbeat::LIFECYCLE_ACTIVE, healthy, msg));
+}
+
+void OgsNode::register_with_manager()
+{
+  if (!register_client_->wait_for_service(std::chrono::milliseconds(200))) {
+    RCLCPP_WARN(get_logger(), "system_manager unavailable; continuing");
+    return;
+  }
+  auto req = std::make_shared<RegisterSubsystem::Request>();
+  req->subsystem_name = "ogs";
+  req->published_topics = {"/ssos/ogs/o2_kg_day", "/ssos/ogs/diagnostics"};
+  req->subscribed_topics = {"/sim/world_state"};
+  req->heartbeat_topic = "/ssos/ogs/heartbeat";
+  register_client_->async_send_request(req);
+}
+
+}  // namespace nodes
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/nodes/wrs_node.cpp
+++ b/ssos_eclss/src/nodes/wrs_node.cpp
@@ -1,0 +1,154 @@
+#include "ssos_eclss/nodes/wrs_node.hpp"
+
+#include <functional>
+
+#include "ssos_eclss/common/units.hpp"
+#include "ssos_eclss/nodes/eclss_diagnostics.hpp"
+
+namespace ssos_eclss
+{
+namespace nodes
+{
+
+WrsNode::WrsNode(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("wrs_node", options)
+{
+  this->declare_parameter("step_rate_hz", step_rate_hz_);
+  this->declare_parameter("urine_kg_day", urine_kg_day_);
+  this->declare_parameter("condensate_kg_day", condensate_kg_day_);
+  this->declare_parameter("potable_limit_us", potable_limit_us_);
+}
+
+CallbackReturn WrsNode::on_configure(const rclcpp_lifecycle::State &)
+{
+  step_rate_hz_ = this->get_parameter("step_rate_hz").as_double();
+  urine_kg_day_ = this->get_parameter("urine_kg_day").as_double();
+  condensate_kg_day_ = this->get_parameter("condensate_kg_day").as_double();
+  potable_limit_us_ = this->get_parameter("potable_limit_us").as_double();
+
+  wrs_ = std::make_unique<wrs::WaterRecoverySystem>();
+  wrs_->reset();
+
+  water_pub_ =
+    this->create_publisher<std_msgs::msg::Float64>("/ssos/wrs/potable_kg_day", 10);
+  telemetry_pub_ = this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
+    "/ssos/wrs/diagnostics", 10);
+  heartbeat_pub_ =
+    this->create_publisher<SubsystemHeartbeat>("/ssos/wrs/heartbeat", 10);
+  fault_pub_ = this->create_publisher<FaultEvent>("/ssos/fault_event", 10);
+  register_client_ =
+    this->create_client<RegisterSubsystem>("/ssos/register_subsystem");
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn WrsNode::on_activate(const rclcpp_lifecycle::State &)
+{
+  water_pub_->on_activate();
+  telemetry_pub_->on_activate();
+  heartbeat_pub_->on_activate();
+  fault_pub_->on_activate();
+  first_step_ = true;
+  const auto period = std::chrono::duration<double>(1.0 / std::max(step_rate_hz_, 1.0e-3));
+  step_timer_ = this->create_wall_timer(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+    std::bind(&WrsNode::step, this));
+  register_with_manager();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn WrsNode::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  if (step_timer_) {
+    step_timer_->cancel();
+    step_timer_.reset();
+  }
+  water_pub_->on_deactivate();
+  telemetry_pub_->on_deactivate();
+  heartbeat_pub_->on_deactivate();
+  fault_pub_->on_deactivate();
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn WrsNode::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  step_timer_.reset();
+  water_pub_.reset();
+  telemetry_pub_.reset();
+  heartbeat_pub_.reset();
+  fault_pub_.reset();
+  register_client_.reset();
+  wrs_.reset();
+  return CallbackReturn::SUCCESS;
+}
+
+void WrsNode::step()
+{
+  const rclcpp::Time now = this->now();
+  double dt = 1.0 / std::max(step_rate_hz_, 1.0e-3);
+  if (!first_step_) {
+    const double measured = (now - last_step_time_).seconds();
+    if (measured > 0.0 && measured < 100.0) {
+      dt = measured;
+    }
+  }
+  first_step_ = false;
+  last_step_time_ = now;
+
+  const double urine = units::kg_per_day_to_kg_per_s(urine_kg_day_);
+  const double condensate = units::kg_per_day_to_kg_per_s(condensate_kg_day_);
+  last_result_ = wrs_->step(dt, urine, condensate, 1.0e-8);
+
+  std_msgs::msg::Float64 water;
+  water.data = last_result_.potable_water_kg_s * units::SECONDS_PER_DAY;
+  water_pub_->publish(water);
+
+  diagnostic_msgs::msg::DiagnosticArray diag;
+  diag.header.stamp = now;
+  diagnostic_msgs::msg::DiagnosticStatus status;
+  status.name = "wrs";
+  status.hardware_id = "ssos_eclss/wrs";
+  auto kv = [&](const std::string & k, double v) {
+    diagnostic_msgs::msg::KeyValue pair;
+    pair.key = k;
+    pair.value = std::to_string(v);
+    status.values.push_back(pair);
+  };
+  kv("potable_kg_day", water.data);
+  kv("conductivity_us", last_result_.product_conductivity_us);
+  kv("overall_recovery", last_result_.overall_recovery);
+  kv("voc_conversion", last_result_.voc_conversion);
+  status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  status.message = "nominal";
+  diag.status.push_back(status);
+  telemetry_pub_->publish(diag);
+
+  bool healthy = true;
+  std::string msg = "nominal";
+  if (last_result_.product_conductivity_us > potable_limit_us_ ||
+      last_result_.multifiltration_broken_through) {
+    healthy = false;
+    msg = "product water out of potable spec";
+    fault_pub_->publish(EclssDiagnostics::make_fault(
+      now, "wrs", "water_quality_out_of_spec", FaultEvent::SEVERITY_CRITICAL, msg,
+      {"/ssos/wrs/potable_kg_day"}));
+  }
+  heartbeat_pub_->publish(EclssDiagnostics::make_heartbeat(
+    now, "wrs", SubsystemHeartbeat::LIFECYCLE_ACTIVE, healthy, msg));
+}
+
+void WrsNode::register_with_manager()
+{
+  if (!register_client_->wait_for_service(std::chrono::milliseconds(200))) {
+    RCLCPP_WARN(get_logger(), "system_manager unavailable; continuing");
+    return;
+  }
+  auto req = std::make_shared<RegisterSubsystem::Request>();
+  req->subsystem_name = "wrs";
+  req->published_topics = {"/ssos/wrs/potable_kg_day", "/ssos/wrs/diagnostics"};
+  req->subscribed_topics = {};
+  req->heartbeat_topic = "/ssos/wrs/heartbeat";
+  register_client_->async_send_request(req);
+}
+
+}  // namespace nodes
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ogs/electrolysis_cell_model.cpp
+++ b/ssos_eclss/src/ogs/electrolysis_cell_model.cpp
@@ -1,0 +1,75 @@
+#include "ssos_eclss/ogs/electrolysis_cell_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+namespace
+{
+constexpr double kE0 = 1.229;          // standard reversible voltage at 298 K [V]
+constexpr double kThermoneutral = 1.481;  // thermoneutral voltage [V]
+constexpr int kElectrons = 2;          // electrons per H2O for the H2 half-cell
+}  // namespace
+
+ElectrolysisCellModel::ElectrolysisCellModel(const CellParams & params)
+: params_(params)
+{}
+
+double ElectrolysisCellModel::reversible_voltage(double temperature_k,
+                                                 double pressure_pa) const
+{
+  // Temperature correction of E0 (dE/dT ~ -0.9 mV/K for water splitting).
+  const double e_temp = kE0 - 0.0009 * (temperature_k - 298.15);
+  // Nernst pressure term: E = E_T + (R T / nF) ln(pH2 * sqrt(pO2) / aH2O).
+  // Product gases at operating pressure (atm-referenced), liquid water aH2O~1.
+  const double p_atm = std::max(pressure_pa / units::STD_PRESSURE_PA, 1.0e-6);
+  const double nernst = units::R_GAS * temperature_k / (kElectrons * units::FARADAY) *
+                        std::log(p_atm * std::sqrt(p_atm));
+  return e_temp + nernst;
+}
+
+CellState ElectrolysisCellModel::solve(double current_a, double temperature_k,
+                                       double pressure_pa) const
+{
+  CellState s{};
+  const double i = std::max(current_a, 0.0) / params_.active_area_m2;  // A/m^2
+
+  s.reversible_voltage = reversible_voltage(temperature_k, pressure_pa);
+
+  // Activation overpotential (Butler-Volmer high-field / Tafel form).
+  const double rt_anf = units::R_GAS * temperature_k /
+                        (params_.charge_transfer_coeff * kElectrons * units::FARADAY);
+  s.activation_overpotential =
+      (i > 0.0) ? rt_anf * std::asinh(i / (2.0 * params_.exchange_current_density))
+                : 0.0;
+
+  // Ohmic overpotential through the membrane (area-specific resistance).
+  s.ohmic_overpotential = i * params_.membrane_resistance;
+
+  // Concentration overpotential near the limiting current.
+  const double ratio = std::clamp(i / params_.limiting_current_density, 0.0, 0.999);
+  s.concentration_overpotential =
+      (i > 0.0) ? -units::R_GAS * temperature_k / (kElectrons * units::FARADAY) *
+                      std::log(1.0 - ratio)
+                : 0.0;
+
+  s.voltage = s.reversible_voltage + s.activation_overpotential +
+              s.ohmic_overpotential + s.concentration_overpotential;
+
+  // Faraday's law: per cell H2 = I/(2F), O2 = I/(4F).
+  s.h2_production_mol_s = current_a / (2.0 * units::FARADAY);
+  s.o2_production_mol_s = current_a / (4.0 * units::FARADAY);
+
+  s.power_w = s.voltage * current_a;
+  s.efficiency = (s.voltage > 0.0) ? kThermoneutral / s.voltage : 0.0;
+  return s;
+}
+
+}  // namespace ogs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ogs/electrolysis_stack_model.cpp
+++ b/ssos_eclss/src/ogs/electrolysis_stack_model.cpp
@@ -1,0 +1,52 @@
+#include "ssos_eclss/ogs/electrolysis_stack_model.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+namespace
+{
+constexpr double kThermoneutral = 1.481;  // V
+}
+
+ElectrolysisStackModel::ElectrolysisStackModel(const StackParams & stack,
+                                               const CellParams & cell)
+: stack_(stack), cell_(cell), temperature_k_(330.0)
+{}
+
+void ElectrolysisStackModel::reset(double temperature_k)
+{
+  temperature_k_ = temperature_k;
+}
+
+StackState ElectrolysisStackModel::step(double dt, double current_a,
+                                        double pressure_pa, double coolant_temp_k)
+{
+  const CellState cell = cell_.solve(current_a, temperature_k_, pressure_pa);
+  const double n = static_cast<double>(std::max(stack_.n_cells, 1));
+
+  StackState s{};
+  s.current_a = current_a;
+  s.total_voltage = cell.voltage * n;
+  s.o2_production_mol_s = cell.o2_production_mol_s * n;
+  s.h2_production_mol_s = cell.h2_production_mol_s * n;
+  s.power_w = cell.power_w * n;
+  s.efficiency = cell.efficiency;
+
+  // Waste heat = (V_cell - V_thermoneutral) * I per cell, when V > V_tn.
+  const double waste_per_cell = std::max(0.0, cell.voltage - kThermoneutral) * current_a;
+  s.waste_heat_w = waste_per_cell * n;
+
+  // Lumped thermal update: dT/dt = (Q_waste - UA (T - T_cool)) / C.
+  const double q_cool = stack_.heat_loss_coeff_w_k * (temperature_k_ - coolant_temp_k);
+  const double dT = (s.waste_heat_w - q_cool) / std::max(stack_.thermal_mass_j_k, 1.0);
+  temperature_k_ += dT * dt;
+  s.temperature_k = temperature_k_;
+  return s;
+}
+
+}  // namespace ogs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ogs/gas_separator_model.cpp
+++ b/ssos_eclss/src/ogs/gas_separator_model.cpp
@@ -1,0 +1,28 @@
+#include "ssos_eclss/ogs/gas_separator_model.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+GasSeparatorModel::GasSeparatorModel(const SeparatorParams & params) : params_(params)
+{}
+
+SeparationResult GasSeparatorModel::separate(double gas_mol_s, double water_mol_s) const
+{
+  SeparationResult r{};
+  const double eff = std::clamp(params_.efficiency, 0.0, 1.0);
+  const double carry = std::clamp(params_.carryover_fraction, 0.0, 1.0);
+
+  // Gas passes downstream (a small fraction of water is carried over).
+  r.dry_gas_mol_s = gas_mol_s;
+  r.carryover_water_mol_s = water_mol_s * carry;
+  // The rest of the entrained water is recovered, scaled by efficiency.
+  r.recovered_water_mol_s = (water_mol_s - r.carryover_water_mol_s) * eff;
+  return r;
+}
+
+}  // namespace ogs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/ogs/oxygen_generator_system.cpp
+++ b/ssos_eclss/src/ogs/oxygen_generator_system.cpp
@@ -1,0 +1,129 @@
+#include "ssos_eclss/ogs/oxygen_generator_system.hpp"
+
+#include <algorithm>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace ogs
+{
+
+OxygenGeneratorSystem::OxygenGeneratorSystem(const OgsParameters & params)
+: params_(params)
+{
+  stack_ = std::make_unique<ElectrolysisStackModel>(params_.stack, params_.cell);
+  separator_ = std::make_unique<GasSeparatorModel>(params_.separator);
+  reset(params_.operating.feedwater_temp_k > 0.0 ? 330.0 : 330.0);
+}
+
+void OxygenGeneratorSystem::reset(double temperature_k)
+{
+  stack_->reset(temperature_k);
+}
+
+void OxygenGeneratorSystem::set_parameters(const OgsParameters & params)
+{
+  params_ = params;
+  stack_->set_params(params_.stack);
+  stack_->set_cell_params(params_.cell);
+  separator_->set_params(params_.separator);
+}
+
+OgsResult OxygenGeneratorSystem::step(double dt, double current_a,
+                                      double available_water_mol_s)
+{
+  OgsResult r{};
+
+  // Water demanded by electrolysis at this current: H2O = 2 * O2 = I*n/(2F).
+  const double n_cells = static_cast<double>(std::max(params_.stack.n_cells, 1));
+  const double water_demand = current_a * n_cells / (2.0 * units::FARADAY);
+
+  // Limit current if feed water is insufficient.
+  double effective_current = current_a;
+  if (available_water_mol_s < water_demand && water_demand > 0.0) {
+    effective_current = current_a * available_water_mol_s / water_demand;
+    r.feedwater_limited = true;
+  }
+
+  const StackState s = stack_->step(dt, effective_current, params_.operating.cell_pressure_pa,
+                                    params_.operating.coolant_temp_k);
+
+  // Separate carried water from the O2 product.
+  const SeparationResult sep = separator_->separate(s.o2_production_mol_s, 0.0);
+
+  r.o2_production_mol_s = sep.dry_gas_mol_s;
+  r.h2_production_mol_s = s.h2_production_mol_s;
+  r.water_consumed_mol_s = s.o2_production_mol_s * 2.0;  // 2 H2O per O2
+  r.o2_production_kg_day =
+      r.o2_production_mol_s * units::M_O2 * units::SECONDS_PER_DAY;
+  r.water_consumed_kg_day =
+      r.water_consumed_mol_s * units::M_H2O * units::SECONDS_PER_DAY;
+  r.stack_voltage = s.total_voltage;
+  r.stack_power_w = s.power_w;
+  r.stack_temperature_k = s.temperature_k;
+
+  const double o2_kg_s = r.o2_production_mol_s * units::M_O2;
+  r.specific_energy_wh_kg =
+      (o2_kg_s > 0.0) ? s.power_w / (o2_kg_s * units::SECONDS_PER_HOUR) : 0.0;
+  return r;
+}
+
+OgsResult OxygenGeneratorSystem::step_nominal(double dt)
+{
+  return step(dt, params_.operating.stack_current_a, 1.0e9);
+}
+
+// ---- Parameter factories (ISS OGA-class defaults) ----
+
+CellParams default_cell_params()
+{
+  CellParams c{};
+  c.active_area_m2 = 0.093;          // ~0.093 m^2 (1 ft^2)
+  c.exchange_current_density = 1.0e-3;  // A/m^2 (sluggish OER)
+  c.limiting_current_density = 2.0e4;   // A/m^2
+  c.membrane_resistance = 1.5e-5;    // ohm*m^2
+  c.charge_transfer_coeff = 0.5;
+  c.reference_temp_k = 298.15;
+  return c;
+}
+
+StackParams default_stack_params()
+{
+  StackParams s{};
+  s.n_cells = 28;
+  s.thermal_mass_j_k = 5.0e4;
+  s.heat_loss_coeff_w_k = 40.0;
+  return s;
+}
+
+SeparatorParams default_separator_params()
+{
+  SeparatorParams s{};
+  s.efficiency = 0.98;
+  s.carryover_fraction = 0.01;
+  return s;
+}
+
+OgsOperating default_ogs_operating()
+{
+  OgsOperating o{};
+  o.stack_current_a = 27.0;          // ~5.4 kg O2/day for 28 cells (OGA-class)
+  o.feedwater_temp_k = units::celsius_to_kelvin(25.0);
+  o.coolant_temp_k = units::celsius_to_kelvin(18.0);
+  o.cell_pressure_pa = units::STD_PRESSURE_PA;
+  return o;
+}
+
+OgsParameters default_ogs_parameters()
+{
+  OgsParameters p{};
+  p.cell = default_cell_params();
+  p.stack = default_stack_params();
+  p.separator = default_separator_params();
+  p.operating = default_ogs_operating();
+  return p;
+}
+
+}  // namespace ogs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/sabatier/reactor_kinetics.cpp
+++ b/ssos_eclss/src/sabatier/reactor_kinetics.cpp
@@ -1,0 +1,32 @@
+#include "ssos_eclss/sabatier/reactor_kinetics.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace sabatier
+{
+
+ReactorKinetics::ReactorKinetics(const KineticsParams & params) : params_(params) {}
+
+double ReactorKinetics::rate_constant(double temperature_k) const
+{
+  if (temperature_k <= 0.0) {
+    return 0.0;
+  }
+  return params_.pre_exponential *
+         std::exp(-params_.activation_energy / (units::R_GAS * temperature_k));
+}
+
+double ReactorKinetics::conversion(double temperature_k) const
+{
+  const double k = rate_constant(temperature_k);
+  const double x = 1.0 - std::exp(-k * params_.residence_time_s);
+  return std::clamp(params_.max_conversion * x, 0.0, params_.max_conversion);
+}
+
+}  // namespace sabatier
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/sabatier/sabatier_system.cpp
+++ b/ssos_eclss/src/sabatier/sabatier_system.cpp
@@ -1,0 +1,97 @@
+#include "ssos_eclss/sabatier/sabatier_system.hpp"
+
+#include <algorithm>
+
+#include "ssos_eclss/common/units.hpp"
+
+namespace ssos_eclss
+{
+namespace sabatier
+{
+
+SabatierSystem::SabatierSystem(const SabatierParameters & params) : params_(params)
+{
+  kinetics_ = std::make_unique<ReactorKinetics>(params_.kinetics);
+  reactor_temp_k_ = params_.reactor.operating_temp_k;
+}
+
+void SabatierSystem::reset(double temperature_k) { reactor_temp_k_ = temperature_k; }
+
+void SabatierSystem::set_parameters(const SabatierParameters & params)
+{
+  params_ = params;
+  kinetics_->set_params(params_.kinetics);
+}
+
+SabatierResult SabatierSystem::step(double dt, double co2_in_mol_s, double h2_in_mol_s)
+{
+  SabatierResult r{};
+  co2_in_mol_s = std::max(0.0, co2_in_mol_s);
+  h2_in_mol_s = std::max(0.0, h2_in_mol_s);
+
+  // Stoichiometry: 4 H2 per CO2. Determine the limiting reactant feed.
+  const double co2_equiv_from_h2 = h2_in_mol_s / 4.0;
+  double co2_reactable = co2_in_mol_s;
+  if (co2_equiv_from_h2 < co2_in_mol_s) {
+    co2_reactable = co2_equiv_from_h2;
+    r.hydrogen_limited = true;
+  }
+
+  // Kinetic / equilibrium conversion at the current reactor temperature.
+  const double x = kinetics_->conversion(reactor_temp_k_);
+  r.conversion = x;
+
+  r.co2_consumed_mol_s = co2_reactable * x;
+  r.h2_consumed_mol_s = 4.0 * r.co2_consumed_mol_s;
+  r.ch4_produced_mol_s = r.co2_consumed_mol_s;          // 1 CH4 per CO2
+  r.water_produced_mol_s = 2.0 * r.co2_consumed_mol_s;  // 2 H2O per CO2
+  r.water_produced_kg_s = r.water_produced_mol_s * units::M_H2O;
+
+  // Exothermic heat release.
+  r.reaction_heat_w = r.co2_consumed_mol_s * params_.kinetics.heat_of_reaction;
+
+  // Lumped reactor thermal update: dT/dt = (Q_rxn - UA(T - Tamb)) / C.
+  const double q_loss = params_.reactor.heat_loss_coeff_w_k *
+                        (reactor_temp_k_ - params_.reactor.ambient_temp_k);
+  const double dT = (r.reaction_heat_w - q_loss) /
+                    std::max(params_.reactor.thermal_mass_j_k, 1.0);
+  reactor_temp_k_ += dT * dt;
+  r.reactor_temp_k = reactor_temp_k_;
+  return r;
+}
+
+// ---- Parameter factories ----
+
+KineticsParams default_kinetics_params()
+{
+  KineticsParams p{};
+  p.pre_exponential = 5.0e3;      // 1/s
+  p.activation_energy = 4.0e4;    // J/mol
+  p.max_conversion = 0.95;        // equilibrium-limited
+  p.residence_time_s = 2.0;       // s
+  p.heat_of_reaction = 165000.0;  // J/mol CO2 (exothermic)
+  return p;
+}
+
+ReactorParams default_reactor_params()
+{
+  ReactorParams p{};
+  p.operating_temp_k = 600.0;     // ~327 C
+  p.thermal_mass_j_k = 2000.0;
+  // Well-insulated small reactor: the exotherm (~150 W at flight CO2 rates)
+  // sustains the operating temperature against this loss.
+  p.heat_loss_coeff_w_k = 0.5;
+  p.ambient_temp_k = 295.0;
+  return p;
+}
+
+SabatierParameters default_sabatier_parameters()
+{
+  SabatierParameters p{};
+  p.kinetics = default_kinetics_params();
+  p.reactor = default_reactor_params();
+  return p;
+}
+
+}  // namespace sabatier
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/wrs/catalytic_reactor_model.cpp
+++ b/ssos_eclss/src/wrs/catalytic_reactor_model.cpp
@@ -1,0 +1,38 @@
+#include "ssos_eclss/wrs/catalytic_reactor_model.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+CatalyticReactorModel::CatalyticReactorModel(const CatalyticReactorParams & params)
+: params_(params)
+{}
+
+double CatalyticReactorModel::conversion(double temperature_k) const
+{
+  // Conversion approaches max_conversion as T rises above the activation
+  // temperature: X = Xmax * (1 - exp(-(T - T0)/scale)) for T > T0.
+  if (temperature_k <= params_.activation_temp_k) {
+    return 0.0;
+  }
+  const double scale = 0.25 * params_.activation_temp_k;
+  const double x = params_.max_conversion *
+                   (1.0 - std::exp(-(temperature_k - params_.activation_temp_k) / scale));
+  return std::clamp(x, 0.0, params_.max_conversion);
+}
+
+CatalyticResult CatalyticReactorModel::process(double voc_in_kg_s,
+                                               double temperature_k) const
+{
+  CatalyticResult r{};
+  r.conversion = conversion(temperature_k);
+  r.outlet_voc_kg_s = std::max(0.0, voc_in_kg_s * (1.0 - r.conversion));
+  return r;
+}
+
+}  // namespace wrs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/wrs/distillation_model.cpp
+++ b/ssos_eclss/src/wrs/distillation_model.cpp
@@ -1,0 +1,28 @@
+#include "ssos_eclss/wrs/distillation_model.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+DistillationModel::DistillationModel(const DistillationParams & params)
+: params_(params)
+{}
+
+DistillationResult DistillationModel::process(double feed_kg_s) const
+{
+  DistillationResult r{};
+  const double feed = std::clamp(feed_kg_s, 0.0, params_.max_throughput_kg_s);
+  const double rec = std::clamp(params_.recovery_fraction, 0.0, 1.0);
+
+  r.distillate_kg_s = feed * rec;
+  r.brine_kg_s = feed - r.distillate_kg_s;
+  r.energy_w = r.distillate_kg_s * params_.specific_energy_j_kg;
+  r.recovery_fraction = rec;
+  return r;
+}
+
+}  // namespace wrs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/wrs/multifiltration_model.cpp
+++ b/ssos_eclss/src/wrs/multifiltration_model.cpp
@@ -1,0 +1,40 @@
+#include "ssos_eclss/wrs/multifiltration_model.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+MultifiltrationModel::MultifiltrationModel(const MultifiltrationParams & params)
+: params_(params)
+{}
+
+void MultifiltrationModel::reset() { accumulated_kg_ = 0.0; }
+
+MultifiltrationResult MultifiltrationModel::process(double dt, double feed_kg_s,
+                                                    double feed_conductivity_us)
+{
+  MultifiltrationResult r{};
+  const double cap = std::max(params_.bed_capacity_kg, 1.0e-12);
+  const double utilization = accumulated_kg_ / cap;
+
+  // Removal efficiency degrades as the bed approaches breakthrough.
+  const double remaining = std::clamp(1.0 - utilization, 0.0, 1.0);
+  const double eff = std::clamp(params_.removal_efficiency, 0.0, 1.0) * remaining;
+
+  r.product_kg_s = feed_kg_s;
+  r.product_conductivity_us = feed_conductivity_us * (1.0 - eff);
+  // Contaminant mass captured ~ proportional to feed * conductivity * eff.
+  // Use conductivity as a proxy for contaminant concentration [g per uS scale].
+  const double captured_kg = feed_kg_s * feed_conductivity_us * 1.0e-6 * eff * dt;
+  accumulated_kg_ += captured_kg;
+
+  r.bed_utilization = std::clamp(accumulated_kg_ / cap, 0.0, 1.0);
+  r.broken_through = (accumulated_kg_ >= cap);
+  return r;
+}
+
+}  // namespace wrs
+}  // namespace ssos_eclss

--- a/ssos_eclss/src/wrs/water_recovery_system.cpp
+++ b/ssos_eclss/src/wrs/water_recovery_system.cpp
@@ -1,0 +1,107 @@
+#include "ssos_eclss/wrs/water_recovery_system.hpp"
+
+#include <algorithm>
+
+namespace ssos_eclss
+{
+namespace wrs
+{
+
+namespace
+{
+constexpr double kPotableLimitUs = 100.0;  // potable conductivity limit [uS/cm]
+}
+
+WaterRecoverySystem::WaterRecoverySystem(const WrsParameters & params)
+: params_(params)
+{
+  distillation_ = std::make_unique<DistillationModel>(params_.distillation);
+  multifiltration_ = std::make_unique<MultifiltrationModel>(params_.multifiltration);
+  catalytic_ = std::make_unique<CatalyticReactorModel>(params_.catalytic);
+}
+
+void WaterRecoverySystem::reset()
+{
+  multifiltration_->reset();
+}
+
+void WaterRecoverySystem::set_parameters(const WrsParameters & params)
+{
+  params_ = params;
+  distillation_->set_params(params_.distillation);
+  multifiltration_->set_params(params_.multifiltration);
+  catalytic_->set_params(params_.catalytic);
+}
+
+WrsResult WaterRecoverySystem::step(double dt, double urine_kg_s,
+                                    double condensate_kg_s, double voc_kg_s)
+{
+  WrsResult r{};
+
+  // ---- UPA: distil urine ----
+  const DistillationResult dist = distillation_->process(urine_kg_s);
+
+  // ---- Combine distillate with humidity condensate to feed the WPA ----
+  const double wpa_feed = dist.distillate_kg_s + condensate_kg_s;
+
+  // ---- Catalytic oxidation of volatile organics ----
+  const CatalyticResult cat = catalytic_->process(voc_kg_s, params_.catalytic.operating_temp_k);
+
+  // ---- Multifiltration polish ----
+  const MultifiltrationResult mf = multifiltration_->process(
+    dt, wpa_feed, params_.multifiltration.inlet_conductivity_us);
+
+  r.potable_water_kg_s = mf.product_kg_s;
+  r.brine_kg_s = dist.brine_kg_s;
+  r.product_conductivity_us = mf.product_conductivity_us;
+  r.power_w = dist.energy_w;
+  r.voc_conversion = cat.conversion;
+  r.multifiltration_broken_through = mf.broken_through;
+  r.potable_in_spec = (mf.product_conductivity_us <= kPotableLimitUs);
+
+  const double water_in = urine_kg_s + condensate_kg_s;
+  r.overall_recovery = (water_in > 0.0) ? r.potable_water_kg_s / water_in : 0.0;
+  return r;
+}
+
+// ---- Parameter factories (ISS WRS-class defaults) ----
+
+DistillationParams default_distillation_params()
+{
+  DistillationParams p{};
+  p.recovery_fraction = 0.87;            // UPA ~85-87%
+  p.specific_energy_j_kg = 1.1e5 * 3.6;  // ~110 Wh/kg -> J/kg
+  p.max_throughput_kg_s = 9.0 / 86400.0; // ~9 kg/day
+  p.brine_solids_fraction = 0.05;
+  return p;
+}
+
+MultifiltrationParams default_multifiltration_params()
+{
+  MultifiltrationParams p{};
+  p.bed_capacity_kg = 0.5;          // contaminant capacity [kg]
+  p.removal_efficiency = 0.999;
+  p.inlet_conductivity_us = 2000.0; // feed conductivity [uS/cm]
+  return p;
+}
+
+CatalyticReactorParams default_catalytic_params()
+{
+  CatalyticReactorParams p{};
+  p.operating_temp_k = 403.15;   // ~130 C
+  p.activation_temp_k = 333.15;  // ~60 C
+  p.max_conversion = 0.99;
+  return p;
+}
+
+WrsParameters default_wrs_parameters()
+{
+  WrsParameters p{};
+  p.distillation = default_distillation_params();
+  p.multifiltration = default_multifiltration_params();
+  p.catalytic = default_catalytic_params();
+  return p;
+}
+
+}  // namespace wrs
+}  // namespace ssos_eclss

--- a/ssos_eclss/standalone/ars_validation.cpp
+++ b/ssos_eclss/standalone/ars_validation.cpp
@@ -1,0 +1,75 @@
+// ARS validation workbench (no ROS). Runs the FourBedSystem at the 4BCO2 EDU
+// design point, dumps a CSV time history, and compares the steady CO2 removal
+// against the ICES-2021-313 target band (4.16-4.76 kg/day at 2 torr, 26 SCFM).
+//
+// Usage: ars_validation [output.csv] [sim_minutes]
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+#include "ssos_eclss/ars/four_bed_system.hpp"
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+
+int main(int argc, char ** argv)
+{
+  const std::string out_path = (argc > 1) ? argv[1] : "ars_validation.csv";
+  const double sim_minutes = (argc > 2) ? std::atof(argv[2]) : 180.0;
+
+  ars::ArsParameters params = ars::default_ars_parameters();
+  // Moderate resolution keeps the multi-hour run fast while staying faithful.
+  params.desiccant_bed.n_cells = 20;
+  params.adsorbent_bed.n_cells = 20;
+  ars::FourBedSystem fbs(params);
+  fbs.reset(units::celsius_to_kelvin(22.0));
+
+  ars::CabinConditions cabin{};
+  cabin.co2_partial_pressure_pa = units::torr_to_pa(2.0);
+  cabin.h2o_partial_pressure_pa =
+      gas::water_pp_from_rh(0.40, units::celsius_to_kelvin(22.0));
+  cabin.temperature_k = units::celsius_to_kelvin(22.0);
+  cabin.total_pressure_pa = units::torr_to_pa(760.0);
+
+  std::ofstream csv(out_path);
+  csv << "time_s,co2_removal_kg_day,scrubbed_co2_torr,system_dp_in_h2o,"
+         "max_bed_temp_f,precooler_exit_f,blower_flow_scfm,adsorbing_train\n";
+
+  const double dt = 2.0;
+  const int n_steps = static_cast<int>(sim_minutes * 60.0 / dt);
+  double sum_removal = 0.0;
+  int sample_count = 0;
+
+  for (int i = 0; i < n_steps; ++i) {
+    const ars::ArsResult r = fbs.step(dt, cabin);
+    const double t = i * dt;
+    if (i % 15 == 0) {
+      csv << t << "," << r.co2_removal_rate_kg_day << ","
+          << units::pa_to_torr(r.scrubbed_co2_pp_pa) << ","
+          << units::pa_to_in_h2o(r.system_pressure_drop_pa) << ","
+          << units::kelvin_to_fahrenheit(r.max_bed_temp_k) << ","
+          << units::kelvin_to_fahrenheit(r.precooler_exit_temp_k) << ","
+          << r.blower_flow_scfm << "," << r.adsorbing_train << "\n";
+    }
+    // Average over the second half (cyclic steady-ish state).
+    if (i > n_steps / 2) {
+      sum_removal += r.co2_removal_rate_kg_day;
+      ++sample_count;
+    }
+  }
+  csv.close();
+
+  const double mean_removal = (sample_count > 0) ? sum_removal / sample_count : 0.0;
+  const double design = fbs.design_co2_removal_kg_day();
+
+  std::cout << "=== ARS Validation (ICES-2021-313) ===\n";
+  std::cout << "Output CSV:            " << out_path << "\n";
+  std::cout << "Design CO2 removal:    " << design << " kg/day\n";
+  std::cout << "Mean transient removal:" << mean_removal << " kg/day\n";
+  std::cout << "Paper target band:     4.16 - 4.76 kg/day\n";
+  const bool in_band = (design >= 4.16 && design <= 4.76);
+  std::cout << "Design in band:        " << (in_band ? "YES" : "NO") << "\n";
+  return in_band ? 0 : 1;
+}

--- a/ssos_eclss/standalone/breakthrough_curve_gen.cpp
+++ b/ssos_eclss/standalone/breakthrough_curve_gen.cpp
@@ -1,0 +1,70 @@
+// Breakthrough-curve generator (no ROS). Drives a single fresh adsorbent bed
+// with a constant CO2 inlet and records the normalised outlet concentration
+// over time, producing the Figure 6 / Figure 12 style breakthrough curve.
+//
+// Usage: breakthrough_curve_gen [output.csv] [duration_min]
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+#include "ssos_eclss/ars/adsorption_isotherm.hpp"
+#include "ssos_eclss/ars/bed_model.hpp"
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+int main(int argc, char ** argv)
+{
+  const std::string out_path = (argc > 1) ? argv[1] : "breakthrough_curve.csv";
+  const double duration_min = (argc > 2) ? std::atof(argv[2]) : 200.0;
+
+  BedGeometry geom = default_adsorbent_geometry();
+  geom.n_cells = 40;
+  TothIsotherm co2(default_co2_on_13x());
+  TothIsotherm h2o(default_h2o_on_13x());
+  BedModel bed(geom, default_adsorbent_thermal(), co2, h2o,
+               default_adsorbent_ldf(), /*is_desiccant=*/false);
+  bed.reset(units::celsius_to_kelvin(22.0));
+
+  const double inlet_pp_co2 = units::torr_to_pa(3.0);
+  const double inlet_t = units::celsius_to_kelvin(22.0);
+
+  BedInlet in{};
+  in.temperature_k = inlet_t;
+  in.pressure_pa = units::torr_to_pa(760.0);
+  in.velocity_superficial = 0.4;
+  in.c_co2 = gas::concentration_from_pp(inlet_pp_co2, inlet_t);
+  in.c_h2o = 0.0;  // dry feed (downstream of desiccant)
+
+  std::ofstream csv(out_path);
+  csv << "time_min,outlet_co2_fraction,bed_loading_mol,mean_bed_temp_f\n";
+
+  const double dt = 2.0;
+  const int n_steps = static_cast<int>(duration_min * 60.0 / dt);
+  double breakthrough_min = -1.0;
+  for (int i = 0; i < n_steps; ++i) {
+    const BedOutputs out = bed.step(dt, in, BedMode::ADSORBING, 0.0);
+    const double frac = (in.c_co2 > 0.0) ? out.outlet_c_co2 / in.c_co2 : 0.0;
+    if (i % 10 == 0) {
+      csv << (i * dt / 60.0) << "," << frac << "," << out.co2_loading_mol << ","
+          << units::kelvin_to_fahrenheit(out.mean_solid_temp) << "\n";
+    }
+    // Record 5% breakthrough onset.
+    if (breakthrough_min < 0.0 && frac > 0.05) {
+      breakthrough_min = i * dt / 60.0;
+    }
+  }
+  csv.close();
+
+  std::cout << "=== Breakthrough Curve ===\n";
+  std::cout << "Output CSV:        " << out_path << "\n";
+  std::cout << "5% breakthrough:   "
+            << (breakthrough_min >= 0.0 ? std::to_string(breakthrough_min) + " min"
+                                        : "not reached")
+            << "\n";
+  std::cout << "Paper onset (ref): ~140-145 min\n";
+  return 0;
+}

--- a/ssos_eclss/standalone/parameter_sweep.cpp
+++ b/ssos_eclss/standalone/parameter_sweep.cpp
@@ -1,0 +1,75 @@
+// ARS parameter-sweep workbench (no ROS). Reproduces the paper's sensitivity
+// studies by sweeping ppCO2, process flow, half-cycle time and LTL coolant
+// temperature, reporting the resulting design-point CO2 removal and efficiency.
+//
+// Usage: parameter_sweep [output.csv]
+
+#include <fstream>
+#include <iostream>
+
+#include "ssos_eclss/ars/four_bed_system.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+
+namespace
+{
+double removal_for(const ars::ArsParameters & p)
+{
+  ars::FourBedSystem fbs(p);
+  return fbs.design_co2_removal_kg_day();
+}
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  const std::string out_path = (argc > 1) ? argv[1] : "parameter_sweep.csv";
+  std::ofstream csv(out_path);
+  csv << "parameter,value,co2_removal_kg_day,capture_efficiency\n";
+
+  const ars::ArsParameters base = ars::default_ars_parameters();
+
+  std::cout << "=== ARS Parameter Sweep ===\n";
+
+  // Sweep ppCO2 [torr].
+  for (double ppco2 = 1.0; ppco2 <= 4.0; ppco2 += 0.5) {
+    ars::ArsParameters p = base;
+    p.operating.inlet_ppco2_torr = ppco2;
+    const double rem = removal_for(p);
+    csv << "ppco2_torr," << ppco2 << "," << rem << ","
+        << p.efficiency.capture_efficiency << "\n";
+    std::cout << "ppCO2 = " << ppco2 << " torr -> " << rem << " kg/day\n";
+  }
+
+  // Sweep process flow [SCFM].
+  for (double scfm = 14.0; scfm <= 34.0; scfm += 4.0) {
+    ars::ArsParameters p = base;
+    p.operating.inlet_flow_scfm = scfm;
+    const double rem = removal_for(p);
+    csv << "flow_scfm," << scfm << "," << rem << ","
+        << p.efficiency.capture_efficiency << "\n";
+    std::cout << "flow  = " << scfm << " SCFM -> " << rem << " kg/day\n";
+  }
+
+  // Sweep half-cycle adsorb time [min].
+  for (double adsorb_min = 40.0; adsorb_min <= 80.0; adsorb_min += 10.0) {
+    ars::ArsParameters p = base;
+    p.cycle.adsorb_s = adsorb_min * units::SECONDS_PER_MINUTE;
+    const double rem = removal_for(p);
+    csv << "adsorb_min," << adsorb_min << "," << rem << ","
+        << p.efficiency.capture_efficiency << "\n";
+  }
+
+  // Sweep LTL coolant temperature [C].
+  for (double ltl_c = 4.0; ltl_c <= 16.0; ltl_c += 3.0) {
+    ars::ArsParameters p = base;
+    p.operating.ltl_inlet_temp_k = units::celsius_to_kelvin(ltl_c);
+    const double rem = removal_for(p);
+    csv << "ltl_temp_c," << ltl_c << "," << rem << ","
+        << p.efficiency.capture_efficiency << "\n";
+  }
+
+  csv.close();
+  std::cout << "Wrote " << out_path << "\n";
+  return 0;
+}

--- a/ssos_eclss/test/integration/test_ars_closed_loop.cpp
+++ b/ssos_eclss/test/integration/test_ars_closed_loop.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/four_bed_system.hpp"
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+#include "ssos_eclss/cabin/crew_metabolic_model.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+
+// Closed loop: crew add CO2 to the cabin, the ARS scrubs it out. Verify the ARS
+// removes CO2 and the cabin ppCO2 stays bounded (does not run away).
+TEST(ArsClosedLoop, RemovesCrewCO2)
+{
+  cabin::CabinParams cp{};
+  cp.volume_m3 = 90.0;
+  cp.temperature_k = units::celsius_to_kelvin(22.0);
+  cabin::CabinAtmosphere atm(cp);
+  atm.initialize_nominal(3000.0, 0.40);  // start somewhat elevated
+
+  cabin::CrewMetabolicModel crew(3, cabin::default_crew_profile());
+
+  // Coarse, fast ARS configuration.
+  ars::ArsParameters p = ars::default_ars_parameters();
+  p.desiccant_bed.n_cells = 8;
+  p.adsorbent_bed.n_cells = 8;
+  ars::FourBedSystem fbs(p);
+
+  const double dt = 2.0;
+  const double co2_ppm_start = atm.co2_ppm();
+  double total_removed_kg = 0.0;
+
+  for (int i = 0; i < 600; ++i) {  // 1200 s
+    ars::CabinConditions cc{};
+    cc.co2_partial_pressure_pa = atm.partial_pressure_pa(cabin::Gas::CO2);
+    cc.h2o_partial_pressure_pa = atm.partial_pressure_pa(cabin::Gas::H2O);
+    cc.temperature_k = atm.temperature_k();
+    cc.total_pressure_pa = atm.total_pressure_pa();
+
+    ars::ArsResult r = fbs.step(dt, cc);
+    total_removed_kg += r.co2_removal_rate_kg_s * dt;
+
+    const cabin::MetabolicLoads m = crew.loads(1.0);
+    cabin::GasFlows f{};
+    f.co2 = m.flows.co2 - r.co2_removal_rate_kg_s / units::M_CO2;
+    f.o2 = m.flows.o2;
+    f.h2o = m.flows.h2o;
+    atm.apply_flows(dt, f);
+  }
+
+  EXPECT_GT(total_removed_kg, 0.0);
+  // CO2 should not have run away (ARS keeps it bounded / falling).
+  EXPECT_LT(atm.co2_ppm(), co2_ppm_start + 2000.0);
+}

--- a/ssos_eclss/test/integration/test_eclss_mass_balance.cpp
+++ b/ssos_eclss/test/integration/test_eclss_mass_balance.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+#include "ssos_eclss/cabin/crew_metabolic_model.hpp"
+#include "ssos_eclss/cabin/leak_model.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::cabin;
+
+// Mass conservation is mandatory for a life-support model. This test runs the
+// cabin under crew CO2 production, ARS-style CO2 removal and leakage, and
+// verifies the CO2 budget closes exactly:
+//   CO2_in = CO2_accumulated + CO2_removed + CO2_leaked.
+TEST(EclssMassBalance, CO2BudgetCloses)
+{
+  CabinParams cp{};
+  cp.volume_m3 = 100.0;
+  cp.temperature_k = units::celsius_to_kelvin(22.0);
+  CabinAtmosphere atm(cp);
+
+  CrewMetabolicModel crew(4, default_crew_profile());
+
+  LeakParams lp{};
+  lp.nominal_area_m2 = 1.0e-7;
+  lp.discharge_coeff = 0.62;
+  LeakModel leak(lp);
+
+  // Constant ARS CO2 removal sink [mol/s] (design point).
+  const double ars_removal_mol_s = units::kg_per_day_to_kg_per_s(4.3) / units::M_CO2;
+
+  const double co2_initial = atm.moles(Gas::CO2);
+  double co2_in = 0.0, co2_removed = 0.0, co2_leaked = 0.0;
+
+  const double dt = 1.0;
+  for (int i = 0; i < 3600; ++i) {  // 1 hour
+    const MetabolicLoads m = crew.loads(1.0);
+    const GasFlows lk = leak.leak_flows(atm);
+
+    GasFlows total{};
+    total.o2 = m.flows.o2 + lk.o2;
+    total.co2 = m.flows.co2 - ars_removal_mol_s + lk.co2;
+    total.n2 = lk.n2;
+    total.h2o = m.flows.h2o + lk.h2o;
+
+    co2_in += m.flows.co2 * dt;
+    co2_removed += ars_removal_mol_s * dt;
+    co2_leaked += -lk.co2 * dt;  // lk.co2 is negative (leaving)
+
+    atm.apply_flows(dt, total);
+  }
+
+  const double co2_accumulated = atm.moles(Gas::CO2) - co2_initial;
+  const double residual = co2_in - (co2_accumulated + co2_removed + co2_leaked);
+  // Should close to within floating-point round-off.
+  EXPECT_NEAR(residual, 0.0, 1.0e-6 * (co2_in + 1.0));
+}
+
+TEST(EclssMassBalance, TotalGasMassConservedWithoutSources)
+{
+  CabinParams cp{};
+  cp.volume_m3 = 100.0;
+  cp.temperature_k = units::celsius_to_kelvin(22.0);
+  CabinAtmosphere atm(cp);
+
+  const double m0 = atm.total_gas_mass_kg();
+  // No flows applied -> mass unchanged.
+  atm.apply_flows(100.0, GasFlows{});
+  EXPECT_NEAR(atm.total_gas_mass_kg(), m0, 1.0e-12);
+}
+
+TEST(EclssMassBalance, LeakReducesPressure)
+{
+  CabinParams cp{};
+  cp.volume_m3 = 100.0;
+  cp.temperature_k = units::celsius_to_kelvin(22.0);
+  CabinAtmosphere atm(cp);
+
+  LeakParams lp{};
+  lp.nominal_area_m2 = 1.0e-4;  // large leak
+  lp.discharge_coeff = 0.62;
+  LeakModel leak(lp);
+
+  const double p0 = atm.total_pressure_pa();
+  for (int i = 0; i < 600; ++i) {
+    atm.apply_flows(1.0, leak.leak_flows(atm));
+  }
+  EXPECT_LT(atm.total_pressure_pa(), p0);
+}

--- a/ssos_eclss/test/integration/test_four_bed_system.cpp
+++ b/ssos_eclss/test/integration/test_four_bed_system.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/four_bed_system.hpp"
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+namespace
+{
+CabinConditions nominal_cabin()
+{
+  CabinConditions c{};
+  c.co2_partial_pressure_pa = units::torr_to_pa(2.0);
+  c.h2o_partial_pressure_pa = gas::water_pp_from_rh(0.40, units::celsius_to_kelvin(22.0));
+  c.temperature_k = units::celsius_to_kelvin(22.0);
+  c.total_pressure_pa = units::torr_to_pa(760.0);
+  return c;
+}
+}  // namespace
+
+TEST(FourBedSystem, DesignRemovalMatchesPaper)
+{
+  FourBedSystem ars;
+  const double removal = ars.design_co2_removal_kg_day();
+  // ICES-2021-313: 4.16 - 4.76 kg/day at 2 torr, 26 SCFM.
+  EXPECT_GE(removal, 4.16);
+  EXPECT_LE(removal, 4.76);
+}
+
+TEST(FourBedSystem, FreshSystemRemovesCO2)
+{
+  FourBedSystem ars;
+  ars.reset(units::celsius_to_kelvin(22.0));
+  CabinConditions cabin = nominal_cabin();
+
+  ArsResult r{};
+  for (int i = 0; i < 60; ++i) {
+    r = ars.step(1.0, cabin);
+  }
+  // A fresh adsorbing bed scrubs CO2: removal positive and within the band.
+  EXPECT_GT(r.co2_removal_rate_kg_day, 0.0);
+  EXPECT_LE(r.co2_removal_rate_kg_day, 5.2);
+  // Return air is drier/cleaner than the cabin.
+  EXPECT_LT(r.scrubbed_co2_pp_pa, cabin.co2_partial_pressure_pa);
+}
+
+TEST(FourBedSystem, PressureDropInRange)
+{
+  FourBedSystem ars;
+  CabinConditions cabin = nominal_cabin();
+  ArsResult r = ars.step(1.0, cabin);
+  const double dp_in_h2o = units::pa_to_in_h2o(r.system_pressure_drop_pa);
+  // System dP order of magnitude check (paper ~37-40 in-H2O total path;
+  // bed-only component is a fraction of that).
+  EXPECT_GT(dp_in_h2o, 0.0);
+  EXPECT_LT(dp_in_h2o, 200.0);
+}
+
+TEST(FourBedSystem, RegeneratingBedHeatsUp)
+{
+  // Use a coarse, short-cycle configuration so the desorb heaters act quickly
+  // (keeps the transient cheap; the physics is identical to the 50-cell case).
+  ArsParameters p = default_ars_parameters();
+  p.desiccant_bed.n_cells = 10;
+  p.adsorbent_bed.n_cells = 10;
+  p.cycle.air_save_s = 60.0;
+  p.cycle.adsorb_s = 300.0;
+  p.cycle.vacuum_s = 60.0;
+  FourBedSystem ars(p);
+  ars.reset(units::celsius_to_kelvin(22.0));
+  CabinConditions cabin = nominal_cabin();
+
+  const double t0 = ars.adsorbent_bed(1).mean_solid_temperature();
+  for (int i = 0; i < 150; ++i) {
+    ars.step(2.0, cabin);  // 300 s -> through air-save into desorb
+  }
+  EXPECT_GT(ars.adsorbent_bed(1).mean_solid_temperature(), t0 + 20.0);
+}
+
+TEST(FourBedSystem, BlowerFlowNearDesign)
+{
+  FourBedSystem ars;
+  CabinConditions cabin = nominal_cabin();
+  ArsResult r = ars.step(1.0, cabin);
+  EXPECT_NEAR(r.blower_flow_scfm, 26.0, 3.0);
+}
+
+TEST(FourBedSystem, PrecoolerExitCool)
+{
+  FourBedSystem ars;
+  CabinConditions cabin = nominal_cabin();
+  ArsResult r = ars.step(1.0, cabin);
+  // Precooler exit below cabin and above LTL inlet (7 C).
+  EXPECT_LT(r.precooler_exit_temp_k, cabin.temperature_k);
+  EXPECT_GT(r.precooler_exit_temp_k, units::celsius_to_kelvin(6.0));
+}

--- a/ssos_eclss/test/ros/test_ars_node.cpp
+++ b/ssos_eclss/test/ros/test_ars_node.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "rclcpp/rclcpp.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include "ssos_eclss/nodes/ars_node.hpp"
+
+using namespace ssos_eclss::nodes;
+using namespace std::chrono_literals;
+
+class ArsNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    node_ = std::make_shared<ArsNode>();
+  }
+
+  void spin_for(std::chrono::milliseconds d)
+  {
+    rclcpp::executors::SingleThreadedExecutor exec;
+    exec.add_node(node_->get_node_base_interface());
+    const auto end = std::chrono::steady_clock::now() + d;
+    while (std::chrono::steady_clock::now() < end && rclcpp::ok()) {
+      exec.spin_some();
+      std::this_thread::sleep_for(5ms);
+    }
+  }
+
+  std::shared_ptr<ArsNode> node_;
+};
+
+TEST_F(ArsNodeTest, ConfigureActivateDeactivateCleanup)
+{
+  using lifecycle_msgs::msg::State;
+  // Fast step rate so the timer fires several times within the spin window.
+  node_->set_parameter(rclcpp::Parameter("step_rate_hz", 30.0));
+  EXPECT_EQ(node_->configure().id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->activate().id(), State::PRIMARY_STATE_ACTIVE);
+  // Let the step timer run several cycles.
+  spin_for(500ms);
+  EXPECT_GT(node_->last_co2_removal_kg_day(), 0.0);
+  EXPECT_EQ(node_->deactivate().id(), State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->cleanup().id(), State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+TEST_F(ArsNodeTest, RejectsInvalidParameterWhileConfigured)
+{
+  node_->configure();
+  // Toth exponent out of range must be rejected by the set-parameters callback.
+  const auto results =
+    node_->set_parameters({rclcpp::Parameter("ars.isotherm.co2_13x.t0", 2.0)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_FALSE(results[0].successful);
+}
+
+TEST_F(ArsNodeTest, AcceptsValidDynamicParameter)
+{
+  node_->configure();
+  const auto results =
+    node_->set_parameters({rclcpp::Parameter("ars.heater.total_power_w", 800.0)});
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_TRUE(results[0].successful);
+  EXPECT_NEAR(node_->get_parameter("ars.heater.total_power_w").as_double(), 800.0, 1e-9);
+}

--- a/ssos_eclss/test/ros/test_parameter_bridge.cpp
+++ b/ssos_eclss/test/ros/test_parameter_bridge.cpp
@@ -1,0 +1,96 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "ssos_eclss/nodes/eclss_parameter_bridge.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::nodes;
+
+class ParameterBridgeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>("bridge_test_node");
+    bridge_ = std::make_unique<EclssParameterBridge>(node_.get());
+    bridge_->declare_ars_parameters(ars::default_ars_parameters());
+  }
+
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
+  std::unique_ptr<EclssParameterBridge> bridge_;
+};
+
+TEST_F(ParameterBridgeTest, DeclaresAndReadsDefaults)
+{
+  const ars::ArsParameters p = bridge_->read_ars_parameters();
+  const ars::ArsParameters d = ars::default_ars_parameters();
+  EXPECT_NEAR(p.heater.total_power_w, d.heater.total_power_w, 1.0e-9);
+  EXPECT_NEAR(p.operating.inlet_flow_scfm, d.operating.inlet_flow_scfm, 1.0e-9);
+  EXPECT_EQ(p.adsorbent_bed.n_cells, d.adsorbent_bed.n_cells);
+}
+
+TEST_F(ParameterBridgeTest, ReadsOverriddenValue)
+{
+  node_->set_parameter(rclcpp::Parameter("ars.heater.total_power_w", 850.0));
+  const ars::ArsParameters p = bridge_->read_ars_parameters();
+  EXPECT_NEAR(p.heater.total_power_w, 850.0, 1.0e-9);
+}
+
+TEST_F(ParameterBridgeTest, ValidatesTothExponentRange)
+{
+  // Valid t0 accepted.
+  auto ok = bridge_->validate({rclcpp::Parameter("ars.isotherm.co2_13x.t0", 0.5)});
+  EXPECT_TRUE(ok.successful);
+  // t0 > 1 rejected.
+  auto bad = bridge_->validate({rclcpp::Parameter("ars.isotherm.co2_13x.t0", 1.5)});
+  EXPECT_FALSE(bad.successful);
+  EXPECT_FALSE(bad.reason.empty());
+  // t0 <= 0 rejected.
+  auto bad2 = bridge_->validate({rclcpp::Parameter("ars.isotherm.co2_13x.t0", 0.0)});
+  EXPECT_FALSE(bad2.successful);
+}
+
+TEST_F(ParameterBridgeTest, ValidatesVoidageRange)
+{
+  EXPECT_FALSE(
+    bridge_->validate({rclcpp::Parameter("ars.bed.adsorbent.voidage", 1.5)}).successful);
+  EXPECT_TRUE(
+    bridge_->validate({rclcpp::Parameter("ars.bed.adsorbent.voidage", 0.4)}).successful);
+}
+
+TEST_F(ParameterBridgeTest, ValidatesNonNegativeFlow)
+{
+  EXPECT_FALSE(
+    bridge_->validate({rclcpp::Parameter("ars.operating.inlet_flow_scfm", -1.0)})
+      .successful);
+}
+
+TEST_F(ParameterBridgeTest, ValidatesTemperaturePositive)
+{
+  EXPECT_FALSE(
+    bridge_->validate({rclcpp::Parameter("ars.operating.cabin_temp_k", -5.0)})
+      .successful);
+}
+
+TEST_F(ParameterBridgeTest, EfficiencyBoundedToUnitInterval)
+{
+  EXPECT_FALSE(
+    bridge_->validate({rclcpp::Parameter("ars.efficiency.capture_efficiency", 1.4)})
+      .successful);
+  EXPECT_TRUE(
+    bridge_->validate({rclcpp::Parameter("ars.efficiency.capture_efficiency", 0.84)})
+      .successful);
+}
+
+TEST_F(ParameterBridgeTest, StaticParameterClassification)
+{
+  EXPECT_TRUE(EclssParameterBridge::is_static_parameter("ars.bed.adsorbent.length"));
+  EXPECT_FALSE(EclssParameterBridge::is_static_parameter("ars.heater.total_power_w"));
+}

--- a/ssos_eclss/test/unit/ars/test_bed_model.cpp
+++ b/ssos_eclss/test/unit/ars/test_bed_model.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/adsorption_isotherm.hpp"
+#include "ssos_eclss/ars/bed_model.hpp"
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+namespace
+{
+BedModel make_adsorbent_bed()
+{
+  BedGeometry g = default_adsorbent_geometry();
+  g.n_cells = 30;  // keep tests fast
+  TothIsotherm co2(default_co2_on_13x());
+  TothIsotherm h2o(default_h2o_on_13x());
+  return BedModel(g, default_adsorbent_thermal(), co2, h2o,
+                  default_adsorbent_ldf(), /*is_desiccant=*/false);
+}
+
+BedInlet make_inlet()
+{
+  BedInlet in{};
+  in.temperature_k = 295.0;
+  in.pressure_pa = units::torr_to_pa(760.0);
+  in.velocity_superficial = 0.4;
+  in.c_co2 = gas::concentration_from_pp(units::torr_to_pa(3.0), 295.0);
+  in.c_h2o = 0.0;  // dry (downstream of desiccant)
+  return in;
+}
+}  // namespace
+
+TEST(BedModel, FreshBedAdsorbsCO2)
+{
+  BedModel bed = make_adsorbent_bed();
+  bed.reset(295.0);
+  BedInlet in = make_inlet();
+
+  // Run a short transient.
+  BedOutputs out{};
+  for (int i = 0; i < 20; ++i) {
+    out = bed.step(1.0, in, BedMode::ADSORBING, 0.0);
+  }
+  // A fresh bed should remove most CO2: outlet < inlet.
+  EXPECT_LT(out.outlet_c_co2, in.c_co2);
+  // And it should be accumulating CO2.
+  EXPECT_GT(bed.total_co2_loading_mol(), 0.0);
+}
+
+TEST(BedModel, CaptureRateNonNegative)
+{
+  BedModel bed = make_adsorbent_bed();
+  bed.reset(295.0);
+  BedInlet in = make_inlet();
+  BedOutputs out = bed.step(1.0, in, BedMode::ADSORBING, 0.0);
+  EXPECT_GE(out.co2_capture_rate, 0.0);
+}
+
+TEST(BedModel, HeaterRaisesBedTemperature)
+{
+  BedModel bed = make_adsorbent_bed();
+  bed.reset(295.0);
+  const double t0 = bed.mean_solid_temperature();
+
+  BedInlet in = make_inlet();
+  in.velocity_superficial = 0.0;
+  in.pressure_pa = units::torr_to_pa(2.0);
+  for (int i = 0; i < 300; ++i) {
+    bed.step(2.0, in, BedMode::DESORBING, 700.0);
+  }
+  EXPECT_GT(bed.mean_solid_temperature(), t0 + 50.0);
+}
+
+TEST(BedModel, DesorptionRemovesLoading)
+{
+  BedModel bed = make_adsorbent_bed();
+  bed.equilibrate(units::torr_to_pa(3.0), 0.0, 295.0);
+  const double loaded = bed.total_co2_loading_mol();
+  EXPECT_GT(loaded, 0.0);
+
+  BedInlet in = make_inlet();
+  in.velocity_superficial = 0.0;
+  in.pressure_pa = units::torr_to_pa(2.0);
+  for (int i = 0; i < 400; ++i) {
+    bed.step(2.0, in, BedMode::DESORBING, 700.0);
+  }
+  // Regeneration should drive loading well below the adsorbed level.
+  EXPECT_LT(bed.total_co2_loading_mol(), 0.5 * loaded);
+}
+
+TEST(BedModel, PressureDropPositiveWhenFlowing)
+{
+  BedModel bed = make_adsorbent_bed();
+  BedInlet in = make_inlet();
+  BedOutputs out = bed.step(1.0, in, BedMode::ADSORBING, 0.0);
+  EXPECT_GT(out.pressure_drop_pa, 0.0);
+}
+
+TEST(BedModel, MassNotCreatedFromNothing)
+{
+  // With zero inlet CO2 and a clean bed, no CO2 may appear.
+  BedModel bed = make_adsorbent_bed();
+  bed.reset(295.0);
+  BedInlet in = make_inlet();
+  in.c_co2 = 0.0;
+  for (int i = 0; i < 10; ++i) {
+    bed.step(1.0, in, BedMode::ADSORBING, 0.0);
+  }
+  EXPECT_NEAR(bed.total_co2_loading_mol(), 0.0, 1.0e-9);
+}

--- a/ssos_eclss/test/unit/ars/test_blower.cpp
+++ b/ssos_eclss/test/unit/ars/test_blower.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/blower_model.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+namespace
+{
+BlowerParams make_params(double q_design)
+{
+  BlowerParams p{};
+  p.rated_rpm = 12000.0;
+  p.shutoff_dp = 2.0 * units::in_h2o_to_pa(40.0);
+  p.max_rpm = 18000.0;
+  p.curve_quad = units::in_h2o_to_pa(40.0) / (q_design * q_design);
+  return p;
+}
+}  // namespace
+
+TEST(Blower, ConstantFlowDeliversSetpoint)
+{
+  const double q_design = units::scfm_to_m3s(26.0);
+  BlowerModel b(make_params(q_design));
+  // System resistance giving ~40 in-H2O at design flow.
+  const double r = units::in_h2o_to_pa(40.0) / (q_design * q_design);
+  BlowerResult res = b.solve(r, BlowerControl::CONSTANT_FLOW, q_design);
+  EXPECT_NEAR(res.flow_m3s, q_design, 1.0e-9);
+  EXPECT_GT(res.delta_p, 0.0);
+}
+
+TEST(Blower, OperatingHeadInExpectedRange)
+{
+  const double q_design = units::scfm_to_m3s(26.0);
+  BlowerModel b(make_params(q_design));
+  const double r = units::in_h2o_to_pa(38.0) / (q_design * q_design);
+  BlowerResult res = b.solve(r, BlowerControl::CONSTANT_RPM, 12000.0);
+  const double head_in_h2o = units::pa_to_in_h2o(res.delta_p);
+  // Target ~37-40 in-H2O.
+  EXPECT_GT(head_in_h2o, 15.0);
+  EXPECT_LT(head_in_h2o, 60.0);
+}
+
+TEST(Blower, HigherResistanceLowersFlow)
+{
+  const double q_design = units::scfm_to_m3s(26.0);
+  BlowerModel b(make_params(q_design));
+  const double r_low = units::in_h2o_to_pa(20.0) / (q_design * q_design);
+  const double r_high = units::in_h2o_to_pa(80.0) / (q_design * q_design);
+  BlowerResult low = b.solve(r_low, BlowerControl::CONSTANT_RPM, 12000.0);
+  BlowerResult high = b.solve(r_high, BlowerControl::CONSTANT_RPM, 12000.0);
+  EXPECT_GT(low.flow_m3s, high.flow_m3s);
+}
+
+TEST(Blower, PowerPositive)
+{
+  const double q_design = units::scfm_to_m3s(26.0);
+  BlowerModel b(make_params(q_design));
+  const double r = units::in_h2o_to_pa(40.0) / (q_design * q_design);
+  BlowerResult res = b.solve(r, BlowerControl::CONSTANT_FLOW, q_design);
+  EXPECT_GT(res.power_w, 0.0);
+}

--- a/ssos_eclss/test/unit/ars/test_cycle_state_machine.cpp
+++ b/ssos_eclss/test/unit/ars/test_cycle_state_machine.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/cycle_state_machine.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+TEST(CycleStateMachine, StartsWithTrain0Adsorbing)
+{
+  CycleStateMachine sm(default_cycle_timing(), default_heater());
+  EXPECT_EQ(sm.adsorbing_train(), 0);
+  EXPECT_EQ(sm.regenerating_train(), 1);
+}
+
+TEST(CycleStateMachine, SwapsAtHalfCycle)
+{
+  CycleTiming t = default_cycle_timing();
+  CycleStateMachine sm(t, default_heater());
+  // Advance just past one half cycle.
+  sm.update(t.half_cycle_s() + 1.0);
+  EXPECT_EQ(sm.adsorbing_train(), 1);
+  EXPECT_EQ(sm.half_cycle_count(), 1);
+}
+
+TEST(CycleStateMachine, RegenPhaseSequence)
+{
+  CycleTiming t = default_cycle_timing();
+  CycleStateMachine sm(t, default_heater());
+
+  EXPECT_EQ(sm.regen_phase(), RegenPhase::AIR_SAVE);
+  sm.update(t.air_save_s + 1.0);
+  EXPECT_EQ(sm.regen_phase(), RegenPhase::DESORB);
+  sm.update(t.adsorb_s);
+  EXPECT_EQ(sm.regen_phase(), RegenPhase::VACUUM);
+}
+
+TEST(CycleStateMachine, AdsorbingTrainHasNoHeat)
+{
+  CycleStateMachine sm(default_cycle_timing(), default_heater());
+  TrainCommand cmd = sm.command_for_train(sm.adsorbing_train());
+  EXPECT_EQ(cmd.adsorbent_mode, BedMode::ADSORBING);
+  EXPECT_EQ(cmd.adsorbent_heater_w, 0.0);
+}
+
+TEST(CycleStateMachine, DesorbUsesFullHeaterPower)
+{
+  CycleTiming t = default_cycle_timing();
+  HeaterParams h = default_heater();
+  CycleStateMachine sm(t, h);
+  // Advance into the desorb phase.
+  sm.update(t.air_save_s + 10.0);
+  TrainCommand cmd = sm.command_for_train(sm.regenerating_train());
+  EXPECT_EQ(cmd.adsorbent_mode, BedMode::DESORBING);
+  EXPECT_NEAR(cmd.adsorbent_heater_w, h.total_power_w, 1.0e-6);
+}
+
+TEST(CycleStateMachine, AirSaveUsesCentralHeaters)
+{
+  HeaterParams h = default_heater();
+  CycleStateMachine sm(default_cycle_timing(), h);
+  TrainCommand cmd = sm.command_for_train(sm.regenerating_train());
+  EXPECT_EQ(cmd.adsorbent_mode, BedMode::AIR_SAVE);
+  EXPECT_NEAR(cmd.adsorbent_heater_w, h.central_power_w, 1.0e-6);
+  EXPECT_LT(cmd.adsorbent_heater_w, h.total_power_w);
+}

--- a/ssos_eclss/test/unit/ars/test_isotherm.cpp
+++ b/ssos_eclss/test/unit/ars/test_isotherm.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/adsorption_isotherm.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+TEST(Isotherm, LoadingMonotonicInPressure)
+{
+  TothIsotherm iso(default_co2_on_13x());
+  const double t = 298.15;
+  double prev = 0.0;
+  for (double torr = 0.1; torr < 10.0; torr += 0.5) {
+    const double q = iso.loading(units::torr_to_pa(torr), t);
+    EXPECT_GT(q, prev);
+    prev = q;
+  }
+}
+
+TEST(Isotherm, LoadingDecreasesWithTemperature)
+{
+  TothIsotherm iso(default_co2_on_13x());
+  const double pp = units::torr_to_pa(3.0);
+  EXPECT_GT(iso.loading(pp, 280.0), iso.loading(pp, 360.0));
+}
+
+TEST(Isotherm, ZeroPressureZeroLoading)
+{
+  TothIsotherm iso(default_co2_on_13x());
+  EXPECT_NEAR(iso.loading(0.0, 298.15), 0.0, 1.0e-12);
+}
+
+TEST(Isotherm, AnalyticDerivativeMatchesNumeric)
+{
+  TothIsotherm iso(default_co2_on_13x());
+  const double t = 298.15;
+  const double pp = units::torr_to_pa(2.0);
+  const double h = 1.0;  // Pa
+  const double numeric = (iso.loading(pp + h, t) - iso.loading(pp - h, t)) / (2.0 * h);
+  EXPECT_NEAR(iso.dloading_dp(pp, t), numeric, 1.0e-3 * std::abs(numeric) + 1.0e-9);
+}
+
+TEST(Isotherm, ExponentClampedToUnitInterval)
+{
+  TothIsotherm iso(default_co2_on_13x());
+  for (double t = 200.0; t < 600.0; t += 25.0) {
+    const double e = iso.exponent(t);
+    EXPECT_GT(e, 0.0);
+    EXPECT_LE(e, 1.0);
+  }
+}
+
+TEST(Isotherm, WaterSuppressesCO2Loading)
+{
+  TothIsotherm co2(default_co2_on_13x());
+  TothIsotherm h2o(default_h2o_on_13x());
+  const double t = 298.15;
+  const double pp_co2 = units::torr_to_pa(3.0);
+
+  const auto dry = competitive_loading(co2, h2o, pp_co2, 0.0, t);
+  const auto wet = competitive_loading(co2, h2o, pp_co2, units::torr_to_pa(8.0), t);
+
+  // Water present strongly reduces CO2 capacity.
+  EXPECT_LT(wet.q_co2, dry.q_co2);
+  EXPECT_GT(wet.q_h2o, 0.0);
+}
+
+TEST(Isotherm, HeatOfAdsorptionPositive)
+{
+  TothIsotherm iso(default_co2_on_13x());
+  EXPECT_GT(iso.heat_of_adsorption(), 0.0);
+}

--- a/ssos_eclss/test/unit/ars/test_precooler.cpp
+++ b/ssos_eclss/test/unit/ars/test_precooler.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/precooler_model.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+namespace
+{
+PrecoolerParams make_params()
+{
+  PrecoolerParams p{};
+  p.air_mass_flow = 0.015;   // kg/s
+  p.coolant_mass_flow = 0.026;  // kg/s (~0.42 gpm water)
+  p.air_cp = 1006.0;
+  p.coolant_cp = 4180.0;
+  p.ua = 30.0;  // W/K
+  return p;
+}
+}  // namespace
+
+TEST(Precooler, CoolsTheAir)
+{
+  PrecoolerModel pc(make_params());
+  const double air_in = units::celsius_to_kelvin(25.0);
+  const double cool_in = units::celsius_to_kelvin(7.0);
+  PrecoolerResult r = pc.solve(air_in, cool_in);
+  EXPECT_LT(r.air_outlet_temp, air_in);
+  EXPECT_GT(r.air_outlet_temp, cool_in);
+  EXPECT_GT(r.heat_duty, 0.0);
+}
+
+TEST(Precooler, ExitApproachesCoolantInletAtHighUA)
+{
+  PrecoolerParams p = make_params();
+  p.ua = 2000.0;  // very high conductance
+  PrecoolerModel pc(p);
+  const double cool_in = units::celsius_to_kelvin(7.0);
+  PrecoolerResult r = pc.solve(units::celsius_to_kelvin(25.0), cool_in);
+  // Within ~6.5 F (~3.6 K) of the LTL water inlet (paper Fig 20).
+  EXPECT_NEAR(r.air_outlet_temp, cool_in, units::fahrenheit_to_kelvin(32.0 + 6.5) -
+                                          units::fahrenheit_to_kelvin(32.0));
+}
+
+TEST(Precooler, EffectivenessBounded)
+{
+  PrecoolerModel pc(make_params());
+  PrecoolerResult r = pc.solve(300.0, 280.0);
+  EXPECT_GE(r.effectiveness, 0.0);
+  EXPECT_LE(r.effectiveness, 1.0);
+}
+
+TEST(Precooler, EnergyBalanceConsistent)
+{
+  PrecoolerParams p = make_params();
+  PrecoolerModel pc(p);
+  PrecoolerResult r = pc.solve(300.0, 280.0);
+  const double q_air = p.air_mass_flow * p.air_cp * (300.0 - r.air_outlet_temp);
+  const double q_cool = p.coolant_mass_flow * p.coolant_cp *
+                        (r.coolant_outlet_temp - 280.0);
+  EXPECT_NEAR(q_air, q_cool, 1.0e-6 * std::abs(q_air) + 1.0e-6);
+  EXPECT_NEAR(q_air, r.heat_duty, 1.0e-6 * std::abs(q_air) + 1.0e-6);
+}

--- a/ssos_eclss/test/unit/ars/test_valve.cpp
+++ b/ssos_eclss/test/unit/ars/test_valve.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/ars/valve_model.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ars;
+
+namespace
+{
+ValveModel make_valve()
+{
+  ValveParams p{};
+  p.cv = 1.0e-4;
+  p.stroke_time_s = 2.0;
+  p.repress_time_s = 5.0;
+  return ValveModel(p);
+}
+}  // namespace
+
+TEST(Valve, SlewsTowardCommand)
+{
+  ValveModel v = make_valve();
+  v.command(1.0);
+  EXPECT_NEAR(v.position(), 0.0, 1.0e-9);
+  for (int i = 0; i < 5; ++i) {
+    v.update(0.5);
+  }
+  EXPECT_NEAR(v.position(), 1.0, 1.0e-9);
+}
+
+TEST(Valve, FlowScalesWithPosition)
+{
+  ValveModel v = make_valve();
+  v.command(1.0);
+  v.update(10.0);  // fully open
+  const double q_open = v.flow(1000.0);
+  EXPECT_GT(q_open, 0.0);
+  // Closed valve passes nothing.
+  ValveModel closed = make_valve();
+  EXPECT_NEAR(closed.flow(1000.0), 0.0, 1.0e-12);
+}
+
+TEST(Valve, FlowReversesWithPressure)
+{
+  ValveModel v = make_valve();
+  v.command(1.0);
+  v.update(10.0);
+  EXPECT_GT(v.flow(1000.0), 0.0);
+  EXPECT_LT(v.flow(-1000.0), 0.0);
+}
+
+TEST(Valve, RepressurizationReaches800Torr)
+{
+  ValveModel v = make_valve();
+  const double target = units::torr_to_pa(800.0);
+  double p = 0.0;
+  // ~3 time constants (15 s) should fill to >95%.
+  for (int i = 0; i < 30; ++i) {
+    p = v.repressurize(0.5, p, target);
+  }
+  EXPECT_GT(p, 0.95 * target);
+  EXPECT_LE(p, target + 1.0);
+}

--- a/ssos_eclss/test/unit/cabin/test_cabin_atmosphere.cpp
+++ b/ssos_eclss/test/unit/cabin/test_cabin_atmosphere.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/cabin/cabin_atmosphere.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::cabin;
+
+namespace
+{
+CabinAtmosphere make_cabin()
+{
+  CabinParams p{};
+  p.volume_m3 = 100.0;
+  p.temperature_k = units::celsius_to_kelvin(22.0);
+  return CabinAtmosphere(p);
+}
+}  // namespace
+
+TEST(CabinAtmosphere, NominalCompositionReasonable)
+{
+  CabinAtmosphere atm = make_cabin();
+  EXPECT_NEAR(atm.total_pressure_pa(), units::STD_PRESSURE_PA, 200.0);
+  EXPECT_NEAR(atm.o2_fraction(), 0.21, 0.02);
+  EXPECT_GT(atm.co2_ppm(), 0.0);
+  EXPECT_LT(atm.co2_ppm(), 5000.0);
+}
+
+TEST(CabinAtmosphere, CO2ProductionRaisesPP)
+{
+  CabinAtmosphere atm = make_cabin();
+  const double pp0 = atm.partial_pressure_pa(Gas::CO2);
+  GasFlows f{};
+  f.co2 = 1.0e-3;  // mol/s into cabin
+  atm.apply_flows(60.0, f);
+  EXPECT_GT(atm.partial_pressure_pa(Gas::CO2), pp0);
+}
+
+TEST(CabinAtmosphere, CO2RemovalLowersPP)
+{
+  CabinAtmosphere atm = make_cabin();
+  const double pp0 = atm.partial_pressure_pa(Gas::CO2);
+  GasFlows f{};
+  f.co2 = -1.0e-4;  // mol/s out of cabin
+  atm.apply_flows(60.0, f);
+  EXPECT_LT(atm.partial_pressure_pa(Gas::CO2), pp0);
+}
+
+TEST(CabinAtmosphere, MolesNeverNegative)
+{
+  CabinAtmosphere atm = make_cabin();
+  GasFlows f{};
+  f.co2 = -1.0e9;  // absurd sink
+  atm.apply_flows(1.0, f);
+  EXPECT_GE(atm.moles(Gas::CO2), 0.0);
+}
+
+TEST(CabinAtmosphere, MoleConservationOnAddRemove)
+{
+  CabinAtmosphere atm = make_cabin();
+  const double n0 = atm.moles(Gas::O2);
+  atm.add_moles(Gas::O2, 5.0);
+  EXPECT_NEAR(atm.moles(Gas::O2), n0 + 5.0, 1.0e-9);
+  atm.add_moles(Gas::O2, -2.0);
+  EXPECT_NEAR(atm.moles(Gas::O2), n0 + 3.0, 1.0e-9);
+}
+
+TEST(CabinAtmosphere, HumidityAndDewPointConsistent)
+{
+  CabinAtmosphere atm = make_cabin();
+  const double rh = atm.relative_humidity();
+  EXPECT_GT(rh, 0.0);
+  EXPECT_LT(rh, 1.0);
+  // Dew point must be below cabin temperature for sub-saturated air.
+  EXPECT_LT(atm.dew_point_k(), atm.temperature_k());
+}
+
+TEST(CabinAtmosphere, PartialPressuresSumToTotal)
+{
+  CabinAtmosphere atm = make_cabin();
+  const double sum = atm.partial_pressure_pa(Gas::O2) + atm.partial_pressure_pa(Gas::CO2) +
+                     atm.partial_pressure_pa(Gas::N2) + atm.partial_pressure_pa(Gas::H2O);
+  EXPECT_NEAR(sum, atm.total_pressure_pa(), 1.0e-6 * atm.total_pressure_pa());
+}

--- a/ssos_eclss/test/unit/cabin/test_crew_metabolic.cpp
+++ b/ssos_eclss/test/unit/cabin/test_crew_metabolic.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/cabin/crew_metabolic_model.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::cabin;
+
+TEST(CrewMetabolic, CO2ProducedO2Consumed)
+{
+  CrewMetabolicModel crew(4, default_crew_profile());
+  const MetabolicLoads l = crew.loads(1.0);
+  EXPECT_GT(l.flows.co2, 0.0);   // CO2 produced
+  EXPECT_LT(l.flows.o2, 0.0);    // O2 consumed
+  EXPECT_GT(l.flows.h2o, 0.0);   // water produced
+  EXPECT_GT(l.heat_w, 0.0);
+}
+
+TEST(CrewMetabolic, ScalesWithCrewSize)
+{
+  CrewMetabolicModel one(1, default_crew_profile());
+  CrewMetabolicModel four(4, default_crew_profile());
+  EXPECT_NEAR(four.loads().flows.co2, 4.0 * one.loads().flows.co2, 1.0e-12);
+}
+
+TEST(CrewMetabolic, ActivityFactorScales)
+{
+  CrewMetabolicModel crew(3, default_crew_profile());
+  EXPECT_NEAR(crew.loads(2.0).flows.co2, 2.0 * crew.loads(1.0).flows.co2, 1.0e-12);
+}
+
+TEST(CrewMetabolic, MagnitudeMatchesDailyFigures)
+{
+  CrewMetabolicModel crew(1, default_crew_profile());
+  const MetabolicLoads l = crew.loads(1.0);
+  // CO2 ~1 kg/day per crew member.
+  const double co2_kg_day = l.flows.co2 * units::M_CO2 * units::SECONDS_PER_DAY;
+  EXPECT_NEAR(co2_kg_day, 1.04, 0.05);
+  const double o2_kg_day = -l.flows.o2 * units::M_O2 * units::SECONDS_PER_DAY;
+  EXPECT_NEAR(o2_kg_day, 0.84, 0.05);
+}

--- a/ssos_eclss/test/unit/common/test_gas_properties.cpp
+++ b/ssos_eclss/test/unit/common/test_gas_properties.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "ssos_eclss/common/gas_properties.hpp"
+#include "ssos_eclss/common/units.hpp"
+
+using namespace ssos_eclss;
+
+TEST(GasProperties, IdealGasDensityAir)
+{
+  // Air at 1 atm, 273.15 K -> ~1.29 kg/m^3
+  const double rho = gas::gas_density(units::STD_PRESSURE_PA, 273.15, units::M_AIR);
+  EXPECT_NEAR(rho, 1.293, 0.02);
+}
+
+TEST(GasProperties, ConcentrationPartialPressureRoundTrip)
+{
+  const double pp = units::torr_to_pa(2.0);  // 2 torr ppCO2
+  const double t = 295.0;
+  const double c = gas::concentration_from_pp(pp, t);
+  EXPECT_NEAR(gas::partial_pressure(c, t), pp, 1.0e-6);
+}
+
+TEST(GasProperties, SaturationPressureMonotonic)
+{
+  const double p_low = gas::water_saturation_pressure(280.0);
+  const double p_high = gas::water_saturation_pressure(310.0);
+  EXPECT_GT(p_high, p_low);
+  // At 100 degC saturation pressure ~ 1 atm.
+  EXPECT_NEAR(gas::water_saturation_pressure(373.15), 101325.0, 5000.0);
+}
+
+TEST(GasProperties, DewPointInvertsSaturation)
+{
+  const double t = 290.0;
+  const double psat = gas::water_saturation_pressure(t);
+  // At RH=100% dew point equals temperature.
+  EXPECT_NEAR(gas::dew_point_from_pp(psat), t, 0.5);
+}
+
+TEST(GasProperties, RelativeHumidityBounds)
+{
+  const double t = 295.0;
+  const double psat = gas::water_saturation_pressure(t);
+  EXPECT_NEAR(gas::relative_humidity(0.5 * psat, t), 0.5, 1.0e-6);
+  EXPECT_NEAR(gas::water_pp_from_rh(0.5, t), 0.5 * psat, 1.0e-6);
+}
+
+TEST(GasProperties, HumidityRatioPositive)
+{
+  const double w = gas::humidity_ratio(2000.0, units::STD_PRESSURE_PA);
+  EXPECT_GT(w, 0.0);
+  EXPECT_LT(w, 0.1);
+}
+
+TEST(GasProperties, MixtureMolarMassWeighting)
+{
+  std::vector<gas::MixtureComponent> comps = {
+    {0.79, units::M_N2, 1.7e-5},
+    {0.21, units::M_O2, 2.0e-5},
+  };
+  const double m = gas::mixture_molar_mass(comps);
+  EXPECT_NEAR(m, 0.79 * units::M_N2 + 0.21 * units::M_O2, 1.0e-9);
+}
+
+TEST(GasProperties, MixtureViscosityBetweenComponents)
+{
+  std::vector<gas::MixtureComponent> comps = {
+    {0.5, units::M_N2, 1.7e-5},
+    {0.5, units::M_O2, 2.0e-5},
+  };
+  const double mu = gas::mixture_viscosity(comps);
+  EXPECT_GT(mu, 1.6e-5);
+  EXPECT_LT(mu, 2.1e-5);
+}
+
+TEST(GasProperties, SutherlandViscosityIncreasesWithT)
+{
+  EXPECT_GT(gas::sutherland_viscosity(350.0), gas::sutherland_viscosity(280.0));
+}

--- a/ssos_eclss/test/unit/common/test_heat_transfer.cpp
+++ b/ssos_eclss/test/unit/common/test_heat_transfer.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "ssos_eclss/common/fluid_dynamics.hpp"
+#include "ssos_eclss/common/heat_transfer.hpp"
+
+using namespace ssos_eclss;
+
+TEST(HeatTransfer, WakaoKagueiLimit)
+{
+  // At Re -> 0 the Nusselt number approaches 2.
+  EXPECT_NEAR(heat::nusselt_wakao_kaguei(0.0, 0.7), 2.0, 1.0e-9);
+  // Increases with Reynolds.
+  EXPECT_GT(heat::nusselt_wakao_kaguei(100.0, 0.7),
+            heat::nusselt_wakao_kaguei(10.0, 0.7));
+}
+
+TEST(HeatTransfer, EffectivenessBounds)
+{
+  for (double ntu = 0.1; ntu < 10.0; ntu += 0.5) {
+    const double eps = heat::effectiveness_counterflow(ntu, 0.5);
+    EXPECT_GE(eps, 0.0);
+    EXPECT_LE(eps, 1.0);
+  }
+}
+
+TEST(HeatTransfer, EffectivenessCrZeroIsExponential)
+{
+  const double ntu = 2.0;
+  EXPECT_NEAR(heat::effectiveness_counterflow(ntu, 0.0), 1.0 - std::exp(-ntu), 1.0e-9);
+}
+
+TEST(HeatTransfer, EffectivenessMonotonicInNTU)
+{
+  EXPECT_GT(heat::effectiveness_counterflow(4.0, 0.5),
+            heat::effectiveness_counterflow(1.0, 0.5));
+}
+
+TEST(HeatTransfer, HeatDutySign)
+{
+  // Hot inlet above cold inlet -> positive duty.
+  EXPECT_GT(heat::hx_heat_duty(0.8, 100.0, 350.0, 300.0), 0.0);
+}
+
+TEST(HeatTransfer, SpecificSurfaceAreaPositive)
+{
+  const double av = heat::specific_surface_area(0.4, 0.002);
+  EXPECT_GT(av, 0.0);
+  // a_v = 6*(1-e)/dp = 6*0.6/0.002 = 1800.
+  EXPECT_NEAR(av, 1800.0, 1.0);
+}
+
+TEST(FluidDynamics, ErgunPressureDropPositive)
+{
+  // Air through a packed bed.
+  const double dp = fluid::ergun_pressure_drop(0.5, 0.4, 0.002, 1.2, 1.8e-5, 0.3);
+  EXPECT_GT(dp, 0.0);
+}
+
+TEST(FluidDynamics, ErgunIncreasesWithVelocity)
+{
+  const double slow = fluid::ergun_pressure_drop(0.2, 0.4, 0.002, 1.2, 1.8e-5, 0.3);
+  const double fast = fluid::ergun_pressure_drop(0.8, 0.4, 0.002, 1.2, 1.8e-5, 0.3);
+  EXPECT_GT(fast, slow);
+}
+
+TEST(FluidDynamics, ReynoldsScaling)
+{
+  EXPECT_NEAR(fluid::reynolds_number(1.2, 1.0, 0.002, 1.8e-5),
+              1.2 * 1.0 * 0.002 / 1.8e-5, 1.0e-6);
+}
+
+TEST(FluidDynamics, LaminarFrictionFactor)
+{
+  EXPECT_NEAR(fluid::darcy_friction_factor(1000.0), 64.0 / 1000.0, 1.0e-9);
+}

--- a/ssos_eclss/test/unit/common/test_thermodynamics.cpp
+++ b/ssos_eclss/test/unit/common/test_thermodynamics.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/common/thermodynamics.hpp"
+
+using namespace ssos_eclss;
+using thermo::Species;
+
+TEST(Thermodynamics, AirCpReasonable)
+{
+  // cp of air near room temp ~1005 J/(kg*K).
+  const double cp = thermo::cp_mass(Species::AIR, 300.0);
+  EXPECT_NEAR(cp, 1005.0, 60.0);
+}
+
+TEST(Thermodynamics, GammaAirNear14)
+{
+  EXPECT_NEAR(thermo::gamma_ratio(Species::AIR, 300.0), 1.4, 0.05);
+}
+
+TEST(Thermodynamics, CvLessThanCp)
+{
+  EXPECT_LT(thermo::cv_mass(Species::CO2, 300.0), thermo::cp_mass(Species::CO2, 300.0));
+}
+
+TEST(Thermodynamics, SensibleEnthalpyZeroAtReference)
+{
+  EXPECT_NEAR(thermo::sensible_enthalpy(Species::AIR, 298.15, 298.15), 0.0, 1.0e-6);
+}
+
+TEST(Thermodynamics, SensibleEnthalpyIncreasesWithT)
+{
+  const double h1 = thermo::sensible_enthalpy(Species::AIR, 350.0);
+  const double h0 = thermo::sensible_enthalpy(Species::AIR, 300.0);
+  EXPECT_GT(h1, h0);
+  // Roughly cp * dT.
+  EXPECT_NEAR(h1 - h0, 1005.0 * 50.0, 0.2 * 1005.0 * 50.0);
+}
+
+TEST(Thermodynamics, LatentHeatWaterDecreasesWithT)
+{
+  const double l_cold = thermo::latent_heat_water(280.0);
+  const double l_hot = thermo::latent_heat_water(360.0);
+  EXPECT_GT(l_cold, l_hot);
+  // ~2.45e6 J/kg near room temperature.
+  EXPECT_NEAR(thermo::latent_heat_water(298.15), 2.44e6, 1.0e5);
+}
+
+TEST(Thermodynamics, LiquidWaterCpNear4180)
+{
+  EXPECT_NEAR(thermo::cp_liquid_water(300.0), 4180.0, 50.0);
+}
+
+TEST(Thermodynamics, SorbentCpPositive)
+{
+  EXPECT_GT(thermo::cp_sorbent_solid(400.0), 0.0);
+}

--- a/ssos_eclss/test/unit/faults/test_fault_injector.cpp
+++ b/ssos_eclss/test/unit/faults/test_fault_injector.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/faults/fault_injector.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::faults;
+
+namespace
+{
+FaultDefinition make(FaultType type, const std::string & target, double mag,
+                     double start = 0.0, double dur = -1.0)
+{
+  FaultDefinition d{};
+  d.type = type;
+  d.target = target;
+  d.magnitude = mag;
+  d.start_time_s = start;
+  d.duration_s = dur;
+  return d;
+}
+}  // namespace
+
+TEST(FaultInjector, ActivationWindow)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::HEATER_FAILED, "ars_heater", 0.0, 100.0, 50.0));
+  fi.update(50.0);
+  EXPECT_FALSE(fi.any_active());
+  fi.update(120.0);
+  EXPECT_TRUE(fi.any_active());
+  fi.update(200.0);
+  EXPECT_FALSE(fi.any_active());
+}
+
+TEST(FaultInjector, HeaterFailedZerosPower)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::HEATER_FAILED, "ars_heater", 0.0));
+  fi.update(10.0);
+  EXPECT_NEAR(fi.thermal_effect("ars_heater").heater_power_factor, 0.0, 1.0e-12);
+  // A different component is unaffected.
+  EXPECT_NEAR(fi.thermal_effect("other").heater_power_factor, 1.0, 1.0e-12);
+}
+
+TEST(FaultInjector, HeaterPartialReducesPower)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::HEATER_PARTIAL, "ars_heater", 7.0 / 19.0));
+  fi.update(0.0);
+  EXPECT_NEAR(fi.thermal_effect("ars_heater").heater_power_factor, 7.0 / 19.0, 1.0e-9);
+}
+
+TEST(FaultInjector, BlowerDegradedReducesEffectiveness)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::BLOWER_DEGRADED, "ars_blower", 0.6));
+  fi.update(0.0);
+  EXPECT_NEAR(fi.actuator_effect("ars_blower").effectiveness, 0.6, 1.0e-9);
+}
+
+TEST(FaultInjector, ValveStuckClosedOverrides)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::VALVE_STUCK_CLOSED, "sel_valve", 0.0));
+  fi.update(0.0);
+  const ActuatorEffect e = fi.actuator_effect("sel_valve");
+  EXPECT_TRUE(e.override_position);
+  EXPECT_NEAR(e.forced_position, 0.0, 1.0e-12);
+  EXPECT_NEAR(e.effectiveness, 0.0, 1.0e-12);
+}
+
+TEST(FaultInjector, SensorBiasApplied)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::SENSOR_BIAS, "co2_sensor", 50.0));
+  fi.update(0.0);
+  EXPECT_NEAR(fi.apply_sensor("co2_sensor", 400.0), 450.0, 1.0e-9);
+  // Inactive when out of window doesn't change reading.
+  EXPECT_NEAR(fi.apply_sensor("other_sensor", 400.0), 400.0, 1.0e-9);
+}
+
+TEST(FaultInjector, SensorStuckLatches)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::SENSOR_STUCK, "co2_sensor", 0.0));
+  fi.update(0.0);
+  const double first = fi.apply_sensor("co2_sensor", 400.0);
+  const double second = fi.apply_sensor("co2_sensor", 800.0);
+  EXPECT_NEAR(first, 400.0, 1.0e-9);
+  EXPECT_NEAR(second, 400.0, 1.0e-9);  // latched
+}
+
+TEST(FaultInjector, CabinLeakAreaAccumulates)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::CABIN_LEAK, "cabin", 1.0e-4));
+  fi.update(0.0);
+  EXPECT_NEAR(fi.leak_fault_area("cabin"), 1.0e-4, 1.0e-12);
+}
+
+TEST(FaultInjector, ClearRemovesAll)
+{
+  FaultInjector fi;
+  fi.register_fault(make(FaultType::HEATER_FAILED, "ars_heater", 0.0));
+  fi.clear();
+  fi.update(10.0);
+  EXPECT_FALSE(fi.any_active());
+  EXPECT_EQ(fi.count(), 0u);
+}

--- a/ssos_eclss/test/unit/ogs/test_electrolysis.cpp
+++ b/ssos_eclss/test/unit/ogs/test_electrolysis.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/common/units.hpp"
+#include "ssos_eclss/ogs/electrolysis_cell_model.hpp"
+#include "ssos_eclss/ogs/oxygen_generator_system.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::ogs;
+
+TEST(Electrolysis, ReversibleVoltageNear1p23)
+{
+  ElectrolysisCellModel cell(default_cell_params());
+  EXPECT_NEAR(cell.reversible_voltage(298.15, units::STD_PRESSURE_PA), 1.229, 0.05);
+}
+
+TEST(Electrolysis, VoltageExceedsReversibleUnderLoad)
+{
+  ElectrolysisCellModel cell(default_cell_params());
+  const CellState s = cell.solve(20.0, 330.0, units::STD_PRESSURE_PA);
+  EXPECT_GT(s.voltage, s.reversible_voltage);
+  EXPECT_GT(s.activation_overpotential, 0.0);
+  EXPECT_GT(s.ohmic_overpotential, 0.0);
+}
+
+TEST(Electrolysis, VoltageMonotonicInCurrent)
+{
+  ElectrolysisCellModel cell(default_cell_params());
+  const CellState lo = cell.solve(5.0, 330.0, units::STD_PRESSURE_PA);
+  const CellState hi = cell.solve(40.0, 330.0, units::STD_PRESSURE_PA);
+  EXPECT_GT(hi.voltage, lo.voltage);
+}
+
+TEST(Electrolysis, FaradayStoichiometry)
+{
+  ElectrolysisCellModel cell(default_cell_params());
+  const CellState s = cell.solve(20.0, 330.0, units::STD_PRESSURE_PA);
+  // H2 should be twice O2 (2 H2 + O2 from 2 H2O).
+  EXPECT_NEAR(s.h2_production_mol_s, 2.0 * s.o2_production_mol_s, 1.0e-12);
+  // Per cell, O2 = I/(4F).
+  EXPECT_NEAR(s.o2_production_mol_s, 20.0 / (4.0 * units::FARADAY), 1.0e-12);
+}
+
+TEST(Electrolysis, SystemProducesOxygen)
+{
+  OxygenGeneratorSystem ogs;
+  ogs.reset(330.0);
+  OgsResult r{};
+  for (int i = 0; i < 100; ++i) {
+    r = ogs.step_nominal(1.0);
+  }
+  EXPECT_GT(r.o2_production_kg_day, 0.0);
+  // OGA-class production a few kg/day.
+  EXPECT_GT(r.o2_production_kg_day, 2.0);
+  EXPECT_LT(r.o2_production_kg_day, 12.0);
+  // 2 H2O consumed per O2.
+  EXPECT_NEAR(r.water_consumed_mol_s, 2.0 * r.o2_production_mol_s / 0.98, 1.0e-6 +
+              0.05 * r.water_consumed_mol_s);
+}
+
+TEST(Electrolysis, FeedwaterLimiting)
+{
+  OxygenGeneratorSystem ogs;
+  ogs.reset(330.0);
+  // Provide almost no feed water.
+  const OgsResult r = ogs.step(1.0, 27.0, 1.0e-9);
+  EXPECT_TRUE(r.feedwater_limited);
+  EXPECT_LT(r.o2_production_mol_s, 1.0e-6);
+}
+
+TEST(Electrolysis, StackHeatsUnderLoad)
+{
+  OxygenGeneratorSystem ogs;
+  ogs.reset(300.0);
+  OgsResult r{};
+  for (int i = 0; i < 500; ++i) {
+    r = ogs.step_nominal(1.0);
+  }
+  // Waste heat above thermoneutral raises stack temperature above coolant.
+  EXPECT_GT(r.stack_temperature_k, units::celsius_to_kelvin(18.0));
+}

--- a/ssos_eclss/test/unit/wrs/test_sabatier.cpp
+++ b/ssos_eclss/test/unit/wrs/test_sabatier.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/common/units.hpp"
+#include "ssos_eclss/sabatier/reactor_kinetics.hpp"
+#include "ssos_eclss/sabatier/sabatier_system.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::sabatier;
+
+TEST(SabatierKinetics, ConversionRisesWithTemperature)
+{
+  ReactorKinetics k(default_kinetics_params());
+  EXPECT_LT(k.conversion(400.0), k.conversion(650.0));
+  EXPECT_LE(k.conversion(700.0), default_kinetics_params().max_conversion + 1.0e-9);
+}
+
+TEST(SabatierSystem, StoichiometryAndProducts)
+{
+  SabatierSystem s;
+  s.reset(600.0);
+  // Ample H2 (excess), CO2-limited.
+  const double co2 = 1.0e-4;
+  const double h2 = 8.0e-4;  // > 4*co2
+  const SabatierResult r = s.step(1.0, co2, h2);
+  EXPECT_GT(r.co2_consumed_mol_s, 0.0);
+  EXPECT_NEAR(r.h2_consumed_mol_s, 4.0 * r.co2_consumed_mol_s, 1.0e-12);
+  EXPECT_NEAR(r.ch4_produced_mol_s, r.co2_consumed_mol_s, 1.0e-12);
+  EXPECT_NEAR(r.water_produced_mol_s, 2.0 * r.co2_consumed_mol_s, 1.0e-12);
+  EXPECT_FALSE(r.hydrogen_limited);
+}
+
+TEST(SabatierSystem, HydrogenLimited)
+{
+  SabatierSystem s;
+  s.reset(600.0);
+  // Insufficient H2.
+  const SabatierResult r = s.step(1.0, 1.0e-3, 1.0e-4);
+  EXPECT_TRUE(r.hydrogen_limited);
+}
+
+TEST(SabatierSystem, ExothermicHeatsReactor)
+{
+  // Started warm, the exotherm sustains/raises the reactor temperature against
+  // heat loss (the reactor self-sustains once lit).
+  SabatierSystem s;
+  s.reset(550.0);
+  SabatierResult r{};
+  for (int i = 0; i < 200; ++i) {
+    r = s.step(1.0, 5.0e-3, 4.0e-2);  // generous feed
+  }
+  EXPECT_GT(r.reaction_heat_w, 0.0);
+  EXPECT_GT(r.reactor_temp_k, 550.0);
+}
+
+TEST(SabatierSystem, HigherFeedRaisesSteadyTemperature)
+{
+  auto steady_temp = [](double co2, double h2) {
+    SabatierSystem s;
+    s.reset(600.0);
+    SabatierResult r{};
+    for (int i = 0; i < 2000; ++i) {
+      r = s.step(1.0, co2, h2);
+    }
+    return r.reactor_temp_k;
+  };
+  EXPECT_GT(steady_temp(2.0e-3, 1.6e-2), steady_temp(5.0e-4, 4.0e-3));
+}
+
+TEST(SabatierSystem, ProducesWaterForWrs)
+{
+  SabatierSystem s;
+  s.reset(600.0);
+  const SabatierResult r = s.step(1.0, 1.0e-4, 8.0e-4);
+  EXPECT_GT(r.water_produced_kg_s, 0.0);
+  EXPECT_NEAR(r.water_produced_kg_s, r.water_produced_mol_s * units::M_H2O, 1.0e-15);
+}

--- a/ssos_eclss/test/unit/wrs/test_water_recovery.cpp
+++ b/ssos_eclss/test/unit/wrs/test_water_recovery.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include "ssos_eclss/common/units.hpp"
+#include "ssos_eclss/wrs/catalytic_reactor_model.hpp"
+#include "ssos_eclss/wrs/distillation_model.hpp"
+#include "ssos_eclss/wrs/multifiltration_model.hpp"
+#include "ssos_eclss/wrs/water_recovery_system.hpp"
+
+using namespace ssos_eclss;
+using namespace ssos_eclss::wrs;
+
+TEST(Distillation, RecoversConfiguredFraction)
+{
+  DistillationModel d(default_distillation_params());
+  const double feed = 5.0 / 86400.0;  // 5 kg/day
+  const DistillationResult r = d.process(feed);
+  EXPECT_NEAR(r.distillate_kg_s, feed * 0.87, 1.0e-12);
+  EXPECT_NEAR(r.distillate_kg_s + r.brine_kg_s, feed, 1.0e-12);
+  EXPECT_GT(r.energy_w, 0.0);
+}
+
+TEST(Multifiltration, ReducesConductivity)
+{
+  MultifiltrationModel mf(default_multifiltration_params());
+  mf.reset();
+  const MultifiltrationResult r = mf.process(1.0, 1.0e-4, 2000.0);
+  EXPECT_LT(r.product_conductivity_us, 2000.0);
+}
+
+TEST(Multifiltration, EventualBreakthrough)
+{
+  MultifiltrationParams p = default_multifiltration_params();
+  p.bed_capacity_kg = 1.0e-3;  // small bed
+  MultifiltrationModel mf(p);
+  mf.reset();
+  MultifiltrationResult r{};
+  // Push a lot of contaminated water through.
+  for (int i = 0; i < 100000 && !r.broken_through; ++i) {
+    r = mf.process(1.0, 1.0, 5000.0);
+  }
+  EXPECT_TRUE(r.broken_through);
+}
+
+TEST(Catalytic, ConversionRisesWithTemperature)
+{
+  CatalyticReactorModel c(default_catalytic_params());
+  EXPECT_LT(c.conversion(340.0), c.conversion(420.0));
+  EXPECT_LE(c.conversion(420.0), default_catalytic_params().max_conversion + 1.0e-9);
+  EXPECT_NEAR(c.conversion(300.0), 0.0, 1.0e-9);  // below activation
+}
+
+TEST(WaterRecovery, ProducesPotableWater)
+{
+  WaterRecoverySystem wrs;
+  wrs.reset();
+  const double urine = 5.0 / 86400.0;
+  const double condensate = 3.0 / 86400.0;
+  const WrsResult r = wrs.step(1.0, urine, condensate, 1.0e-8);
+  EXPECT_GT(r.potable_water_kg_s, 0.0);
+  EXPECT_TRUE(r.potable_in_spec);
+  EXPECT_GT(r.voc_conversion, 0.5);
+}
+
+TEST(WaterRecovery, RecoveryFractionReasonable)
+{
+  WaterRecoverySystem wrs;
+  wrs.reset();
+  const double urine = 5.0 / 86400.0;
+  const double condensate = 3.0 / 86400.0;
+  const WrsResult r = wrs.step(1.0, urine, condensate, 0.0);
+  // Combined recovery should be high (condensate ~100%, urine ~87%).
+  EXPECT_GT(r.overall_recovery, 0.85);
+  EXPECT_LE(r.overall_recovery, 1.0);
+}


### PR DESCRIPTION
## Summary

Adds `ssos_eclss`, a new physics-based ECLSS simulation package.
The architecture enforces a strict separation between physics and ROS: a pure
physics library with zero ROS dependencies, wrapped in lifecycle nodes that
subscribe to `/sim/world_state` and report through the system_manager.

The ARS (4-Bed Molecular Sieve CO₂ scrubber) is modeled from first principles
based on Peters, Cmarik & Knox, "4BCO2 EDU Performance" (ICES-2021-313).

## Additive 

- `space_station_eclss` (the demo package) is **untouched** 
- New parallel package `ssos_eclss` created alongside it
- Builds on the A1.1 sim interfaces and integrates with ssos_core / ssos_sim

## Architecture (three layers)

**Layer 1 - common (no ROS):** units, gas properties, thermodynamics, Ergun
fluid dynamics, Wakao-Kaguei / zeta-NTU heat transfer, RK4 + finite-volume + CFL
numerical helpers.

**Layer 2 -  physics (zero ROS dependencies):**
- ARS 4BMS - Toth + competitive isotherms, 1D finite-volume packed-bed PDE with
  semi-implicit gas-energy coupling, precooler, blower, air-save pump, valve,
  10-60-10 cycle state machine, FourBedSystem orchestrator
- OGS - PEM electrolysis (Nernst + overpotentials)
- WRS - distillation, multifiltration, catalytic reactor
- Sabatier - CO₂ reduction kinetics (closes the loop)
- Cabin - atmosphere mass balance + crew metabolic + leak models
- Faults - sensor / actuator / thermal + central injector

**Layer 3 ROS:** `EclssParameterBridge` 
diagnostics helper, four lifecycle nodes + mains.


## Testing

```bash
colcon build --packages-select ssos_eclss
colcon test --packages-select ssos_eclss
```

- Clean build, **138 tests pass, 0 failures**
- `eclss_physics` library has zero ROS deps (standalone executables link only it)
- Parameter validation tests: invalid values rejected with clear messages

## Validation against Peters et al. (2021)

- Standalone `ars_validation` reproduces **4.26 kg/day** CO₂ removal at 2 torr /
  26 SCFM — within the paper's 4.16–4.76 kg/day band
- Steady-state design point (the acceptance requirement) matches the paper

## Known limitation (documented in docs/validation.md)

The cell-resolved bed's CO₂ breakthrough onset (~24 min) is earlier than the
paper's ~140 min. The current model captures the adsorption thermal wave more
simply than the EDU's detailed bed-cooling behaviour. This affects the transient
breakthrough curve, **not** the steady-state removal design point (which matches
the paper and is the acceptance criterion). Isotherm, LDF, geometry, and
efficiency parameters are all ROS-tunable for further transient calibration —
this is a known follow-up, not a blocker for the design-point requirement.

## Parameter tunability

Every physical parameter is exposed via the parameter bridge with validation.
Static params (geometry, cell count) read on configure; dynamic params (heater
power, flow, cycle timing, isotherm coefficients) are live-tunable via
`ros2 param set`, the foundation for future dashboard control over rosbridge.

## Integration

- Nodes subscribe to `/sim/world_state` (Epic A boundary respected)
- Register with system_manager via `/ssos/register_subsystem`
- Publish heartbeats to `/ssos/<name>/heartbeat` and faults to `/ssos/fault_event`
- Launch smoke test confirms clean lifecycle activation

## Related

- Closes #221  (A3 ssos_eclss)
- Depends on: A1.1 interfaces, A1.2 system_manager, A2 simulation_controller
- Parent: [Epic] A #202, [Epic] C #204