### PR TITLE
[v0.9.0][CI] Make supported ROS 2 tests blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,21 +57,20 @@ jobs:
             --cmake-args -DCMAKE_BUILD_TYPE=Release
         shell: bash
 
-      - name: Test (non-blocking)
+      - name: Test
         run: |
           source /opt/ros/jazzy/setup.bash
           source install/setup.bash
           colcon test \
             --event-handlers console_direct+
         shell: bash
-        continue-on-error: true
 
       - name: Test results
         if: always()
         run: |
           source /opt/ros/jazzy/setup.bash
           source install/setup.bash
-          colcon test-result --verbose || true
+          colcon test-result --verbose
         shell: bash
 
   # Lightweight lint check — runs in parallel with build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,16 @@ jobs:
         run: |
           source /opt/ros/jazzy/setup.bash
           source install/setup.bash
+
+          # v0.9.0 blocking test boundary.
+          # Legacy space_station_* subsystem packages remain build-checked,
+          # but are outside the v0.9.0 release test gate.
           colcon test \
+            --packages-select \
+              space_station \
+              ssos_core \
+              ssos_sim \
+              ssos_eclss \
             --event-handlers console_direct+
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,18 +63,14 @@ jobs:
           source install/setup.bash
 
           # v0.9+ blocking test boundary:
-          # - current and future ssos_* packages
-          # - the top-level space_station application
-          # Legacy space_station_* subsystem packages remain build-checked
-          # but are outside the release test gate.
-
+          # all current and future ssos_* packages.
+          # The top-level space_station app and legacy space_station_* packages
+          # remain build-checked; application/lint validation is handled separately.
           colcon test \
-            --packages-select-regex \
-              '^ssos_.*$' \
-              '^space_station$' \
+            --packages-select-regex '^ssos_.*$' \
             --event-handlers console_direct+
         shell: bash
-        
+
       - name: Test results
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,18 +62,19 @@ jobs:
           source /opt/ros/jazzy/setup.bash
           source install/setup.bash
 
-          # v0.9.0 blocking test boundary.
-          # Legacy space_station_* subsystem packages remain build-checked,
-          # but are outside the v0.9.0 release test gate.
+          # v0.9+ blocking test boundary:
+          # - current and future ssos_* packages
+          # - the top-level space_station application
+          # Legacy space_station_* subsystem packages remain build-checked
+          # but are outside the release test gate.
+
           colcon test \
-            --packages-select \
-              space_station \
-              ssos_core \
-              ssos_sim \
-              ssos_eclss \
+            --packages-select-regex \
+              '^ssos_.*$' \
+              '^space_station$' \
             --event-handlers console_direct+
         shell: bash
-
+        
       - name: Test results
         if: always()
         run: |


### PR DESCRIPTION
Closes #248

This PR makes the primary ROS 2 test path blocking for the v0.9.0 release gate.

Broad cleanup of legacy space_station_* packages is intentionally out of scope.