### PR TITLE
fix: align v0.9 setup paths and locked Pixi installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 https://github.com/user-attachments/assets/5b82c516-075d-44ac-b440-fb73bedc1e91
 
 [![CI](https://github.com/space-station-os/space_station_os/actions/workflows/ci.yml/badge.svg)](https://github.com/space-station-os/space_station_os/actions/workflows/ci.yml)
+[![Pixi CI](https://github.com/space-station-os/space_station_os/actions/workflows/pixi.yml/badge.svg)](https://github.com/space-station-os/space_station_os/actions/workflows/pixi.yml)
 
 Space Station OS (SSOS) is an open-source simulation of a crewed space station and
 its subsystems, built on ROS 2. It models the closed-loop physics of life support,
@@ -24,6 +25,9 @@ learning about space stations and their subsystems.
 | `space_station` | Mission-control GUI and the top-level launch files |
 
 ### Legacy Systems
+
+| Package | What it is |
+|---------|------------|
 | `space_station_eclss` | Environmental Control and Life Support System |
 | `space_station_eps` | Electrical Power System |
 | `space_station_gnc` | Guidance, Navigation and Control |
@@ -34,60 +38,213 @@ learning about space stations and their subsystems.
 
 ---
 
-## Quick Start with pixi (reproducible local build)
+## Choose how to use SSOS
 
-[pixi](https://pixi.sh) gives you a pinned ROS 2 Jazzy environment (via
-[RoboStack](https://robostack.github.io)) with no system ROS, `apt`, or `rosdep`.
-From a clean checkout:
+| Goal | Recommended path |
+|------|------------------|
+| Try SSOS on Ubuntu without using the terminal after installation | Tier-1 Desktop App |
+| Run SSOS from the terminal without installing system ROS 2 | Pixi |
+| Develop SSOS in a reproducible environment | Pixi |
+| Develop and integrate against a native ROS 2 installation | Ubuntu 24.04 + ROS 2 Jazzy |
+| Work with the containerized environment | Docker (advanced) |
 
-```bash
-pixi install        # resolve + fetch ROS 2 Jazzy + build tools + GUI deps
-pixi run build      # colcon build space_station, ssos_core, ssos_sim, ssos_eclss
-pixi run station    # launch the full stack (GUI + core + sim + eclss)
-```
+Pixi is the recommended reproducible environment for most SSOS development.
+Native ROS 2 Jazzy is supported for system integration and development against
+a system ROS installation.
 
 ---
 
-## Install as a Desktop App (Ubuntu)
+## Try SSOS as a Desktop App
 
-Prefer clicking an icon over the terminal? Install a desktop shortcut that
-launches the full mission-control stack. Requires [pixi](https://pixi.sh).
+The Tier-1 Desktop App is supported on Ubuntu 24.04 Desktop. It creates a
+Space Station OS shortcut that launches the full mission-control stack through
+the repository's Pixi environment.
+
+Starting from a clean Ubuntu 24.04 Desktop installation:
 
 ```bash
+sudo apt update
+sudo apt install -y curl git zenity
+
+curl -fsSL https://pixi.sh/install.sh | sh
+export PATH="$HOME/.pixi/bin:$PATH"
+
+git clone https://github.com/space-station-os/space_station_os.git
 cd space_station_os
+
 bash desktop/install.sh
 ```
 
-A progress popup runs `pixi install` + `pixi run build`, then places a
-**Space Station OS** icon on your Desktop. Double-click it to launch (on the
-first launch, if GNOME warns, right-click the icon and choose "Allow Launching").
-Uninstall with `bash desktop/uninstall.sh`. Full details in
-[docs/DESKTOP_APP.md](docs/DESKTOP_APP.md).
+The installer uses the committed `pixi.lock`, builds SSOS, and places a
+**Space Station OS** icon on your Desktop.
+
+Double-click the icon to launch SSOS. On first launch, if GNOME displays an
+untrusted-launcher warning, right-click the icon and choose **Allow Launching**.
+
+To uninstall the shortcut:
+
+```bash
+bash desktop/uninstall.sh
+```
+
+The repository and Pixi environment are not removed.
+
+See [docs/DESKTOP_APP.md](docs/DESKTOP_APP.md) for details and troubleshooting.
 
 ---
 
-## Quick Start with Docker (with GUI support)
+## Run SSOS from the Terminal with Pixi
 
-If you prefer not to build locally, use the prebuilt Docker image, including GUI
-support for the simulation.
+Pixi provides ROS 2 Jazzy through RoboStack and does not require a system ROS 2
+installation, `rosdep`, or a ROS-specific `apt` setup.
 
-### 1. Pull the image
+Starting from a clean Ubuntu installation:
+
+```bash
+sudo apt update
+sudo apt install -y curl git
+
+curl -fsSL https://pixi.sh/install.sh | sh
+export PATH="$HOME/.pixi/bin:$PATH"
+
+git clone https://github.com/space-station-os/space_station_os.git
+cd space_station_os
+
+pixi install --locked
+pixi run build
+pixi run test
+pixi run station
+```
+
+`pixi install --locked` installs the environment recorded in the committed
+`pixi.lock` and prevents normal setup from silently regenerating dependency
+versions.
+
+See [docs/PIXI.md](docs/PIXI.md) for the environment structure and dependency
+update procedure.
+
+---
+
+## Develop SSOS
+
+### Recommended: Pixi
+
+Pixi is the recommended development environment when you want a reproducible
+SSOS toolchain without modifying the host ROS installation.
+
+After cloning your working repository:
+
+```bash
+cd space_station_os
+
+pixi install --locked
+pixi run build
+pixi run test
+pixi run station
+```
+
+Common Pixi tasks:
+
+| Task | Purpose |
+|------|---------|
+| `pixi run build` | Build the current SSOS package set with colcon |
+| `pixi run test` | Run the current Pixi validation test set |
+| `pixi run station` | Build and launch the full SSOS stack |
+| `pixi run gui` | Launch the mission-control GUI |
+| `pixi run clean` | Remove `build/`, `install/`, and `log/` |
+
+Do not regenerate `pixi.lock` during normal setup. Contributors intentionally
+changing dependencies should follow the procedure in
+[docs/PIXI.md](docs/PIXI.md).
+
+### Native ROS 2 Jazzy
+
+Use the native path when developing or integrating SSOS against a system ROS 2
+installation.
+
+Prerequisites:
+
+- Ubuntu 24.04
+- ROS 2 Jazzy Desktop
+- ROS development tools
+
+Follow the official ROS 2 Jazzy installation guide to install both ROS 2 Jazzy
+Desktop and the ROS development tools before continuing below.
+
+Install ROS 2 Jazzy using the official documentation:
+
+[ROS 2 Jazzy installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
+
+Create a workspace and clone SSOS:
+
+```bash
+mkdir -p ~/ssos_ws/src
+cd ~/ssos_ws/src
+
+git clone https://github.com/space-station-os/space_station_os.git
+cd ~/ssos_ws
+```
+
+Install dependencies:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+
+sudo rosdep init   # Skip if rosdep has already been initialized.
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
+```
+
+Build and test:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+
+colcon build --symlink-install
+source install/setup.bash
+
+colcon test
+colcon test-result --verbose
+```
+
+Launch the full station:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source ~/ssos_ws/install/setup.bash
+
+ros2 launch space_station space_station.launch.py
+```
+
+Source both ROS 2 Jazzy and the workspace overlay in each new terminal before
+running SSOS commands.
+
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for the complete contributor
+workflow.
+
+---
+
+## Docker (Advanced)
+
+Docker is maintained as an advanced environment and is not part of the
+Tier-1 v0.9 setup path. Full Docker validation is handled separately.
+
+The current container workflow uses the published GHCR image and X11 GUI
+forwarding.
+
+Pull the image:
 
 ```bash
 docker pull ghcr.io/space-station-os/space_station_os:latest
 ```
 
-> Docker must be installed and running. No need to install ROS 2 or dependencies manually.
-
-### 2. Allow GUI access
-
-Allow local Docker containers to reach your X server:
+Allow the local container to reach the X server:
 
 ```bash
 xhost +local:root
 ```
 
-### 3. Run the container
+Run the container:
 
 ```bash
 docker run -it --rm \
@@ -99,54 +256,21 @@ docker run -it --rm \
   ghcr.io/space-station-os/space_station_os:latest
 ```
 
----
-
-## Build from source
-
-Use this if you want to modify the code and are not using pixi or Docker.
-
-### Prerequisites
-
-* **OS:** Ubuntu 24.04
-* **ROS 2:** Jazzy (Desktop)
-  -> [ROS 2 Jazzy installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
-
-### 1. Create a workspace and clone
-
-```bash
-mkdir -p ~/ssos_ws/src
-cd ~/ssos_ws/src
-git clone https://github.com/space-station-os/space_station_os.git
-```
-
-### 2. Install dependencies and build
-
-```bash
-cd ~/ssos_ws
-sudo rosdep init      # first time only; skip if already initialized
-rosdep update
-rosdep install --from-paths src --ignore-src -r -y
-colcon build --symlink-install
-source install/setup.bash
-```
-
-> Source the workspace in every new terminal before running ROS 2 commands:
->
-> ```bash
-> source ~/ssos_ws/install/setup.bash
-> ```
+Docker behavior and GUI compatibility should be validated separately from the
+Tier-1 Desktop App and Pixi setup paths.
 
 ---
 
-## Running the simulation
+## Running Individual Systems
 
-Launch the full space station (New systems following SSOS 2026 architecture):
+With a native ROS 2 workspace sourced, the full current architecture can be
+launched with:
 
 ```bash
 ros2 launch space_station space_station.launch.py
 ```
 
-Or launch a single subsystem (Legacy systems):
+Legacy subsystem launch files are also available:
 
 ```bash
 ros2 launch space_station eclss.launch.py
@@ -157,24 +281,27 @@ ros2 launch space_station thermals.launch.py
 
 ### OpenMCT dashboard
 
-To run the OpenMCT bridge (then open http://localhost:9097):
+To run the OpenMCT bridge:
 
 ```bash
 ./open_mct-bridge.sh
 ```
 
+Then open `http://localhost:9097`.
+
 ---
 
 ## Documentation
 
-* [docs/PIXI.md](docs/PIXI.md) - reproducible pixi build and run
-* [docs/DESKTOP_APP.md](docs/DESKTOP_APP.md) - desktop app install and updates
-* [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) - how to contribute
-* [Project wiki](https://github.com/space-station-os/space_station_os/wiki)
+- [docs/PIXI.md](docs/PIXI.md) - reproducible Pixi build, run, and dependency management
+- [docs/DESKTOP_APP.md](docs/DESKTOP_APP.md) - Tier-1 Desktop App installation and updates
+- [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) - contributor setup and development workflow
+- [Project wiki](https://github.com/space-station-os/space_station_os/wiki)
 
 ---
 
 ## Contributing
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) and the project backlog:
+
 [Space Station OS - Project Board](https://github.com/orgs/space-station-os/projects/2/views/1)

--- a/desktop/install.sh
+++ b/desktop/install.sh
@@ -39,8 +39,8 @@ mkdir -p "$DESKTOP_DIR"
 # Emits progress (percent + '# label') on stdout; verbose output goes to LOG.
 run_steps() {
   echo 10;  echo "# Checking environment..."
-  echo 25;  echo "# Fetching ROS 2 environment (pixi install)..."
-  ( cd "$REPO_DIR" && pixi install ) >>"$LOG" 2>&1 || return 1
+  echo 25;  echo "# Fetching ROS 2 environment (pixi install --locked)..."
+  ( cd "$REPO_DIR" && pixi install --locked ) >>"$LOG" 2>&1 || return 1
   echo 65;  echo "# Building Space Station OS (this can take a minute)..."
   ( cd "$REPO_DIR" && pixi run build ) >>"$LOG" 2>&1 || return 1
   echo 85;  echo "# Installing desktop shortcut..."

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,50 +32,135 @@ If this is your first contribution, issues labeled `good first issue` are a grea
 
 ## Development setup
 
-### Prerequisites
+SSOS supports two development environments:
 
-- **OS:** Ubuntu 24.04
-- **ROS 2:** Jazzy (Desktop) — [installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
-- **Colcon:** `sudo apt install python3-colcon-common-extensions`
+- **Pixi** — recommended for reproducible development without a system ROS 2 installation
+- **Native ROS 2 Jazzy** — supported for system integration and development against a host ROS installation
 
-### Build from source
+Docker is maintained as an advanced environment and is not the primary
+development path for v0.9.
+
+### Recommended: Pixi
+
+Pixi provides the SSOS ROS 2 Jazzy environment through RoboStack and uses the
+committed `pixi.lock` to reproduce the development environment.
+
+Install Pixi if it is not already available:
+
+```bash
+curl -fsSL https://pixi.sh/install.sh | sh
+export PATH="$HOME/.pixi/bin:$PATH"
+```
+
+Clone your fork:
+
+```bash
+git clone https://github.com/<your-fork>/space_station_os.git
+cd space_station_os
+```
+
+Install the committed environment, build, and test:
+
+```bash
+pixi install --locked
+pixi run build
+pixi run test
+```
+
+Launch the full SSOS stack:
+
+```bash
+pixi run station
+```
+
+Normal development setup must use `pixi install --locked`. If you intentionally
+change dependencies in `pixi.toml`, follow the lock-file update procedure in
+[PIXI.md](PIXI.md).
+
+### Native ROS 2 Jazzy
+
+Use this path when developing or integrating SSOS against a system ROS 2
+installation.
+
+Prerequisites:
+
+- Ubuntu 24.04
+- ROS 2 Jazzy Desktop
+- ROS development tools
+
+Install ROS 2 Jazzy using the official
+[ROS 2 Jazzy installation guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
+before continuing.
+
+Create a workspace and clone your fork:
 
 ```bash
 mkdir -p ~/ssos_ws/src
 cd ~/ssos_ws/src
+
 git clone https://github.com/<your-fork>/space_station_os.git
 cd ~/ssos_ws
-
-# Install dependencies
-sudo rosdep init   # skip if already done
-rosdep update
-rosdep install --from-paths src --ignore-src -r -y
-
-# Build
-colcon build --symlink-install
-source install/setup.bash
 ```
 
-### Using Docker
+Install dependencies:
 
 ```bash
-docker pull ghcr.io/space-station-os/space_station_os:latest
+source /opt/ros/jazzy/setup.bash
 
-xhost +local:root
-
-docker run -it --rm \
-  --env="DISPLAY=$DISPLAY" \
-  --env="QT_X11_NO_MITSHM=1" \
-  --env="LIBGL_ALWAYS_SOFTWARE=1" \
-  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-  --network=host \
-  ghcr.io/space-station-os/space_station_os:latest
+sudo rosdep init   # Skip if rosdep has already been initialized.
+rosdep update
+rosdep install --from-paths src --ignore-src -r -y
 ```
+
+Build and test:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+
+colcon build --symlink-install
+source install/setup.bash
+
+colcon test
+colcon test-result --verbose
+```
+
+Launch SSOS:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source ~/ssos_ws/install/setup.bash
+
+ros2 launch space_station space_station.launch.py
+```
+
+Source both ROS 2 Jazzy and the workspace overlay in each new terminal before
+running ROS 2 commands.
+
+### Docker (advanced)
+
+Docker is maintained as an advanced, separately handled environment rather than
+the recommended development setup for v0.9.
+
+See the root [README](../README.md) for the current Docker workflow.
 
 ### Verify your setup
 
+For Pixi:
+
 ```bash
+pixi run build
+pixi run test
+pixi run station
+```
+
+For native ROS 2 Jazzy:
+
+```bash
+source /opt/ros/jazzy/setup.bash
 source ~/ssos_ws/install/setup.bash
+
+colcon test
+colcon test-result --verbose
 ros2 launch space_station space_station.launch.py
 ```
 
@@ -208,20 +293,57 @@ Examples:
 
 ## CI/CD pipeline
 
-The repository uses two GitHub Actions workflows:
+The repository uses three complementary GitHub Actions workflows:
 
-| Workflow | File | Triggers | Purpose |
-|----------|------|----------|---------|
-| **CI** | `ci.yml` | PRs + push to main | Build, test, lint |
-| **Docker Publish** | `docker-publish.yml` | Push to main + version tags | Build and publish Docker image to GHCR |
+| Workflow | File | Purpose |
+|----------|------|---------|
+| **Native ROS 2 CI** | `ci.yml` | Build and validation against ROS 2 Jazzy on Ubuntu 24.04 |
+| **Pixi CI** | `pixi.yml` | Reproduce the committed locked Pixi environment, build, test, and verify that `pixi.lock` remains unchanged |
+| **Docker Publish** | `docker-publish.yml` | Build and publish the container image from `main` and version tags |
 
-When you open a PR, the CI workflow runs automatically. It must pass before your PR can be merged. The CI workflow:
+Both Native ROS 2 CI and Pixi CI run for pull requests and are used as
+repository integration checks.
 
-1. Builds all packages with `colcon build` on ROS 2 Jazzy.
-2. Runs all tests with `colcon test`.
-3. Runs lint checks (`ament_cppcheck`, `ament_xmllint`).
+### Native ROS 2 CI
 
-Docker images are only built and published when code merges to `main` or a version tag is pushed.
+The native workflow builds the repository in a ROS 2 Jazzy environment on
+Ubuntu 24.04.
+
+It currently:
+
+1. installs the native ROS 2 and system dependencies
+2. builds the repository with `colcon build`
+3. runs `colcon test`
+4. reports the test results
+
+The native test execution is currently non-blocking within the workflow, while
+build failures still fail the job.
+
+### Pixi CI
+
+The Pixi workflow validates the reproducible development environment from the
+committed `pixi.lock`.
+
+It runs:
+
+```bash
+pixi run build
+pixi run test
+```
+
+and then verifies that the CI run did not modify `pixi.lock`.
+
+A mismatch between `pixi.toml` and `pixi.lock`, a Pixi build failure, or a Pixi
+test failure causes this workflow to fail.
+
+### Docker publishing
+
+Docker publishing is separate from pull-request validation. The publish
+workflow runs from `main` and version tags and publishes the generated image to
+GHCR.
+
+Before requesting review, make sure the required CI checks for your pull
+request are green.
 
 ---
 

--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -18,7 +18,7 @@ Only the shortcut goes on the Desktop; everything else stays in the repo:
 | Desktop shortcut | `~/Desktop/SpaceStationOS.desktop` |
 | Launcher | `<repo>/desktop/launch.sh` |
 | Icon | `<repo>/assets/logo/ssosapplogo.png` |
-| pixi environment | `<repo>/.pixi/` (created by `pixi install`) |
+| pixi environment | `<repo>/.pixi/` (created by `pixi install --locked`) |
 
 The launcher `cd`s into the `space_station_os` folder before running
 `pixi run station`, because a Desktop double-click starts from an arbitrary
@@ -26,18 +26,33 @@ directory.
 
 ## Install
 
+On a clean Ubuntu 24.04 Desktop installation:
+
 ```bash
-cd <repo>/space_station_os
+sudo apt update
+sudo apt install -y curl git zenity
+
+curl -fsSL https://pixi.sh/install.sh | sh
+export PATH="$HOME/.pixi/bin:$PATH"
+
+git clone https://github.com/space-station-os/space_station_os.git
+cd space_station_os
+
 bash desktop/install.sh
 ```
 
-A progress popup steps through: check pixi -> `pixi install` (fetch ROS 2 Jazzy)
--> `pixi run build` -> create the Desktop shortcut. When it finishes, a
-"double-click the icon on your Desktop" popup appears.
+The installer runs `pixi install --locked`, builds SSOS, and creates the
+desktop shortcut.
 
-Prerequisite: [pixi installed](https://pixi.sh/latest/#installation). Ubuntu
-(GNOME) with `zenity` (present by default) shows the progress popups; on a
-headless machine the installer prints progress to the terminal instead.
+Pixi is installed into `~/.pixi/bin`. A new terminal will normally pick up the
+updated `PATH` automatically.
+
+During installation, the progress popup reports environment setup, build, and
+desktop-shortcut creation. When installation finishes, a confirmation popup
+instructs the user to double-click the Space Station OS icon.
+
+On Ubuntu Desktop, `zenity` provides the installation progress popups. On a
+headless machine, the installer prints progress to the terminal instead.
 
 ## Launch
 
@@ -62,7 +77,7 @@ most changes there is nothing special to do:
 | You changed... | To pick it up |
 |----------------|---------------|
 | Node / GUI **code** | `git pull` (or edit) — the next double-click rebuilds and runs the latest. Run `pixi run build` first if you want to catch build errors before launching. |
-| **Dependencies** in `pixi.toml` | `pixi install` (updates the env + `pixi.lock`). |
+| **Dependencies** in `pixi.toml` | Follow the dependency-update procedure in [PIXI.md](PIXI.md), regenerate `pixi.lock`, then verify with `pixi install --locked`. |
 | The **launcher, `.desktop` template, or icon** (`desktop/`, `assets/logo/`) | re-run `bash desktop/install.sh` to refresh the shortcut, icon, and trust flag. |
 | The **logo** source | regenerate `assets/logo/ssosapplogo.png` (256×256, see below), then re-run `bash desktop/install.sh`. |
 

--- a/docs/PIXI.md
+++ b/docs/PIXI.md
@@ -20,15 +20,19 @@ The current SSOS stack:
 
 - [pixi installed](https://pixi.sh/latest/#installation)
 - Linux (`linux-64`). macOS/Windows are not covered yet.
-- Network access to `prefix.dev` and `conda-forge` for the first `pixi install`.
+- Network access to `prefix.dev` and `conda-forge` for the first `pixi install --locked`.
 
 ## Usage
 
 ```bash
-pixi install        # resolve + fetch the environment (first run only)
-pixi run build      # colcon build the SSOS packages
-pixi run station    # launch GUI + core + sim + eclss
+pixi install --locked
+pixi run build
+pixi run test
+pixi run station
 ```
+
+`pixi install --locked` installs the environment defined by the committed
+`pixi.lock` and fails if `pixi.toml` and `pixi.lock` are not synchronized.
 
 | Task | What it does |
 |------|--------------|
@@ -47,9 +51,25 @@ the local `install/` overlay.
 `pixi.toml` uses `robostack-jazzy` (first) then `conda-forge`. Keep that order;
 do not add the `defaults` channel (RoboStack is incompatible with it).
 
+## Updating dependencies
+
+Normal setup must use the committed lock file and must not regenerate
+`pixi.lock`.
+
+If a contributor intentionally changes dependencies:
+
+1. Edit `pixi.toml`.
+2. Run `pixi lock` to regenerate `pixi.lock`.
+3. Run `pixi install --locked` to verify that `pixi.toml` and `pixi.lock` are synchronized.
+4. Run `pixi run build` and `pixi run test`.
+5. Commit `pixi.toml` and `pixi.lock` together.
+
+Use `pixi update` only when intentionally updating dependency versions within
+the constraints declared in `pixi.toml`.
+
 ## Notes and known risks
 
-- **RoboStack Jazzy coverage.** The first `pixi install` on a networked machine
+- **RoboStack Jazzy coverage.** The first `pixi install --locked` on a networked machine
   is what confirms every `ros-jazzy-*` dependency resolves. If a package is
   missing on `robostack-jazzy`, either add its correct name or fall back to
   `ros-jazzy-desktop` (broad meta) while the specific set is sorted out.
@@ -88,7 +108,8 @@ The Pixi CI job is the normal compatibility check for changes affecting the
 Tier-1 desktop application. Graphical desktop behavior, Qt/OpenGL rendering,
 and full GUI interaction remain manual release-candidate smoke tests.
 
-## Next step
+## Desktop application
 
-This environment is the foundation for packaging SSOS as an installable
-desktop app (click-to-launch GUI, pixi backend). See the desktop-app issue.
+The Tier-1 Ubuntu desktop application is implemented on top of this Pixi
+environment. See [DESKTOP_APP.md](DESKTOP_APP.md) for installation, launch,
+update, and troubleshooting instructions.

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 # GUI's Python deps) is pinned by pixi.lock.
 #
 # Quick start (Linux):
-#   pixi install          # resolve + fetch the environment
+#   pixi install --locked # install the committed locked environment
 #   pixi run build        # colcon build the SSOS packages
 #   pixi run station      # launch the full stack (GUI + core + sim + eclss)
 #


### PR DESCRIPTION
## Summary

This PR completes the remaining v0.9 public setup and installation alignment tracked in #245.

It reorganizes the supported SSOS setup paths by user intent, establishes the committed Pixi lock file as the normal installation contract, and aligns the related desktop and contributor documentation with the current v0.9 baseline.

## Changes

- reorganize the root README around supported user workflows:
  - Tier-1 Ubuntu Desktop App
  - Pixi terminal usage
  - Pixi development
  - native ROS 2 Jazzy development and integration
  - Docker as an advanced environment
- use `pixi install --locked` as the normal Pixi installation path
- update the Tier-1 desktop installer to use the committed locked environment
- document the intentional dependency and `pixi.lock` update procedure
- add the Pixi CI badge
- fix the legacy package table in the root README
- update `docs/PIXI.md` to reflect the implemented Desktop App
- update `docs/DESKTOP_APP.md` with a clean Ubuntu 24.04 installation path
- update `docs/CONTRIBUTING.md` with the Pixi development path and current CI workflows
- align `pixi.toml` quick-start documentation with the locked installation contract

## Validation

Validated from a fresh checkout of this branch on Ubuntu 24.04:

- `pixi install --locked` — PASS
- `pixi run build` — PASS
- `pixi run test` — PASS
  - 144 tests
  - 0 errors
  - 0 failures
  - 0 skipped
- `pixi.lock` unchanged after installation/build/test — PASS
- `pixi run station` — PASS
- Tier-1 desktop installer — PASS
- Desktop icon launch — PASS
- `bash -n desktop/install.sh` — PASS
- `git diff --check` — PASS

Native ROS 2 Jazzy and Pixi CI remain the repository integration checks.

Closes #245