### PR TITLE
[v0.9.0][Docker] Restore reproducible Docker image builds on release main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep local colcon/pixi artifacts out of the build context so `COPY . src/...`
+# never drops a stale install/ or build/ tree into the image.
+build/
+install/
+log/
+.pixi/
+__pycache__/
+*.py[cod]
+
+.git/
+.github/
+node_modules/

--- a/docker/ros2-dev/Dockerfile
+++ b/docker/ros2-dev/Dockerfile
@@ -67,7 +67,11 @@ RUN mkdir -p src
 COPY . src/space_station_os
 
 # Install ROS dependencies
-RUN bash -c "source /opt/ros/jazzy/setup.bash && rosdep install --from-paths src --ignore-src -r -y"
+# apt lists were cleared above, and rosdep shells out to `apt-get install`
+# without refreshing them first, so update before resolving.
+RUN apt update \
+ && bash -c "source /opt/ros/jazzy/setup.bash && rosdep install --from-paths src --ignore-src -r -y" \
+ && rm -rf /var/lib/apt/lists/*
 RUN rosdep resolve gz-harmonic || true
 
 # Build workspace


### PR DESCRIPTION
## Summary

This PR restores Docker image build reliability against the v0.9.0 release main baseline.

It addresses two build-context and dependency-resolution issues:

- adds a root .dockerignore so host-side colcon/Pixi artifacts such as build/, install/, log/, and .pixi/ are not copied into the Docker image;
- refreshes apt package lists immediately before rosdep install, then removes them again after dependency installation.

## Validation

The PR was locally validated from release main (6c6c8693, [Release] Promote v0.8.9-dev to main for v0.9.0 (#246)) using a checkout that already contained local build/, install/, log/, and .pixi/ directories.

Validation confirmed that:

- docker build --no-cache -f docker/ros2-dev/Dockerfile . completes successfully;
- rosdep install reports all required rosdeps installed successfully;
- all 10 workspace packages complete colcon build --symlink-install inside the image;
- the full SSOS station launches from the built image and reaches NOMINAL;
- the Overview and GNC panels operate correctly, including PyQtGraph/OpenGL rendering;
- currently missing optional runtime dependencies degrade gracefully rather than preventing the core GUI from launching.

The remaining Docker runtime and frontend compatibility work, including optional Comms/NOVA dependencies and OpenMCT/Node.js compatibility, remains tracked in #209.

Docker remains an advanced environment and this PR does not change the Tier-1 Desktop/Pixi setup path.

Closes #251
Refs #209