### PR TITLE
Add locked Pixi environment validation to CI

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,0 +1,38 @@
+name: Pixi CI
+
+on:
+  push:
+    branches:
+      - main
+      - v0.8.9-dev
+      - 'v0.9.*-dev'
+  pull_request:
+
+concurrency:
+  group: pixi-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pixi-validation:
+    name: Pixi Locked Environment
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: v0.73.0
+          locked: true
+          cache: true
+
+      - name: Build with Pixi
+        run: pixi run build
+
+      - name: Test with Pixi
+        run: pixi run test
+
+      - name: Verify lock file unchanged
+        run: git diff --exit-code -- pixi.lock

--- a/docs/PIXI.md
+++ b/docs/PIXI.md
@@ -62,6 +62,32 @@ do not add the `defaults` channel (RoboStack is incompatible with it).
   keeps the environment lean. Swap to `ros-jazzy-desktop` only if you need the
   broader toolset.
 
+## Continuous integration
+
+SSOS uses two complementary continuous-integration validation paths:
+
+- the native ROS 2 Jazzy build and test workflow
+- the locked Pixi environment build and test workflow
+
+Both workflows run for pull requests. The Pixi workflow also runs after pushes
+to `main`, `v0.8.9-dev`, and development branches matching `v0.9.*-dev`; the
+existing native workflow retains its current trigger configuration.
+
+The Pixi CI job installs the environment from the committed `pixi.lock` in
+locked mode and then runs:
+
+```bash
+pixi run build
+pixi run test
+```
+
+If `pixi.toml` and `pixi.lock` are not synchronized, the Pixi CI job fails.
+CI does not regenerate or modify `pixi.lock`.
+
+The Pixi CI job is the normal compatibility check for changes affecting the
+Tier-1 desktop application. Graphical desktop behavior, Qt/OpenGL rendering,
+and full GUI interaction remain manual release-candidate smoke tests.
+
 ## Next step
 
 This environment is the foundation for packaging SSOS as an installable


### PR DESCRIPTION
## Summary

This PR adds a dedicated GitHub Actions workflow for validating the committed Pixi environment.

The new workflow supplements the existing native ROS 2 Jazzy CI and provides a continuous compatibility check for the Pixi execution path used by the Tier-1 desktop application.

Closes #242

## Changes

- Add `.github/workflows/pixi.yml`
- Run Pixi validation on:
  - pull requests
  - pushes to `main`
  - pushes to `v0.8.9-dev`
  - pushes to branches matching `v0.9.*-dev`
- Pin the Pixi setup action to `prefix-dev/setup-pixi@v0.10.0`
- Pin the Pixi version to `v0.73.0`
- Install the committed environment in locked mode
- Enable Pixi environment caching based on `pixi.lock`
- Run:
  - `pixi run build`
  - `pixi run test`
- Verify that CI does not modify `pixi.lock`
- Document the native ROS 2 and Pixi CI validation paths in `docs/PIXI.md`

## CI Design

The repository now has two complementary validation paths:

### Native ROS 2 Jazzy CI

- Ubuntu 24.04
- system-installed ROS 2 Jazzy
- `rosdep`
- `colcon build`
- `colcon test`

### Pixi CI

- Ubuntu 24.04
- pinned Pixi installation
- locked environment installation from the committed `pixi.lock`
- `pixi run build`
- `pixi run test`
- verification that `pixi.lock` remains unchanged

The existing native ROS 2 CI workflow is unchanged.

## Local Validation

Validated locally with Pixi `0.73.0`:

```text
pixi install --locked
    PASS

pixi run build
    7 packages finished successfully

pixi run test
    144 tests
    0 errors
    0 failures
    0 skipped

git diff --exit-code -- pixi.lock
    PASS
```

A temporary manifest change was also introduced to confirm that locked installation rejects an out-of-date lock file:

```text
Error: lock file not up-to-date with the workspace
```

The manifest was restored afterward, and neither pixi.toml nor pixi.lock was modified by the validation.

### Manual Validation Boundary

The following remain manual release-candidate or desktop-related smoke tests:

- Ubuntu desktop shortcut behavior
- GNOME trusted-launcher behavior
- Qt/OpenGL rendering on a physical desktop
- complete GUI interaction

