### PR TITLE
[v0.9.0][Release][hotfix] Align Pixi workspace version with v0.9.0

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@
 
 [workspace]
 name = "space-station-os"
-version = "0.8.9"
+version = "0.9.0"
 description = "Space Station OS -- reproducible ROS 2 Jazzy build/run environment (RoboStack)"
 channels = ["https://prefix.dev/robostack-jazzy", "conda-forge"]
 platforms = ["linux-64"]


### PR DESCRIPTION
## Summary

Align the Pixi workspace metadata with the v0.9.0 release baseline before creating the v0.9.0 tag and GitHub Release.

## Changes

- Update the workspace version in pixi.toml from 0.8.9 to 0.9.0.
- No dependency changes are included.
- pixi.lock remains unchanged.

## Validation

Local validation completed successfully:

pixi install --locked
pixi run build
pixi run test

## Results:

- Locked Pixi environment installed successfully.
- Pixi build completed successfully.
- 144 tests passed with 0 errors, 0 failures, and 0 skipped.
- pixi.lock remained unchanged.
- git diff --check completed without errors.
- pixi.toml is the only modified file.

Native ROS 2 Jazzy CI and Pixi CI will provide the final repository-level validation for this PR.

## Scope

This is intentionally limited to release metadata alignment. It does not modify ROS package versions, dependencies, Docker runtime behavior, or other v0.9.x functionality.

Closes #252