### PR TITLE
Fix/241 ignore desktop runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ log/
 # pixi environment (keep pixi.toml and pixi.lock; ignore the resolved env)
 .pixi/
 .claude/
-.log
+/desktop/*.log


### PR DESCRIPTION
## Summary

- Replace the ineffective `.log` ignore entry with `/desktop/*.log`.
- Ignore runtime log files generated directly under `desktop/`.
- Keep the repository working tree clean after using the Tier-1 desktop application.

## Validation

- Confirmed that `desktop/install.log` is ignored by Git.
- Confirmed that `desktop/last-run.log` is ignored by Git.
- Confirmed that an additional `.log` file directly under `desktop/` is ignored.
- Ran `desktop/install.sh` successfully.
- Launched and shut down Space Station OS from the desktop shortcut.
- Ran `desktop/uninstall.sh` successfully.
- Confirmed that `git status -sb` remained clean after installation, launch, shutdown, and uninstallation.
- Confirmed that no functional change was introduced to the Tier-1 desktop application workflow.

Closes #241